### PR TITLE
New post tool `hwave_dos` for calculating density of states D(E) for each orbital

### DIFF
--- a/docs/en/source/uhfk/tutorial/tu-index.rst
+++ b/docs/en/source/uhfk/tutorial/tu-index.rst
@@ -130,6 +130,38 @@ the output files ``energy.dat``, ``eigen.npz``, and ``green.npz`` in ``output`` 
 
 See :ref:`Sec:outputfile_uhfk` section for the details of the output files.
 
+
+Calculate density of state  (``hwave_dos``)
+------------------------------------------------
+
+You can calculate the density of states (DOS) using the post-processing tool, ``hwave_dos``.
+
+
+``hwave_dos`` uses the ``libtetrabz`` library to integrating over the Brillouin zone.
+``libtetrabz`` can be installed by ``pip``::
+
+    $ python3 -m pip install libtetrabz
+
+The tool requires the input parameter file used in the calculation.
+The following example shows how to calculate the DOS using the sample input file::
+
+    $ hwave_dos input.toml
+
+``hwave_dos`` outputs the DOS file, ``dos.dat`` in the directory specified by the ``file.output.path_to_output`` of the input file.
+The filename can be changed by ``--output`` option::
+
+    $ hwave_dos input.toml --output dos.dat
+
+The DOS is calculated in the energy range specified by ``--ene-window`` option.
+If omitted, the energy range is set to :math:`[E_\text{min}-0.2, E_\text{max}+0.2]` where :math:`E_\text{min}` and :math:`E_\text{max}` are the minimum and maximum energies obtained by ``hwave``.
+The number of the energy points for the DOS calculation is specified by ``--ene-num`` option (default is 101)::
+
+    $ hwave_dos input.toml --ene-window -10.0 5.0 --ene-num 201
+
+The ``--plot`` option plots the DOS. ``matplotlib`` is required::
+
+    $ hwave_dos input.toml --plot dos.png
+
 Compile and run StdFace library
 ----------------------------------------------------------------
 

--- a/docs/ja/source/uhfk/tutorial/tu-index.rst
+++ b/docs/ja/source/uhfk/tutorial/tu-index.rst
@@ -103,6 +103,36 @@ Transferに指定するファイルは、電子系のTransferに相当するHami
 
 出力ファイルの詳細については :ref:`ファイルフォーマット<Sec:outputfile_uhfk>` の章をご覧ください。
 
+
+状態密度の計算 (``hwave_dos``)
+----------------------------------------
+
+ポストツール ``hwave_dos`` を用いることで、状態密度を計算することができます。
+ブリルアンゾーン積分を精度良く計算するために `libtetrabz <https://pypi.org/project/libtetrabz/>`_ を利用しています。 ``pip`` を利用してインストールしてください。 ::
+
+    $ python3 -m pip install libtetrabz
+
+``hwave_dos`` は、 ``hwave`` で利用した入力パラメータファイルを引数として受け取ります ::
+
+    $ hwave_dos input.toml
+
+``hwave_dos`` は、 ``hwave`` と同様に ``[file.output]`` セクションの指定に従い、
+``output`` ディレクトリに ``dos.dat`` ファイルを出力します。
+ファイル名は ``--output`` オプションで変更することができます。 ::
+
+    $ hwave_dos input.toml --output dos.dat
+
+状態密度を計算するエネルギーの範囲は ``--ene-window`` オプションで指定します。
+省略した場合は、 ``hwave`` で得られたエネルギーの最小値と最大値を :math:`E_\text{min}`, :math:`E_\text{max}` として、 :math:`[E_\text{min}-0.2, E_\text{max}+0.2]` で計算されます。
+エネルギーの点数は ``--ene-num`` オプションで指定します（デフォルトは101） ::
+
+    $ hwave_dos input.toml --ene-window -10.0 5.0 --ene-num 201
+
+``--plot`` オプションを指定すると、状態密度をプロットします。 ``matplotlib`` が必要です。 ::
+
+    $ hwave_dos input.toml --plot dos.png
+
+
 StdFaceライブラリのコンパイルと実行
 ----------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ tomli = "^2.0.1"
 
 [tool.poetry.scripts]
 hwave = "hwave.qlms:main"
