### PR TITLE
Add furo to CI docs build dependencies

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install sphinx
+        pip install sphinx furo
 
     - name: Build
       run: |


### PR DESCRIPTION
## Summary
- CIのドキュメントビルドに `furo` パッケージのインストールを追加
- PR #26 でテーマをAlabaster→Furoに変更したが、CIに `pip install furo` が含まれておらずデプロイが失敗していた

## Test plan
- [ ] mainへのマージ後、deploy ワークフローが成功すること
- [ ] gh-pages にドキュメントが正常にデプロイされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)