### PR TITLE
docs(flex): fix duplicate [2] footnote in FLEX tutorial

### DIFF
--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -534,7 +534,7 @@ Model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The third sample is a **two-orbital minimal model for iron-based
-superconductors** proposed by Raghu et al. [2]_
+superconductors** proposed by Raghu et al. [5]_
 The model describes the Fe-As plane using :math:`d_{xz}` and
 :math:`d_{yz}` orbitals on a square lattice (1-Fe unit cell).
 
@@ -573,7 +573,7 @@ electron pockets at :math:`M = (\pi, 0)` / :math:`(0, \pi)`.
 The nesting between these pockets drives strong spin fluctuations
 at :math:`\mathbf{Q} = (\pi, 0)`, which is the hallmark of iron pnictides.
 
-.. [2] S. Raghu, X.-L. Qi, C.-X. Liu, D. J. Scalapino, and S.-C. Zhang,
+.. [5] S. Raghu, X.-L. Qi, C.-X. Liu, D. J. Scalapino, and S.-C. Zhang,
    Phys. Rev. B **77**, 220503(R) (2008).
 
 Prepare input files

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -513,7 +513,7 @@ FLEXソルバーは ``[mode.param]`` セクションで以下のパラメータ�
 モデル
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-3番目のサンプルは、Raghu et al. [2]_ が提案した
+3番目のサンプルは、Raghu et al. [5]_ が提案した
 **鉄系超伝導体の2軌道最小モデル** です。
 Fe-As面を正方格子（1-Fe単位胞）上の :math:`d_{xz}` と
 :math:`d_{yz}` 軌道で記述します。
@@ -555,7 +555,7 @@ Fe-As面を正方格子（1-Fe単位胞）上の :math:`d_{xz}` と
 :math:`\mathbf{Q} = (\pi, 0)` における強いスピンゆらぎを駆動します。
 これが鉄系超伝導体の特徴的な物理です。
 
-.. [2] S. Raghu, X.-L. Qi, C.-X. Liu, D. J. Scalapino, and S.-C. Zhang,
+.. [5] S. Raghu, X.-L. Qi, C.-X. Liu, D. J. Scalapino, and S.-C. Zhang,
    Phys. Rev. B **77**, 220503(R) (2008).
 
 入力ファイルの準備


### PR DESCRIPTION
The FLEX tutorial (en+ja) defined two footnotes both labelled `[2]` -- Kontani
& Onari (intro) and Raghu et al. (Sample 3) -- causing a docutils "Duplicate
target name: 2" error and an ambiguous `[2]_` reference. Renumber the Sample 3
Raghu reference/definition to `[5]`. Sphinx build is now free of that error.

Found during a post-merge docs build (pre-existing issue, follow-up to #32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)