+hwave_dos = "hwave.dos:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/hwave/dos.py
+++ b/src/hwave/dos.py
@@ -64,7 +64,7 @@ def __read_geom(file_name="./dir-model/zvo_geom.dat"):
 def calc_dos(
     input_dict: dict,
     ene_window: list | None = None,
-    ene_num: int = 100,
+    ene_num: int = 101,
     verbose: bool = False,
 ) -> DoS:
 
@@ -122,7 +122,7 @@ def main():
     import tomli
     import argparse
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
         "input", type=str, help="input file of hwave"
     )
@@ -131,10 +131,11 @@ def main():
         "--ene_window",
         default=None,
         type=float,
-        help="energy window; [ene_low, ene_high]. If None, ene_low = ene_min - 0.2, ene_high = ene_max + 0.2",
+        help="""energy window; [ene_low, ene_high].
+If omitted, [ene_min - 0.2, ene_max + 0.2]""",
     )
-    parser.add_argument("--ene_num", default=100, type=int, help="energy step")
-    parser.add_argument("--plot", action="store_true", help="plot DOS")
+    parser.add_argument("--ene_num", default=101, type=int, help="number of energy points")
+    parser.add_argument("--plot", action="store_true", help="plot DOS as 'dos.png'")
     parser.add_argument("--verbose", action="store_true", help="print verbosely")
 
     args = parser.parse_args()

