### PR TITLE
output total energy after converges

### DIFF
--- a/src/hwave/solver/uhfk.py
+++ b/src/hwave/solver/uhfk.py
@@ -526,10 +526,10 @@ class UHFk(solver_base):
         if is_converged:
             logger.info("UHFk calculation succeeded: rest={}, eps={}."
                         .format(self.physics["Rest"], self.param_mod["eps"]))
+            logger.info("Total Energy = {}.".format(self.physics["Ene"]["Total"]))
         else:
             logger.info("UHFk calculation failed: rest={}, eps={}."
                         .format(self.physics["Rest"], self.param_mod["eps"]))
-
         if print_check is not None:
             fch.close()
             

--- a/src/hwave/solver/uhfr.py
+++ b/src/hwave/solver/uhfr.py
@@ -314,6 +314,7 @@ class UHFr(solver_base):
 
         if self.physics["Rest"] < param_mod["eps"]:
             logger.info("UHFr calculation is succeeded: rest={}, eps={}.".format(self.physics["Rest"], param_mod["eps"]))
+            logger.info("Total Energy = {}.".format(self.physics["Ene"]["Total"]))
         else:
             logger.warning("UHFr calculation is failed: rest={}, eps={}.".format(self.physics["Rest"], param_mod["eps"]))
 


### PR DESCRIPTION
Like this:

> ...
2023-02-16 17:41:53,529 INFO qlms.uhfk: UHFk calculation succeeded: rest=7.21073062368489e-09, eps=1e-08.
2023-02-16 17:41:53,529 INFO qlms.uhfk: Total Energy = -2.2661791934436124.
2023-02-16 17:41:53,529 INFO qlms: Save calculation results.
...