### PR TITLE
fix(uhfk): correct sublattice fold sign for Green output and RPA warm-start

### DIFF
--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -1325,8 +1325,8 @@ class RPA:
             tab_r = tab_r[:, inv, :][:, :, inv]   # interleaved -> spin-block
 
         if self.lattice.has_sublattice:
-            # use reshape green to convert layout
-            tab_r = self._reshape_green(tab_r)
+            # use reshape green to convert layout (Hamiltonian/transfer convention)
+            tab_r = self._reshape_green(tab_r, hamiltonian=True)
 
         nx,ny,nz = self.lattice.shape
         nvol = self.lattice.nvol
@@ -1356,9 +1356,10 @@ class RPA:
 
         # green_init is produced by UHFk's _save_green (saves self.Green), the
         # DEFLATED pre-fold green for sublattice -- the same (cellvol, nd0, nd0)
-        # layout and conventions as trans_mod. Mirror _read_trans_mod exactly:
-        # shape validation, SO interleaved->spin-block remap, then sublattice
-        # fold, so green_init is consumed in spin-block order.
+        # layout as trans_mod, and consumed in spin-block order. It does NOT
+        # share trans_mod's fold sign: a Green function carries the within-cell
+        # offset on the first orbital slot, so the sublattice fold below uses
+        # the Green convention (default), the inverse of UHFk._deflate_green.
         expected = (self.lattice.cellvol, self.ns * self.norb_orig, self.ns * self.norb_orig)
         if green.shape != expected:
             raise ValueError(
@@ -1385,8 +1386,15 @@ class RPA:
         nd = self.nd
         return green.reshape(nvol,nd,nd)
 
-    def _reshape_green(self, green_):
+    def _reshape_green(self, green_, hamiltonian=False):
         # convert green function into sublattice
+        #
+        # ``hamiltonian`` selects the cross-sublattice slot convention, mirroring
+        # UHFk._deflate_green. A Green function saved by UHFk._save_green carries
+        # the within-cell offset on the FIRST orbital slot, so folding it back
+        # uses dr = ri - rj (the default), the inverse of that deflate.
+        # Hamiltonian/transfer quantities (trans_mod) carry the offset on the
+        # SECOND slot and fold with dr = rj - ri; pass hamiltonian=True for those.
 
         Lx,Ly,Lz = self.lattice.cellshape
         Lvol = Lx * Ly * Lz
@@ -1437,11 +1445,19 @@ class RPA:
         riy = (ri_arr // Bx) % By
         riz = (ri_arr // (Bx * By)) % Bz
 
-        # Compute jsite for all (isite, aa, bb) combinations
-        # drx[aa,bb] = rjx[bb] - rix[aa], etc.
-        drx = rix[np.newaxis, :] - rix[:, np.newaxis]  # (norb, norb)
-        dry = riy[np.newaxis, :] - riy[:, np.newaxis]
-        drz = riz[np.newaxis, :] - riz[:, np.newaxis]
+        # Compute jsite for all (isite, aa, bb) combinations (rix indexes the
+        # within-cell coordinate of each orbital slot).
+        # Hamiltonian/transfer convention: drx[aa,bb] = rix[bb] - rix[aa].
+        # Green convention (default): drx[aa,bb] = rix[aa] - rix[bb], i.e. the
+        # offset sits on the first slot -- the inverse of UHFk._deflate_green.
+        if hamiltonian:
+            drx = rix[np.newaxis, :] - rix[:, np.newaxis]  # (norb, norb)
+            dry = riy[np.newaxis, :] - riy[:, np.newaxis]
+            drz = riz[np.newaxis, :] - riz[:, np.newaxis]
+        else:
+            drx = rix[:, np.newaxis] - rix[np.newaxis, :]  # (norb, norb)
+            dry = riy[:, np.newaxis] - riy[np.newaxis, :]
+            drz = riz[:, np.newaxis] - riz[np.newaxis, :]
 
         # ix[isite, aa, bb] = (ix0[isite] + drx[aa, bb]) % Lx
         jx = (ix0[:, np.newaxis, np.newaxis] + drx[np.newaxis, :, :]) % Lx  # (Nvol, norb, norb)

--- a/src/hwave/solver/uhfk.py
+++ b/src/hwave/solver/uhfk.py
@@ -482,9 +482,15 @@ class UHFk(solver_base):
                 rix, riy, riz = _unpack_index(ri, (Bx,By,Bz))
                 rjx, rjy, rjz = _unpack_index(rj, (Bx,By,Bz))
 
-                ix = (ix0 + rjx - rix) % Lx
-                iy = (iy0 + rjy - riy) % Ly
-                iz = (iz0 + rjz - riz) % Lz
+                # Green convention: the within-cell offset sits on the first
+                # orbital slot (aa), matching _deflate_green's default. Folding
+                # uses dr = ri - rj, the inverse of that deflate, so folding an
+                # unfolded green and deflating it round-trips. (Hamiltonian/
+                # transfer folding uses dr = rj - ri and lives in
+                # _reshape_interaction.)
+                ix = (ix0 + rix - rjx) % Lx
+                iy = (iy0 + riy - rjy) % Ly
+                iz = (iz0 + riz - rjz) % Lz
 
                 jsite = _pack_site((ix,iy,iz), (Lx,Ly,Lz))
 
@@ -494,14 +500,27 @@ class UHFk(solver_base):
         return green_sub
 
     @do_profile
-    def _deflate_green(self, green_sub):
+    def _deflate_green(self, green_sub, hamiltonian=False):
         """Convert Green function back to original basis.
-        
+
         Parameters
         ----------
         green_sub : ndarray
             Green function in sublattice basis
-        
+        hamiltonian : bool, optional
+            Select the cross-sublattice slot convention. With
+            ``green[jsite,s,a,t,b] = green_sub[isite,s,aa,t,bb]``, where the
+            original site ``jsite`` decomposes per axis into a supercell site
+            ``isite`` and the within-cell offset ``ir``, the default (Green)
+            carries ``ir`` on the FIRST orbital slot
+            (``aa = a + norb_orig*ir``, ``bb = b``); ``hamiltonian=True`` carries
+            it on the SECOND slot (``aa = a``, ``bb = b + norb_orig*ir``). The
+            two differ because the folded Green ``self.Green`` from ``_green()``
+            is the orbital transpose of the Hamiltonian-convention object (it
+            stores ``G_ab(k) = sum_l conj(V_al) f_l V_bl``). Use the default for
+            a Green function and ``hamiltonian=True`` for Hamiltonian / transfer
+            quantities (e.g. ``trans_mod``).
+
         Returns
         -------
         ndarray
@@ -556,8 +575,12 @@ class UHFk(solver_base):
             ir = _pack_index((irx,iry,irz), (Bx,By,Bz))
 
             for a, b in itertools.product(range(norb_orig), range(norb_orig)):
-                aa = a
-                bb = b + norb_orig * ir
+                if hamiltonian:
+                    aa = a
+                    bb = b + norb_orig * ir
+                else:
+                    aa = a + norb_orig * ir
+                    bb = b
                 for s, t in itertools.product(range(ns), range(ns)):
                     green[jsite, s, a, t, b] = green_sub[isite, s, aa, t, bb]
 
@@ -2300,7 +2323,7 @@ class UHFk(solver_base):
             norb = self.norb
             ns = self.ns
 
-            tab_r_defl = self._deflate_green(tab_r.reshape(nvol,ns,norb,ns,norb))
+            tab_r_defl = self._deflate_green(tab_r.reshape(nvol,ns,norb,ns,norb), hamiltonian=True)
 
             lvol = self.cellvol
             norb_orig = self.norb_orig

--- a/tests/test_uhfk_green_deflate_subshape.py
+++ b/tests/test_uhfk_green_deflate_subshape.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Regression tests for sublattice-folded Green deflate/reshape in UHFk.
+
+The k-space Green function ``self.Green`` produced by ``_green()`` stores the
+density matrix in the orbital-transposed slot convention relative to the
+Hamiltonian. As a consequence the unfolded ``green`` output must place the
+cross-sublattice offset on the FIRST orbital slot (``aa = a + norb_orig*ir``),
+opposite to the Hamiltonian/transfer deflate (which uses the SECOND slot). If
+both use the same convention, the unfolded ``green`` of a complex
+(cross-sublattice) Hamiltonian comes out as the Hermitian conjugate of the
+reference ``SubShape=[1,1,1]`` result.
+
+Minimal model: 1D complex Peierls chain.
+  CellShape=[4,1,1], norb=1, Ncond=4, 2Sz=0, U=0
+  T(R=+1) = -exp(+i*0.4), T(R=-1) = -exp(-i*0.4)
+"""
+
+import os
+import tempfile
+import shutil
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+import hwave.solver.rpa as solver_rpa
+from hwave.solver.uhfk import UHFk
+
+
+GEOM = """  1.000000000000   0.000000000000   0.000000000000
+  0.000000000000   1.000000000000   0.000000000000
+  0.000000000000   0.000000000000   1.000000000000
+1
+    0.000000000000000e+00     0.000000000000000e+00     0.000000000000000e+00
+"""
+
+
+def _transfer_text():
+    tp = -np.exp(1j * 0.4)   # R = +1
+    tm = -np.exp(-1j * 0.4)  # R = -1
+    return (
+        "Transfer Peierls 1D chain\n"
+        "1\n"
+        "2\n"
+        " 1 1\n"
+        "  1    0    0    1    1  {:.12f}  {:.12f}\n"
+        " -1    0    0    1    1  {:.12f}  {:.12f}\n"
+    ).format(tp.real, tp.imag, tm.real, tm.imag)
+
+
+def _build_solver(case_dir, subshape):
+    info_inputfile = {
+        "path_to_input": "",
+        "interaction": {
+            "path_to_input": case_dir,
+            "Geometry": "geom.dat",
+            "Transfer": "transfer.dat",
+        },
+    }
+    read_io = read_input_k.QLMSkInput(info_inputfile)
+    ham_info = read_io.get_param("ham")
+    info_log = {"print_level": 0, "print_step": 1}
+    info_mode = {
+        "mode": "UHFk",
+        "param": {
+            "Ncond": 4, "2Sz": 0, "IterationMax": 2000, "EPS": 12,
+            "Mix": 0.5, "RndSeed": 123456789, "T": 0.0,
+            "CellShape": [4, 1, 1], "SubShape": list(subshape),
+        },
+    }
+    solver = UHFk(ham_info, info_log, info_mode)
+    green_info = read_io.get_param("green")
+    solver.solve(green_info, os.path.join(case_dir, "output"))
+    return solver
+
+
+class TestGreenDeflateSubShape(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp(prefix="hwave_peierls_")
+        with open(os.path.join(cls.tmp, "geom.dat"), "w") as f:
+            f.write(GEOM)
+        with open(os.path.join(cls.tmp, "transfer.dat"), "w") as f:
+            f.write(_transfer_text())
+        with open(os.path.join(cls.tmp, "coulombintra.dat"), "w") as f:
+            f.write("CoulombIntra Peierls\n1\n1\n 1\n"
+                    "   0    0    0    1    1   2.000000000000   0.000000000000\n")
+        cls.s111 = _build_solver(cls.tmp, (1, 1, 1))
+        cls.s211 = _build_solver(cls.tmp, (2, 1, 1))
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+    def test_green_subshape_invariance(self):
+        # unfolded green must match the SubShape=[1,1,1] reference
+        g_ref = self.s111.Green                       # no sublattice -> already unfolded
+        g_def = self.s211._deflate_green(self.s211.Green)
+        self.assertLess(np.max(np.abs(g_def - g_ref)), 1.0e-9)
+
+    def test_reshape_green_round_trip(self):
+        # folding the unfolded reference must reproduce the internal folded Green
+        g_ref = self.s111.Green
+        g_folded = self.s211._reshape_green(g_ref)
+        self.assertLess(np.max(np.abs(g_folded - self.s211.Green)), 1.0e-9)
+
+    def test_trans_mod_unchanged(self):
+        # the Hamiltonian/transfer deflate must remain SubShape-invariant
+        s111, s211 = self.s111, self.s211
+
+        def trans_r(solver):
+            nx, ny, nz = solver.shape
+            nvol = solver.nvol
+            nd = solver.nd
+            tab_k = solver.ham
+            return np.fft.fftn(tab_k.reshape(nx, ny, nz, nd, nd),
+                               axes=(0, 1, 2)).reshape(nvol, nd, nd) / nvol
+
+        ns, norb_orig = s111.ns, s111.norb_orig
+        lvol = s111.cellvol
+        tr_ref = trans_r(s111).reshape(lvol, ns, norb_orig, ns, norb_orig)
+        norb, nvol = s211.norb, s211.nvol
+        tab_r = trans_r(s211).reshape(nvol, ns, norb, ns, norb)
+        tr_def = s211._deflate_green(tab_r, hamiltonian=True)
+        # full (spin, orbital, spin, orbital) tensor must match the reference
+        self.assertEqual(tr_def.shape, tr_ref.shape)
+        self.assertLess(np.max(np.abs(tr_def - tr_ref)), 1.0e-9)
+
+    def test_rpa_green_init_fold_matches_uhfk(self):
+        # RPA folds UHFk's saved (unfolded) green via RPA._reshape_green. It must
+        # reconstruct UHFk's correct internal folded Green, i.e. RPA's green fold
+        # must stay the inverse of UHFk._deflate_green's Green convention.
+        info_mode = {
+            "mode": "RPA",
+            "param": {
+                "T": 2.0, "filling": 0.5,
+                "CellShape": [4, 1, 1], "SubShape": [2, 1, 1], "Nmat": 16,
+            },
+            "enable_spin_orbital": False,
+            "calc_scheme": "general",
+        }
+        inter = {
+            "path_to_input": self.tmp,
+            "Geometry": "geom.dat",
+            "Transfer": "transfer.dat",
+            "CoulombIntra": "coulombintra.dat",
+        }
+        read_io = read_input_k.QLMSkInput({"path_to_input": self.tmp, "interaction": inter})
+        ham = read_io.get_param("ham")
+        rpa = solver_rpa.RPA(ham, {}, info_mode)
+
+        unfolded = self.s111.Green                    # SubShape-invariant reference
+        folded_rpa = rpa._reshape_green(unfolded)
+        self.assertEqual(folded_rpa.shape, self.s211.Green.shape)
+        self.assertLess(np.max(np.abs(folded_rpa - self.s211.Green)), 1.0e-9)
+
+    def test_rpa_read_green_file_path(self):
+        # Exercise the real RPA._read_green plumbing (npz load, 5D collapse,
+        # shape validation, sublattice fold) on a UHFk-saved green file.
+        info_mode = {
+            "mode": "RPA",
+            "param": {
+                "T": 2.0, "filling": 0.5,
+                "CellShape": [4, 1, 1], "SubShape": [2, 1, 1], "Nmat": 16,
+            },
+            "enable_spin_orbital": False,
+            "calc_scheme": "general",
+        }
+        inter = {
+            "path_to_input": self.tmp,
+            "Geometry": "geom.dat",
+            "Transfer": "transfer.dat",
+            "CoulombIntra": "coulombintra.dat",
+        }
+        read_io = read_input_k.QLMSkInput({"path_to_input": self.tmp, "interaction": inter})
+        ham = read_io.get_param("ham")
+        rpa = solver_rpa.RPA(ham, {}, info_mode)
+
+        # write a green file in UHFk's _save_green format (unfolded "green" key)
+        npz_path = os.path.join(self.tmp, "green_init.npz")
+        green_unfolded = self.s211._deflate_green(self.s211.Green)
+        np.savez(npz_path, green=green_unfolded, green_sublattice=self.s211.Green)
+
+        nvol, nd = rpa.lattice.nvol, rpa.nd
+        g = rpa._read_green(npz_path)
+        self.assertEqual(g.shape, (nvol, nd, nd))
+        self.assertLess(
+            np.max(np.abs(g - self.s211.Green.reshape(nvol, nd, nd))), 1.0e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uhfk_green_deflate_subshape.py
+++ b/tests/test_uhfk_green_deflate_subshape.py
@@ -74,6 +74,51 @@ def _build_solver(case_dir, subshape):
     return solver
 
 
+# Spin-orbital fixtures: same physical Peierls chain, one physical orbital, with
+# spin folded into the orbital index (interleaved 1=up, 2=down). The hopping is
+# spin-diagonal, so the physics matches the non-SO chain.
+GEOM_SO = ("  1.0 0.0 0.0\n  0.0 1.0 0.0\n  0.0 0.0 1.0\n2\n"
+           "  0.0 0.0 0.0\n  0.0 0.0 0.0\n")
+
+
+def _transfer_text_so():
+    tp = -np.exp(1j * 0.4)
+    tm = -np.exp(-1j * 0.4)
+
+    def row(r, o, v):
+        return " {:2d}    0    0    {}    {}  {:.12f}  {:.12f}\n".format(r, o, o, v.real, v.imag)
+
+    return ("Transfer SO Peierls\n2\n2\n 1 1\n"
+            + row(1, 1, tp) + row(1, 2, tp) + row(-1, 1, tm) + row(-1, 2, tm))
+
+
+def _build_solver_so(case_dir, subshape):
+    info_inputfile = {
+        "path_to_input": "",
+        "interaction": {
+            "path_to_input": case_dir,
+            "Geometry": "geom_so.dat",
+            "Transfer": "transfer_so.dat",
+        },
+    }
+    read_io = read_input_k.QLMSkInput(info_inputfile)
+    ham_info = read_io.get_param("ham")
+    info_log = {"print_level": 0, "print_step": 1}
+    info_mode = {
+        "mode": "UHFk",
+        "enable_spin_orbital": True,
+        "param": {
+            "Ncond": 4, "IterationMax": 2000, "EPS": 12,
+            "Mix": 0.5, "RndSeed": 123456789, "T": 0.0,
+            "CellShape": [4, 1, 1], "SubShape": list(subshape),
+        },
+    }
+    solver = UHFk(ham_info, info_log, info_mode)
+    green_info = read_io.get_param("green")
+    solver.solve(green_info, os.path.join(case_dir, "output"))
+    return solver
+
+
 class TestGreenDeflateSubShape(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -85,6 +130,10 @@ class TestGreenDeflateSubShape(unittest.TestCase):
         with open(os.path.join(cls.tmp, "coulombintra.dat"), "w") as f:
             f.write("CoulombIntra Peierls\n1\n1\n 1\n"
                     "   0    0    0    1    1   2.000000000000   0.000000000000\n")
+        with open(os.path.join(cls.tmp, "geom_so.dat"), "w") as f:
+            f.write(GEOM_SO)
+        with open(os.path.join(cls.tmp, "transfer_so.dat"), "w") as f:
+            f.write(_transfer_text_so())
         cls.s111 = _build_solver(cls.tmp, (1, 1, 1))
         cls.s211 = _build_solver(cls.tmp, (2, 1, 1))
 
@@ -125,6 +174,17 @@ class TestGreenDeflateSubShape(unittest.TestCase):
         # full (spin, orbital, spin, orbital) tensor must match the reference
         self.assertEqual(tr_def.shape, tr_ref.shape)
         self.assertLess(np.max(np.abs(tr_def - tr_ref)), 1.0e-9)
+
+    def test_green_subshape_invariance_spin_orbital(self):
+        # The deflate/reshape path is shared by spin-orbital mode (ns=1, spin
+        # folded into the orbital index). The same fix must keep the SO green
+        # SubShape-invariant for complex cross-sublattice hopping.
+        so111 = _build_solver_so(self.tmp, (1, 1, 1))
+        so211 = _build_solver_so(self.tmp, (2, 1, 1))
+        g_ref = so111.Green                            # no sublattice -> unfolded
+        g_def = so211._deflate_green(so211.Green)
+        self.assertEqual(g_def.shape, g_ref.shape)
+        self.assertLess(np.max(np.abs(g_def - g_ref)), 1.0e-9)
 
     def test_rpa_green_init_fold_matches_uhfk(self):
         # RPA folds UHFk's saved (unfolded) green via RPA._reshape_green. It must


### PR DESCRIPTION
## Summary

In UHFk, the exported Green function was not invariant under sublattice folding (`SubShape != [1,1,1]`) for **complex** Hamiltonians with cross-sublattice hopping. The `green` key in `green.npz` (and `greenone.dat`) came out as the **Hermitian conjugate** of the `SubShape=[1,1,1]` reference, with a max difference of 0.5 on a minimal test case.

Root cause: the k-space Green function `self.Green` from `_green()` stores the density matrix transposed in the orbital indices relative to the Hamiltonian (`G_ab(k) = sum_l conj(V_al) f_l V_bl`). The unfold/fold helpers (`_deflate_green` / `_reshape_green`) applied the Hamiltonian/transfer slot convention to the Green function as well, putting the within-cell offset on the wrong orbital slot.

Energy, eigenvalues and eigenvectors are **unaffected**, and the issue is invisible for real Hamiltonians (the conjugate is equal there).

## Changes

- **UHFk**: `_deflate_green` / `_reshape_green` now use the Green convention (within-cell offset on the first orbital slot) by default. A new `hamiltonian=True` flag selects the Hamiltonian/transfer convention, used only by `_save_trans_mod`.
- **RPA**: `_reshape_green` gains the same flag. `green_init` folding uses the Green convention; `trans_mod` folding stays on the Hamiltonian convention. This is required so RPA warm-start from a UHFk `green` file folds with the correct sign once UHFk writes the corrected green.

Affected outputs: `green.npz` `green` key, `greenone.dat`, green-only warm-start paths, and RPA `green_init`. `green_sublattice` and `trans_mod` are unchanged.

## Tests

New regression tests on a 1D complex Peierls chain (`tests/test_uhfk_green_deflate_subshape.py`):
- `green` SubShape invariance (`[1,1,1]` vs `[2,1,1]`)
- `_reshape_green` round-trip against the internal folded Green
- `trans_mod` regression (full spin/orbital tensor) confirming the Hamiltonian path is preserved
- UHFk→RPA `green_init` fold consistency, plus the real `RPA._read_green` file path

Full suite: 520 passed. The RPA regression test was confirmed to fail when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Additional verification

- Confirmed the `SubShape=[1,1,1]` reference green this fix targets equals the established non-sublattice convention (checked against a direct real-space diagonalization of the chain); the fix propagates that convention to the folded case rather than introducing a new one.
- Confirmed spin-orbital mode (`enable_spin_orbital`) is fixed by the same shared deflate/reshape path and added a spin-orbital regression test, since the existing spin-orbital tests only use synthetic Hermitian green and could not detect the conjugate-side error.

Full suite: 521 passed.