--- a/src/hwave/dos.py
+++ b/src/hwave/dos.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import itertools
+import os
+
+import numpy as np
+
+
+class DoS:
+    dos: np.ndarray
+    ene: np.ndarray
+    ene_num: int
+    norb: int
+
+    def __init__(self, ene: np.ndarray, dos: np.ndarray):
+        assert ene.shape[0] == dos.shape[1]
+        self.ene = ene
+        self.dos = dos
+        self.ene_num = ene.shape[0]
+        self.norb = dos.shape[0]
+
+    def plot(self, filename: str = ""):
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError(
+                "matplotlib is not installed. Please install matplotlib and try again."
+            )
+
+        total_dos = np.sum(self.dos, axis=0)
+
+        plt.plot(self.ene, total_dos, label="Total")
+        for i in range(self.norb):
+            plt.plot(self.ene, self.dos[i], label=str(i))
+        plt.xlabel("Energy")
+        plt.ylabel("DOS")
+        plt.ylim(0)
+        plt.legend()
+        if filename != "":
+            plt.savefig(filename)
+        plt.close()
+
+    def write_dos(self, output: str):
+        with open(output, "w") as fw:
+            fw.write("# ene")
+            for j in range(self.norb):
+                fw.write(f" dos[iorb={j}]")
+            fw.write("\n")
+            for i in range(self.ene_num):
+                fw.write("{:15.8f} ".format(self.ene[i]))
+                for j in range(self.norb):
+                    fw.write("{:15.8f} ".format(self.dos[j, i]))
+                fw.write("\n")
+
+
+def __read_geom(file_name="./dir-model/zvo_geom.dat"):
+    with open(file_name, "r") as fr:
+        uvec = np.zeros((3, 3))
+        for i, line in enumerate(itertools.islice(fr, 3)):  # take first 3 lines
+            uvec[i, :] = np.array(line.split())
+    return uvec
+
+
+def calc_dos(
+    input_dict: dict,
+    ene_window: list | None = None,
+    ene_num: int = 100,
+    verbose: bool = False,
+) -> DoS:
+
+    try:
+        import libtetrabz
+    except ImportError:
+        raise ImportError(
+            "libtetrabz is not installed. Please install libtetrabz and try again."
+        )
+
+    if verbose:
+        print("Reading eigenvalues")
+    output_info_dict = input_dict["file"]["output"]
+    data = np.load(
+        os.path.join(
+            output_info_dict["path_to_output"], output_info_dict["eigen"] + ".npz"
+        )
+    )
+    eigenvalues = data["eigenvalue"]
+    Lx, Ly, Lz = input_dict["mode"]["param"]["CellShape"]
+    norb = eigenvalues.shape[1]
+    if verbose:
+        print("Lx, Ly, Lz, norb: ", Lx, Ly, Lz, norb)
+    eigenvalues.reshape(Lx, Ly, Lz, norb)
+
+    if verbose:
+        print("Reading geometry")
+    input_info_dict = input_dict["file"]["input"]["interaction"]
+    file_name = os.path.join(
+        input_info_dict["path_to_input"], input_info_dict["Geometry"]
+    )
+    uvec = __read_geom(file_name)
+    bvec = 2.0 * np.pi * np.linalg.inv(uvec).T
+
+    if ene_window is None:
+        ene_min = np.min(eigenvalues) - 0.2
+        ene_max = np.max(eigenvalues) + 0.2
+    else:
+        ene_min = ene_window[0]
+        ene_max = ene_window[1]
+
+    ene = np.linspace(ene_min, ene_max, num=ene_num)
+    if verbose:
+        print("ene_min, ene_max, ene_num: ", ene_min, ene_max, ene_num)
+
+    eig = eigenvalues.reshape(Lx, Ly, Lz, norb)
+    if verbose:
+        print("Calculating DOS")
+    wght = libtetrabz.dos(bvec, eig, ene)
+    dos = wght.sum(2).sum(1).sum(0)
+    return DoS(dos=dos, ene=ene)
+
+
+def main():
+    import tomli
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "input", type=str, help="input file of hwave"
+    )
+    parser.add_argument("--output_dos", type=str, default="dos.dat", help="DoS output")
+    parser.add_argument(
+        "--ene_window",
+        default=None,
+        type=float,
+        help="energy window; [ene_low, ene_high]. If None, ene_low = ene_min - 0.2, ene_high = ene_max + 0.2",
+    )
+    parser.add_argument("--ene_num", default=100, type=int, help="energy step")
+    parser.add_argument("--plot", action="store_true", help="plot DOS")
+    parser.add_argument("--verbose", action="store_true", help="print verbosely")
+
+    args = parser.parse_args()
+
+    file_toml = args.input
+    if os.path.exists(file_toml):
+        if args.verbose:
+            print("Reading input file: ", file_toml)
+        with open(file_toml, "rb") as f:
+            input_dict = tomli.load(f)
+    else:
+        raise ValueError("Input file does not exist")
+
+    dos = calc_dos(
+        input_dict,
+        ene_window=args.ene_window,
+        ene_num=args.ene_num,
+        verbose=args.verbose,
+    )
+    if args.output_dos != "":
+        dos.write_dos(args.output_dos)
+    if args.plot:
+        dos.plot("dos.png")


### PR DESCRIPTION
`hwave_dos` requires [libtetrabz](https://pypi.org/project/libtetrabz/) for integrating over the Brillouin zone.
`--plot` option uses [matplotlib](https://pypi.org/project/matplotlib/) for plotting.

Usage (Options are UPDATED):

```
$ hwave_dos --help
usage: hwave_dos [-h] [-o OUTPUT] [--ene-window ENE_WINDOW ENE_WINDOW] [--ene-num ENE_NUM] [-p PLOT] [-q] [-v]
                 input

positional arguments:
  input                 input file of hwave

optional arguments:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        DoS output
  --ene-window ENE_WINDOW ENE_WINDOW
                        energy window; [ene_low, ene_high].
                        If omitted, [ene_min - 0.2, ene_max + 0.2]
  --ene-num ENE_NUM     number of energy points
  -p PLOT, --plot PLOT  plot DOS to file
  -q, --quiet           calculate quietly
  -v, --version         show program's version number and exit

```

(NOTE: original code is written by @k-yoshimi)