### PR TITLE
Fix silent physics regressions and I/O metadata bugs found by multi-round review of develop

### DIFF
--- a/src/hwave/qlmsio/wan90.py
+++ b/src/hwave/qlmsio/wan90.py
@@ -258,6 +258,33 @@ def read_w90(name_in):
 
     return data
 
+def split_coulomb(data):
+    """Split a combined 'Coulomb' table into intra and inter parts.
+
+    The aggregate Coulomb input (zvo_ur.dat) provides both parts at once:
+    the r=0 orbital-diagonal entries are the on-site CoulombIntra terms,
+    everything else is CoulombInter.  This decomposition is the single
+    definition shared by all solvers (UHFk and RPA/FLEX).
+
+    Parameters
+    ----------
+    data : dict
+        {((rx,ry,rz), (alpha,beta)): value} as returned by read_w90.
+
+    Returns
+    -------
+    (dict, dict)
+        (CoulombIntra part, CoulombInter part), same key format.
+    """
+    intra = {}
+    inter = {}
+    for (irvec, orbvec), v in data.items():
+        if irvec == (0, 0, 0) and orbvec[0] == orbvec[1]:
+            intra[(irvec, orbvec)] = v
+        else:
+            inter[(irvec, orbvec)] = v
+    return intra, inter
+
 def write_w90(name_in, info_int, info_geometry, interact_shape):
     """Write Wannier90 Hamiltonian data to file.
     

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -33,10 +33,138 @@ logger = logging.getLogger("hwave_sc")
 # near the nullspace of the commutator and missing a non-centrosymmetric kernel.
 _PARITY_GUARD_PROBES = 3
 
+# Default Matsubara grid size (mode.param.Nmat). Single definition so the
+# legacy-file fallback in _static_freq_position and the main solver loop can
+# never silently disagree on the grid.
+_DEFAULT_NMAT = 1024
+
 
 # ---------------------------------------------------------------------------
 # Data loading
 # ---------------------------------------------------------------------------
+
+def _static_freq_position(freq_index, nfreq, config_nmat, file_name,
+                          file_nmat=None):
+    """Locate the zero bosonic frequency along the chi0q frequency axis.
+
+    RPA writes ``freq_index`` (the ORIGINAL Matsubara indices, zero frequency
+    at original index Nmat//2) into chi0q.npz; the matsubara_frequency option
+    can restrict the stored axis, so the static slice is generally NOT at
+    nfreq//2 of the stored array.  Newer files also record ``nmat`` (the full
+    grid size of the producing run), which resolves the position without any
+    assumption about the hwave_sc configuration.
+
+    Parameters
+    ----------
+    freq_index : array-like or None
+        The freq_index metadata from the npz file (None for legacy files).
+    nfreq : int
+        Length of the stored frequency axis.
+    config_nmat : int
+        Nmat from mode.param of the hwave_sc run (fallback only).
+    file_name : str
+        For error messages.
+    file_nmat : int or None
+        The nmat metadata from the npz file, if present.
+
+    Returns
+    -------
+    int or None
+        Position of the zero bosonic frequency along the stored axis, or
+        None when the file carries no usable metadata -- the caller must
+        then slice the CENTER of the frequency axis it actually uses (only
+        the caller can identify that axis reliably, e.g. for the 6D
+        reference format).
+    """
+    if freq_index is None:
+        logger.warning(
+            "chi0q file '{}' has no freq_index metadata; using the center "
+            "of the stored frequency axis as the static slice.".format(
+                file_name))
+        return None
+
+    freq_index = np.asarray(freq_index).ravel()
+    if freq_index.size == 0:
+        raise ValueError(
+            "chi0q file '{}' records no frequencies (matsubara_frequency="
+            "\"none\"?); it cannot provide the static susceptibility."
+            .format(file_name))
+    if freq_index.size != nfreq:
+        # Legacy FLEX files store the FULL grid but a restricted freq_index
+        # (FLEX never applied the matsubara_frequency filter): the DATA axis
+        # is authoritative, so fall back to the pre-metadata behavior.
+        logger.warning(
+            "chi0q file '{}': freq_index length {} does not match the "
+            "frequency axis length {}; ignoring the metadata and using the "
+            "center of the stored frequency axis as the static slice."
+            .format(file_name, freq_index.size, nfreq))
+        return None
+
+    def _find(nmat_orig):
+        # the zero bosonic frequency has ORIGINAL index nmat_orig//2
+        pos = np.where(freq_index == nmat_orig // 2)[0]
+        if pos.size == 0:
+            raise ValueError(
+                "chi0q file '{}' does not contain the zero bosonic frequency "
+                "(original index Nmat//2 = {}; stored freq_index = {}..{}). "
+                "Regenerate chi0q with a matsubara_frequency range covering "
+                "Nmat//2.".format(file_name, nmat_orig // 2,
+                                  freq_index[0], freq_index[-1]))
+        return int(pos[0])
+
+    if file_nmat is not None:
+        # authoritative: the producing run recorded its own grid size
+        return _find(int(file_nmat))
+
+    if np.array_equal(freq_index, np.arange(nfreq)):
+        # Legacy file (no nmat metadata) with a contiguous 0-based
+        # freq_index: EITHER a full grid of its own (zero at nfreq//2) OR a
+        # matsubara_frequency=[0,K] restriction of SOME run's grid (config
+        # or larger).  Resolve only when the readings coincide; silently
+        # picking either would return a finite frequency whenever the other
+        # reading is the true one.
+        if nfreq == config_nmat:
+            return nfreq // 2
+        raise ValueError(
+            "chi0q file '{}' is ambiguous: freq_index = 0..{} with "
+            "mode.param.Nmat = {} could be either a full {}-point grid "
+            "(zero frequency at {}) or a [0,{}] restriction of a run with "
+            "a different Nmat (zero frequency elsewhere or absent). If the "
+            "file holds a full grid, set mode.param.Nmat = {}; otherwise "
+            "regenerate it with a newer version (which records nmat in "
+            "the file)."
+            .format(file_name, nfreq - 1, config_nmat, nfreq, nfreq // 2,
+                    nfreq - 1, nfreq))
+
+    # Legacy restricted range: fall back to the configured Nmat, which must
+    # be the producing run's grid size (the standard workflow shares one
+    # TOML).  Indices reaching past the config grid disprove that reading,
+    # so refuse to guess (looking up config_nmat//2 could land on a finite
+    # frequency of the true, larger grid).
+    if int(freq_index.max()) >= config_nmat:
+        raise ValueError(
+            "chi0q file '{}': freq_index reaches {} >= mode.param.Nmat = "
+            "{}, so the file was produced by a run with a different Nmat "
+            "and the zero-frequency position cannot be determined. Set "
+            "mode.param.Nmat to the producing run's value, or regenerate "
+            "the file with a newer version (which records nmat)."
+            .format(file_name, int(freq_index.max()), config_nmat))
+    return _find(config_nmat)
+
+
+def _read_freq_meta(data):
+    """Decode the frequency metadata of a chi0q/chiq npz file.
+
+    Returns
+    -------
+    (freq_index or None, nmat or None)
+        Single definition shared by all loaders so chi0q and chiq_s/chiq_c
+        can never interpret the same file's frequency axis differently.
+    """
+    freq_index = data["freq_index"] if "freq_index" in data else None
+    file_nmat = int(data["nmat"]) if "nmat" in data else None
+    return freq_index, file_nmat
+
 
 def _load_chi0q(input_dict):
     """Load chi0q from NPZ file produced by H-wave RPA solver.
@@ -50,6 +178,9 @@ def _load_chi0q(input_dict):
     -------
     chi0q : ndarray
         Bare susceptibility array.
+    static_index : int
+        Position of the zero bosonic frequency along the frequency axis
+        (determined from the freq_index metadata).
     """
     output_info = input_dict["file"]["output"]
     path_to_output = output_info["path_to_output"]
@@ -63,7 +194,46 @@ def _load_chi0q(input_dict):
     validate_chi0q_index_convention(data, enable_spin_orbital, file_name)
     chi0q = data["chi0q"]
     logger.info("chi0q shape: {}".format(chi0q.shape))
-    return chi0q
+
+    freq_index, file_nmat = _read_freq_meta(data)
+    # Identify the frequency axis from the array LAYOUT, never from the
+    # freq_index length (a restricted freq_index can coincidentally match
+    # an orbital axis).  4D raw: axis 0.  8D ref: last axis.  6D is either
+    # raw (nmat, nvol, norb^4; the last four axes are equal) or ref
+    # (norb, norb, Nx, Ny, Nz, nmat; the first two axes are equal) --
+    # disambiguate structurally, with the freq_index length only as the
+    # tiebreaker for degenerate shapes.  Without metadata
+    # _static_freq_position returns None and the caller slices the center
+    # of the axis it actually uses.
+    if freq_index is not None:
+        nfi = np.asarray(freq_index).size
+        if chi0q.ndim == 4:
+            nfreq = chi0q.shape[0]
+        elif chi0q.ndim == 8:
+            nfreq = chi0q.shape[-1]
+        elif chi0q.ndim == 6:
+            raw_like = len(set(chi0q.shape[2:])) == 1
+            ref_like = chi0q.shape[0] == chi0q.shape[1]
+            if raw_like and not ref_like:
+                nfreq = chi0q.shape[0]
+            elif ref_like and not raw_like:
+                nfreq = chi0q.shape[-1]
+            elif nfi == chi0q.shape[0]:
+                nfreq = chi0q.shape[0]
+            else:
+                nfreq = chi0q.shape[-1]
+        else:
+            nfreq = chi0q.shape[-1]
+    else:
+        nfreq = 0  # unused: no metadata -> _static_freq_position gives None
+    config_nmat = input_dict.get("mode", {}).get("param", {}).get("Nmat",
+                                                                _DEFAULT_NMAT)
+    static_index = _static_freq_position(freq_index, nfreq, config_nmat,
+                                         file_name, file_nmat=file_nmat)
+    if static_index is not None and static_index != nfreq // 2:
+        logger.info("static (zero bosonic frequency) slice at index {} "
+                    "of {}".format(static_index, nfreq))
+    return chi0q, static_index
 
 
 def _calc_chi0q_internal(input_dict, chi0q_tensor="auto",
@@ -217,6 +387,21 @@ def _read_interaction_files(input_dict):
             f = os.path.join(path_to_input, files[itype])
             logger.info("Reading {} from {}".format(itype, f))
             interactions[itype] = wan90.read_w90(f)
+
+    # combined 'Coulomb' input: same decomposition as UHFk/RPA
+    # (wan90.split_coulomb; r=0 diagonal -> CoulombIntra, rest -> CoulombInter)
+    if "Coulomb" in files:
+        if "CoulombIntra" in interactions or "CoulombInter" in interactions:
+            raise ValueError(
+                "Coulomb cannot be specified together with "
+                "CoulombIntra or CoulombInter")
+        f = os.path.join(path_to_input, files["Coulomb"])
+        logger.info("Reading Coulomb from {}".format(f))
+        coulomb_intra, coulomb_inter = wan90.split_coulomb(wan90.read_w90(f))
+        if coulomb_intra:
+            interactions["CoulombIntra"] = coulomb_intra
+        if coulomb_inter:
+            interactions["CoulombInter"] = coulomb_inter
 
     return geom_info, hr, interactions
 
@@ -606,7 +791,7 @@ def _build_sc_matrices(inter_k, norb, ix, iy, iz):
 
 
 def _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
-                      pairing_type="singlet"):
+                      pairing_type="singlet", static_index=None):
     """Compute effective pairing interaction V(q).
 
     Supports two modes:
@@ -657,7 +842,8 @@ def _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
         # General mode: 4-index S,C matrices
         # Required when 4-index chi0q is available or Hund/Exchange present
         return _compute_vertices_general(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
-                                         pairing_type=pairing_type)
+                                         pairing_type=pairing_type,
+                                         static_index=static_index)
     else:
         # Simple mode: backward compatible with original implementation
         # Only used for 2-index chi0q without Hund/Exchange
@@ -668,11 +854,12 @@ def _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
                 "cross-channel contributions are dropped. Provide a 4-index "
                 "chi0q (general mode) for the full Kuroki S/C treatment.")
         return _compute_vertices_simple(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
-                                        pairing_type=pairing_type)
+                                        pairing_type=pairing_type,
+                                        static_index=static_index)
 
 
 def _compute_vertices_simple(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
-                             pairing_type="singlet"):
+                             pairing_type="singlet", static_index=None):
     """Compute vertices using simple Wc=U+2V, Ws=-U formulation.
 
     For singlet:
@@ -699,7 +886,9 @@ def _compute_vertices_simple(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
     Ws = (-U_k).transpose(2, 3, 4, 0, 1).copy()
 
     # chi0 at static limit: (Nx, Ny, Nz, norb, norb)
-    chi0_static = chi0q[:, :, :, :, :, nmat // 2].transpose(2, 3, 4, 0, 1).copy()
+    # (zero bosonic frequency; nmat//2 only for a full frequency grid)
+    si = nmat // 2 if static_index is None else static_index
+    chi0_static = chi0q[:, :, :, :, :, si].transpose(2, 3, 4, 0, 1).copy()
 
     I_mat = np.broadcast_to(np.eye(norb, dtype=complex), (Nx, Ny, Nz, norb, norb)).copy()
 
@@ -731,7 +920,7 @@ def _compute_vertices_simple(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
 
 
 def _compute_vertices_general(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
-                              pairing_type="singlet"):
+                              pairing_type="singlet", static_index=None):
     """Compute effective pairing interaction using general S,C matrices.
 
     For singlet (Kuroki et al., arXiv:0902.3691, Eq.(6)):
@@ -759,13 +948,15 @@ def _compute_vertices_general(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
     S_all, C_all = _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz)
 
     # Extract chi0 at static limit for all q-points
+    # (zero bosonic frequency; nmat//2 only for a full frequency grid)
+    si = nmat // 2 if static_index is None else static_index
     if chi0q_is_4index:
         # (norb, norb, norb, norb, Nx, Ny, Nz, nmat) -> (Nx, Ny, Nz, nd, nd)
-        chi0_static = chi0q[:, :, :, :, :, :, :, nmat // 2].reshape(
+        chi0_static = chi0q[:, :, :, :, :, :, :, si].reshape(
             nd, nd, Nx, Ny, Nz).transpose(2, 3, 4, 0, 1).copy()
     else:
         # (norb, norb, Nx, Ny, Nz, nmat) -> expand to (Nx, Ny, Nz, nd, nd)
-        chi0_2d = chi0q[:, :, :, :, :, nmat // 2].transpose(2, 3, 4, 0, 1).copy()
+        chi0_2d = chi0q[:, :, :, :, :, si].transpose(2, 3, 4, 0, 1).copy()
         # chi0_2d shape: (Nx, Ny, Nz, norb, norb)
         if norb == 1:
             chi0_static = chi0_2d.reshape(Nx, Ny, Nz, 1, 1)
@@ -942,13 +1133,27 @@ def _load_flex_susceptibilities(input_dict, norb, Nx, Ny, Nz):
                 chi_convention, chi_convention_c))
 
     # Convert from H-wave format (nmat, nvol, nd, nd) to
-    # reference format (Nx, Ny, Nz, nd, nd) at static limit
-    nmat_s = chi_s_raw.shape[0]
-    center = nmat_s // 2
+    # reference format (Nx, Ny, Nz, nd, nd) at static limit.
+    # The zero bosonic frequency is located via the freq_index/nmat metadata
+    # (RPA chiq files can carry a restricted matsubara_frequency axis whose
+    # center is NOT the static limit); FLEX files always hold the full grid.
+    config_nmat = input_dict.get("mode", {}).get("param", {}).get(
+        "Nmat", _DEFAULT_NMAT)
 
-    # Extract static limit (center Matsubara frequency)
-    chi_s_static = chi_s_raw[center].reshape(Nx, Ny, Nz, -1)
-    chi_c_static = chi_c_raw[center].reshape(Nx, Ny, Nz, -1)
+    def _static_center(data, raw, path):
+        fi, fn = _read_freq_meta(data)
+        pos = _static_freq_position(fi, raw.shape[0], config_nmat, path,
+                                    file_nmat=fn)
+        # no usable metadata: center of the actual data axis (axis 0 in the
+        # H-wave chiq layout)
+        return raw.shape[0] // 2 if pos is None else pos
+
+    center_s = _static_center(data_s, chi_s_raw, chi_s_path)
+    center_c = _static_center(data_c, chi_c_raw, chi_c_path)
+
+    # Extract static limit (zero bosonic frequency)
+    chi_s_static = chi_s_raw[center_s].reshape(Nx, Ny, Nz, -1)
+    chi_c_static = chi_c_raw[center_c].reshape(Nx, Ny, Nz, -1)
 
     # Determine dimensionality
     nd_chi = int(np.sqrt(chi_s_static.shape[-1]))
@@ -2169,7 +2374,7 @@ def _save_results(output_dir, sigma, eigenvalue, eigenvalues_eig, kx_array, ky_a
 # chi0q format conversion
 # ---------------------------------------------------------------------------
 
-def _convert_chi0q_to_ref_format(chi0q, norb, Nx, Ny, Nz, nmat):
+def _convert_chi0q_to_ref_format(chi0q, norb, Nx, Ny, Nz):
     """Convert chi0q from H-wave format to reference code format.
 
     Supports both 2-index (reduced) and 4-index (general) chi0q:
@@ -2184,7 +2389,7 @@ def _convert_chi0q_to_ref_format(chi0q, norb, Nx, Ny, Nz, nmat):
     ----------
     chi0q : ndarray
         chi0q in H-wave format.
-    norb, Nx, Ny, Nz, nmat : int
+    norb, Nx, Ny, Nz : int
         System parameters.
 
     Returns
@@ -2237,7 +2442,7 @@ def calc_eliashberg(input_dict):
     beta = 1.0 / T
     cell_shape = mode_param["CellShape"]
     sub_shape = mode_param.get("SubShape", cell_shape)
-    nmat = mode_param.get("Nmat", 1024)
+    nmat = mode_param.get("Nmat", _DEFAULT_NMAT)
 
     # Filling
     if "filling" in mode_param:
@@ -2349,21 +2554,23 @@ def calc_eliashberg(input_dict):
         if chi0q_mode == "calc":
             chi0q_raw = _calc_chi0q_internal(input_dict, chi0q_tensor=chi0q_tensor,
                                                 precomputed_mu=mu)
+            # internally computed chi0q always carries the full frequency grid
+            static_index = None
         else:
-            chi0q_raw = _load_chi0q(input_dict)
+            chi0q_raw, static_index = _load_chi0q(input_dict)
 
-        # Step 8: Convert chi0q format
-        if chi0q_raw.ndim in (4, 6):
-            nmat_chi0q = chi0q_raw.shape[0]
-        else:
-            nmat_chi0q = chi0q_raw.shape[-1]
-        chi0q = _convert_chi0q_to_ref_format(chi0q_raw, norb, Nx, Ny, Nz, nmat_chi0q)
+        # Step 8: Convert chi0q format; the frequency axis is last in the
+        # reference format, so read its length after the conversion (a 6D
+        # input can be either raw H-wave (nmat first) or ref (nmat last))
+        chi0q = _convert_chi0q_to_ref_format(chi0q_raw, norb, Nx, Ny, Nz)
+        nmat_chi0q = chi0q.shape[-1]
         logger.info("chi0q converted to shape: {}".format(chi0q.shape))
 
         # Step 9: Compute RPA vertices
         logger.info("Computing RPA vertices (pairing_type={})...".format(pairing_type))
         vertex_result = _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat_chi0q,
-                                          pairing_type=pairing_type)
+                                          pairing_type=pairing_type,
+                                          static_index=static_index)
         if isinstance(vertex_result, tuple):
             Pc_q, Ps_q = vertex_result
             Vs_q = Pc_q + Ps_q

--- a/src/hwave/solver/base.py
+++ b/src/hwave/solver/base.py
@@ -277,6 +277,51 @@ class solver_base():
             sys.exit(1)
         return ret
 
+    def _check_spin_flip_with_fixed_sz(self, trans_abs, norb):
+        """Reject one-body spin-flip terms in 2Sz-fixed mode.
+
+        Such terms genuinely break Sz conservation, so a fixed 2Sz is
+        ill-defined.  Numerical noise must not abort the run: cross-spin
+        entries are compared against the overall transfer scale (Wannier
+        transfers carry ~1e-14 cross-spin residues, and a k-sum amplifies
+        them past any absolute epsilon), so entries below 1e-8 of the scale
+        are treated as zero (and masked by the block structure downstream).
+
+        Parameters
+        ----------
+        trans_abs : ndarray, shape (2*norb, 2*norb)
+            Non-negative magnitudes of the one-body terms in spin-block
+            order (possibly summed over k).
+        norb : int
+            Number of orbitals per spin sector.
+
+        Raises
+        ------
+        ValueError
+            If a cross-spin entry exceeds 1e-8 of the largest entry.
+        """
+        scale = trans_abs.max() if trans_abs.size > 0 else 0.0
+        if scale <= 0.0:
+            return
+        cross = max(trans_abs[:norb, norb:].max(initial=0.0),
+                    trans_abs[norb:, :norb].max(initial=0.0))
+        if cross > 1.0e-8 * scale:
+            msg = ("2Sz-fixed mode is incompatible with spin-flip one-body "
+                   "terms: Sz is not conserved, so a fixed 2Sz is "
+                   "ill-defined. Use the Sz-free mode (omit 2Sz) for such "
+                   "systems.")
+            logger.error(msg)
+            raise ValueError(msg)
+        if cross > 0.0:
+            # nonzero but below the noise threshold: masked, not fatal --
+            # say so, in case it is a deliberately weak physical term
+            logger.warning(
+                "2Sz-fixed mode: cross-spin one-body entries up to {:.3e} "
+                "({:.1e} relative to the transfer scale) are below the "
+                "noise threshold (1e-8) and are ignored. If they are "
+                "physical (e.g. weak spin-orbit coupling), use the Sz-free "
+                "mode.".format(cross, cross / scale))
+
     def solve(self, path_to_output):
         """Solve the Hartree-Fock equations.
         

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -971,28 +971,24 @@ class FLEX(RPA):
         # --- Compute Sigma(r, tau) ---
         n_common = min(nfreq, nmat)
 
-        # If nd_block != nd_v, we need to expand G to match V_eff space
-        # spin-free: nd_block = norb, nd_v = norb*ns = nd
+        # If nd_block != nd_v, each Green block only sees its own spin slot
+        # of V_eff (spin-free: nd_block = norb, nd_v = norb*ns = nd)
         if nd_block != nd_v:
-            # Expand Green's function to spin-orbital space using np.kron
-            # For spin-free: G_{sa,tb} = G_{ab} * delta_{st}
+            # The inflated V_eff carries the (raw) chi0q block g on its spin
+            # diagonal slot (g, g) (see _inflate_chi0q_and_ham), so:
+            #   spin-diag (nblock == ns): Green block g pairs with slot g
+            #   spin-free (nblock == 1):  both slots are identical, use slot 0
+            # Sigma stays in block space (nd_block x nd_block); the spin
+            # off-diagonal slots of the inflated form are exactly zero.
             norb = self.norb
-            ns = self.ns
-            # Vectorized spin inflation: use Kronecker product with identity
-            # green_rt[:, :n_common] has shape (nblock, n_common, nvol, norb, norb)
-            # We need kron(eye(ns), G) for each (nblock, time, vol)
-            spin_eye = np.eye(ns, dtype=np.complex128)
-            # sigma_rt[g, t, r] = v_rt[t, r] * kron(I_s, G[g, t, r])
-            # Compute directly without full expansion:
-            # kron(I_s, G) is block-diagonal with G repeated ns times on diagonal
-            # Hadamard with v_rt: only diagonal blocks of v_rt contribute
-            sigma_rt = np.zeros((nblock, nmat, nvol, nd_v, nd_v),
+            sigma_rt = np.zeros((nblock, nmat, nvol, nd_block, nd_block),
                                 dtype=np.complex128)
-            for s in range(ns):
+            for g in range(nblock):
+                s = g if nblock == self.ns else 0
                 sl = slice(s * norb, (s + 1) * norb)
-                sigma_rt[:, :n_common, :, sl, sl] = (
+                sigma_rt[g, :n_common] = (
                     v_rt[:n_common, :, sl, sl]
-                    * green_rt[:, :n_common]
+                    * green_rt[g, :n_common]
                 )
         else:
             # Sigma(r,tau) = V_eff(r,tau) * G(r,tau)  (element-wise product)
@@ -1001,23 +997,20 @@ class FLEX(RPA):
             sigma_rt[:, :n_common] = v_rt[:n_common] * green_rt[:, :n_common]
 
         # --- Transform Sigma back to (k, iwn) space ---
+        nd_sig = sigma_rt.shape[-1]
 
         # Real-space -> k-space
         sigma_kt = FFT.fftn(
-            sigma_rt.reshape(nblock, nmat, nx, ny, nz, nd_v * nd_v),
+            sigma_rt.reshape(nblock, nmat, nx, ny, nz, nd_sig * nd_sig),
             axes=(2, 3, 4)
-        ).reshape(nblock, nmat, nvol * nd_v * nd_v)
+        ).reshape(nblock, nmat, nvol * nd_sig * nd_sig)
 
         # Imaginary time -> Matsubara freq (fermionic)
         # Use broadcasting instead of einsum for phase multiplication
         omg_f_inv = np.exp(1j * np.pi * (1.0 / nmat - 1.0) * np.arange(nmat))
         sigma_kw = (FFT.ifft(sigma_kt * omg_f_inv[np.newaxis, :, np.newaxis],
                              axis=1)
-                    .reshape(nblock, nmat, nvol, nd_v, nd_v) * (1.0 / beta))
-
-        # If we expanded to spin-orbital space, contract back to block space
-        if nd_block != nd_v:
-            return sigma_kw[:, :, :, :nd_block, :nd_block]
+                    .reshape(nblock, nmat, nvol, nd_sig, nd_sig) * (1.0 / beta))
 
         return sigma_kw
 
@@ -1178,14 +1171,32 @@ class FLEX(RPA):
 
         self._init_wavevec()
 
+        # FLEX never applies the matsubara_frequency filter to its outputs
+        # (unlike RPA.solve): every stored frequency axis is the full nmat
+        # grid, so the metadata must describe that grid -- writing the
+        # restricted user option (self.freq_index) would make the strict
+        # hwave_sc loader reject a valid file.
+        full_freq_index = np.arange(self.nmat)
+        if len(self.freq_index) < self.nmat:
+            logger.warning(
+                "matsubara_frequency is restricted but FLEX outputs always "
+                "hold the full frequency grid; the option is ignored.")
+
         # Save chi0q
         if "chi0q" in info_outputfile:
             file_name = os.path.join(path_to_output, info_outputfile["chi0q"])
             np.savez(file_name,
                      chi0q=green_info["chi0q"],
-                     freq_index=self.freq_index,
+                     freq_index=full_freq_index,
+                     # full grid size: lets consumers locate the zero bosonic
+                     # frequency (index nmat//2) unambiguously
+                     nmat=self.nmat,
                      wavevector_unit=self.kvec,
-                     wavevector_index=self.wavenum_table)
+                     wavevector_index=self.wavenum_table,
+                     # FLEX chi0q comes from the same spin-block-ordered RPA
+                     # internals; tag it so the chi0q consumers (RPA read_chi0q,
+                     # hwave_sc _load_chi0q) accept the file in SO mode.
+                     index_convention="spin_block")
             logger.info("save_results: save chi0q in file {}".format(file_name))
 
         # Save susceptibilities (spin and charge channels separately for
@@ -1193,7 +1204,8 @@ class FLEX(RPA):
         # consumer (_load_flex_susceptibilities / _compute_vertices_flex) pairs
         # them with the matching S/C matrices: the general (full-vertex) path
         # produces MYO-convention susceptibilities, the reduced path Kuroki.
-        common_meta = dict(freq_index=self.freq_index,
+        common_meta = dict(freq_index=full_freq_index,
+                           nmat=self.nmat,
                            wavevector_unit=self.kvec,
                            wavevector_index=self.wavenum_table,
                            chi_convention=("myo" if self._flex_general
@@ -1226,7 +1238,7 @@ class FLEX(RPA):
             file_name = os.path.join(path_to_output, info_outputfile["sigma"])
             np.savez(file_name,
                      sigma=green_info.get("sigma"),
-                     freq_index=self.freq_index,
+                     freq_index=full_freq_index,
                      wavevector_unit=self.kvec,
                      wavevector_index=self.wavenum_table)
             logger.info("save_results: save sigma in file {}".format(file_name))
@@ -1236,7 +1248,7 @@ class FLEX(RPA):
             file_name = os.path.join(path_to_output, info_outputfile["green"])
             np.savez(file_name,
                      green=green_info.get("green"),
-                     freq_index=self.freq_index,
+                     freq_index=full_freq_index,
                      wavevector_unit=self.kvec,
                      wavevector_index=self.wavenum_table)
             logger.info("save_results: save green in file {}".format(file_name))

--- a/src/hwave/solver/fold.py
+++ b/src/hwave/solver/fold.py
@@ -1,0 +1,137 @@
+"""Sublattice folding of geometry and R-space interaction/transfer tables.
+
+Single definition shared by UHFk and RPA/FLEX: the two solvers previously
+carried near-verbatim copies of these folds, and bug fixes (physical-orbital
+stride, wrap-around canonicalization/accumulation) had to be mirrored
+between them by hand.
+"""
+import itertools
+
+import numpy as np
+
+
+def reshape_geometry(geom, subshape):
+    """Fold a geometry definition onto the sublattice (supercell) basis.
+
+    Parameters
+    ----------
+    geom : dict
+        Original geometry with 'norb', 'rvec' and 'center'.
+    subshape : tuple of int
+        Supercell shape (Bx, By, Bz).
+
+    Returns
+    -------
+    dict
+        The folded geometry (norb multiplied by the supercell volume,
+        rvec scaled, orbital centers replicated per supercell cell).
+    """
+    Bx, By, Bz = subshape
+    bvol = Bx * By * Bz
+
+    norb = geom['norb']
+
+    geom_new = {}
+    geom_new['norb'] = geom['norb'] * bvol
+    geom_new['rvec'] = np.matmul(np.diag([Bx, By, Bz]), geom['rvec'])
+
+    sc = np.array([1.0/Bx, 1.0/By, 1.0/Bz])
+    cw = [ sc * geom['center'][k] for k in range(norb) ]
+
+    centerv = np.zeros((norb * bvol, 3), dtype=np.float64)
+    k = 0
+    for bz, by, bx in itertools.product(range(Bz), range(By), range(Bx)):
+        for i in range(norb):
+            centerv[k] = cw[i] + np.array([bx, by, bz]) * sc
+            k += 1
+    geom_new['center'] = centerv
+
+    return geom_new
+
+
+def reshape_interaction(ham, subshape, shape, norb_so_orig, norb_phys_orig,
+                        enable_spin_orbital):
+    """Fold an R-space table onto the sublattice (supercell) basis.
+
+    Parameters
+    ----------
+    ham : dict
+        {((rx,ry,rz), (alpha,beta)): value} in the original cell basis.
+    subshape : tuple of int
+        Supercell shape (Bx, By, Bz).
+    shape : tuple of int
+        Folded lattice shape in units of the supercell (Nx, Ny, Nz).
+    norb_so_orig : int
+        Geometry norb of the original cell (the spin-orbital count in
+        enable_spin_orbital mode).
+    norb_phys_orig : int
+        Physical orbital count of the original cell (equals norb_so_orig
+        when spin-orbital mode is off).
+    enable_spin_orbital : bool
+        True when THIS table uses spin-orbital indices (the Transfer in SO
+        mode).  Two-body interaction tables always use physical orbital
+        indices and pass False.
+
+    Returns
+    -------
+    dict
+        The folded table, with R canonicalized to [0, n) and wrap-around
+        collisions accumulated.
+    """
+    Bx, By, Bz = subshape
+    nx, ny, nz = shape
+
+    def _reshape_orbit_(a, x):
+        # Two-body interaction files use PHYSICAL orbital indices even in
+        # spin-orbital mode, and the interaction tables are laid out as
+        # a + norb_phys_orig * cellidx -- so fold with the physical stride.
+        return a + norb_phys_orig * (x[0] + Bx * (x[1] + By * (x[2])))
+
+    def _reshape_orbit_spin(a, x):
+        a_, s_ = a % norb_so_orig, a // norb_so_orig
+        return a_ + norb_so_orig * (x[0] + Bx * (x[1] + By * (x[2] + Bz * s_)))
+
+    if enable_spin_orbital:
+        _reshape_orbit = _reshape_orbit_spin
+    else:
+        _reshape_orbit = _reshape_orbit_
+
+    def _round(x, n):
+        # canonicalize the folded supercell index to [0, n): the consumers
+        # scatter with tab_r[ir] += v, where a negative index wraps onto
+        # the same slot as its positive counterpart
+        return x % n
+
+    ham_new = {}
+    for (irvec, orbvec), v in ham.items():
+        rx, ry, rz = irvec
+        alpha, beta = orbvec
+
+        for bz, by, bx in itertools.product(range(Bz), range(By), range(Bx)):
+
+            # original cell index of both ends
+            #   x0 -> x1=x0+r
+            x0, y0, z0 = bx, by, bz
+            x1, y1, z1 = x0 + rx, y0 + ry, z0 + rz
+
+            # decompose into supercell-index and cell-index within supercell
+            #   x0 = 0 + x0
+            #   x1 = X + xr
+            xx1, xr1 = x1 // Bx, x1 % Bx
+            yy1, yr1 = y1 // By, y1 % By
+            zz1, zr1 = z1 // Bz, z1 % Bz
+
+            # find orbital index within supercell
+            aa = _reshape_orbit(alpha, (x0, y0, z0))
+            bb = _reshape_orbit(beta, (xr1, yr1, zr1))
+
+            # Wrap-around can map distinct original R-vectors onto the same
+            # folded (ir, ov) key (e.g. when the hopping range reaches the
+            # folded supercell size); accumulate so such contributions are
+            # summed rather than overwritten.
+            ir = (_round(xx1, nx), _round(yy1, ny), _round(zz1, nz))
+            ov = (aa, bb)
+
+            ham_new[(ir, ov)] = ham_new.get((ir, ov), 0.0) + v
+
+    return ham_new

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 #import read_input_k
 import hwave.qlmsio.read_input_k as read_input_k
+import hwave.qlmsio.wan90 as wan90
+from . import fold
 
 
 def validate_chi0q_index_convention(data, enable_spin_orbital, file_name=""):
@@ -274,87 +276,23 @@ class Interaction:
 
     def _reshape_geometry(self, geom):
         logger.debug(">>> Interaction._reshape_geometry")
-
-        Bx,By,Bz = self.lattice.subshape
-        bvol = self.lattice.subvol
-
-        norb = geom['norb']
-
-        geom_new = {}
-        geom_new['norb'] = geom['norb'] * bvol
-        geom_new['rvec'] = np.matmul(np.diag([Bx, By, Bz]), geom['rvec'])
-
-        sc = np.array([1.0/Bx, 1.0/By, 1.0/Bz])
-        cw = [ sc * geom['center'][k] for k in range(norb) ]
-
-        centerv = np.zeros((norb * bvol, 3), dtype=np.float64)
-        k = 0
-        for bz,by,bx in itertools.product(range(Bz),range(By),range(Bx)):
-            for i in range(norb):
-                centerv[k] = cw[i] + np.array([bx, by, bz]) * sc
-                k += 1
-        geom_new['center'] = centerv
-
-        return geom_new
+        return fold.reshape_geometry(geom, self.lattice.subshape)
 
     def _reshape_interaction(self, ham, enable_spin_orbital):
         logger.debug(">>> Interaction._reshape_interaction")
 
-        Bx,By,Bz = self.lattice.subshape
-        nx,ny,nz = self.lattice.shape
-
-        # In SO mode, geom norb is the spin-orbital count; interactions use
-        # physical orbital indices, so the stride for non-SO folding is norb_phys.
+        # In SO mode, geom norb is the spin-orbital count; two-body
+        # interactions use physical orbital indices, so the stride for the
+        # non-SO fold is the physical count (see fold.reshape_interaction,
+        # the single definition shared with UHFk).
         geom_norb_orig = self.param_ham_orig["Geometry"]["norb"]
-        norb_orig = geom_norb_orig  # SO count (used by _reshape_orbit_spin)
-        # physical count (stride for non-SO / physical-orbital-indexed terms)
         norb_phys_orig = _so_physical_norb(geom_norb_orig, self.enable_spin_orbital)
 
-        def _reshape_orbit_(a, x):
-            return a + norb_phys_orig * ( x[0] + Bx * (x[1] + By * (x[2])))
-
-        def _reshape_orbit_spin(a, x):
-            a_, s_ = a%norb_orig, a//norb_orig
-            return a_ + norb_orig * ( x[0] + Bx * (x[1] + By * (x[2] + Bz * s_)))
-
-        if enable_spin_orbital:
-            _reshape_orbit = _reshape_orbit_spin
-        else:
-            _reshape_orbit = _reshape_orbit_
-
-        def _round(x, n):
-            return x % n if x >= 0 else x % -n
-
-        ham_new = {}
-        for (irvec,orbvec), v in ham.items():
-            rx,ry,rz = irvec
-            alpha,beta = orbvec
-
-            for bz,by,bx in itertools.product(range(Bz),range(By),range(Bx)):
-
-                # original cell index of both endes
-                #   x0 -> x1=x0+r
-                x0,y0,z0 = bx, by, bz
-                x1,y1,z1 = x0 + rx, y0 + ry, z0 + rz
-
-                # decompose into supercell-index and cell-index within supercell
-                #   x0 = 0 + x0
-                #   x1 = X + xr
-                xx1,xr1 = x1 // Bx, x1 % Bx
-                yy1,yr1 = y1 // By, y1 % By
-                zz1,zr1 = z1 // Bz, z1 % Bz
-
-                # find orbital index within supercell
-                aa = _reshape_orbit(alpha,(x0,y0,z0))
-                bb = _reshape_orbit(beta, (xr1,yr1,zr1))
-
-                # check wrap-around: maybe overwritten by duplicate entries
-                ir = (_round(xx1, nx), _round(yy1, ny), _round(zz1, nz))
-                ov = (aa, bb)
-
-                ham_new[(ir, ov)] = v
-
-        return ham_new
+        return fold.reshape_interaction(
+            ham, self.lattice.subshape, self.lattice.shape,
+            norb_so_orig=geom_norb_orig,
+            norb_phys_orig=norb_phys_orig,
+            enable_spin_orbital=enable_spin_orbital)
 
     def _export_interaction(self, type, file_name):
         logger.debug(">>> Interaction._export_interaction")
@@ -427,7 +365,10 @@ class Interaction:
                         .format(orbvec, nd))
                 a = _so_interleaved_to_spinblock(orbvec[0])
                 b = _so_interleaved_to_spinblock(orbvec[1])
-                tab_r[(*irvec, a, b)] = v
+                # accumulate: R and R+-L are distinct bonds that wrap onto
+                # the same array slot when the hopping range reaches the
+                # lattice size (numpy negative indexing)
+                tab_r[(*irvec, a, b)] += v
 
             # Fourier transform
             tab_q = FFT.ifftn(tab_r, axes=(0,1,2)) * nvol
@@ -440,7 +381,8 @@ class Interaction:
 
             for (irvec,orbvec), v in self.param_ham["Transfer"].items():
                 if orbvec[0] < norb and orbvec[1] < norb:
-                    tab_r[(*irvec,*orbvec)] = v
+                    # accumulate: wrap-around R vectors share the array slot
+                    tab_r[(*irvec,*orbvec)] += v
                 else:
                     pass  # skip spin dependence
 
@@ -469,7 +411,8 @@ class Interaction:
 
             for (irvec,orbvec), v in self.param_ham["Extern"].items():
                 if orbvec[0] < norb and orbvec[1] < norb:
-                    hab_r[(*irvec,*orbvec)] = v
+                    # accumulate: wrap-around R vectors share the array slot
+                    hab_r[(*irvec,*orbvec)] += v
                 else:
                     pass  # skip spin dependence
 
@@ -511,10 +454,12 @@ class Interaction:
         }
 
         # coulomb-type interactions
-        def _append_inter(type):
+        def _append_inter(type, tbl=None):
             logger.debug("_append_inter {}".format(type))
             spins = spin_table[type]
-            for (irvec,orbvec), v in self.param_ham[type].items():
+            if tbl is None:
+                tbl = self.param_ham[type]
+            for (irvec,orbvec), v in tbl.items():
                 a, b = orbvec
                 for spinvec, w in spins.items():
                     s1,s2,s3,s4 = spinvec
@@ -538,6 +483,26 @@ class Interaction:
                         # beta beta' alpha alpha'
                         orb = (s4, b, s3, a, s1, a, s2, b)
                         ham_r[(*irvec, *orb)] += v * w
+
+        if 'Coulomb' in self.param_ham.keys():
+            # The aggregate 'Coulomb' input provides both the intra and inter
+            # parts (shared decomposition, see wan90.split_coulomb).
+            # Combining it with explicit CoulombIntra/CoulombInter is
+            # ambiguous.
+            if ('CoulombIntra' in self.param_ham.keys()
+                    or 'CoulombInter' in self.param_ham.keys()):
+                logger.error(
+                    "Coulomb cannot be specified together with "
+                    "CoulombIntra or CoulombInter")
+                sys.exit(1)
+
+            coulomb_intra, coulomb_inter = wan90.split_coulomb(
+                self.param_ham['Coulomb'])
+
+            _append_inter('CoulombIntra', coulomb_intra)
+            _append_inter('CoulombInter', coulomb_inter)
+            self._has_interaction = True
+            self._has_interaction_coulomb = True
 
         if 'CoulombIntra' in self.param_ham.keys():
             _append_inter('CoulombIntra')
@@ -1037,18 +1002,43 @@ class RPA:
 
         self._init_wavevec()
 
+        # Frequency metadata (freq_index + nmat, the full grid size of the
+        # producing run) lets consumers locate the zero bosonic frequency
+        # (original index nmat//2).  A chi0q loaded via chi0q_init passes
+        # through solve() untouched AND chiq is computed from it, so both
+        # outputs inherit the input file's frequency axis: re-save them with
+        # the metadata of the file that produced the chi0q -- stamping the
+        # CURRENT run's values would mislabel the axis.
+        def _freq_meta_kwargs(arr):
+            init_meta = getattr(self, "_chi0q_init_meta", None)
+            if init_meta is None:
+                return {"freq_index": self.freq_index, "nmat": self.nmat}
+            kwargs = {}
+            if init_meta["freq_index"] is not None:
+                kwargs["freq_index"] = init_meta["freq_index"]
+            else:
+                # The documented format guarantees a freq_index key.  For a
+                # legacy chi0q_init file without one, describe the stored
+                # axis (0..n-1) without fabricating an nmat claim; a
+                # downstream loader then treats the file explicitly as
+                # ambiguous unless its config Nmat matches.
+                kwargs["freq_index"] = np.arange(arr.shape[0])
+            if init_meta["nmat"] is not None:
+                kwargs["nmat"] = init_meta["nmat"]
+            return kwargs
+
         if "chiq" in info_outputfile.keys():
             if self.calc_chiq == True:
                 file_name = os.path.join(path_to_output, info_outputfile["chiq"])
                 save_kwargs = dict(
                     chiq = green_info["chiq"],
-                    freq_index = self.freq_index,
                     wavevector_unit = self.kvec,
                     wavevector_index = self.wavenum_table,
                     # RPA orders spin-orbital axes as spin-block (spin*norb+orb),
                     # unlike UHFk's interleaved (2*orb+spin) output; record it so
                     # consumers do not silently mix the two conventions.
                     index_convention = "spin_block",
+                    **_freq_meta_kwargs(green_info["chiq"]),
                 )
                 # transverse channel chi_+-(q), present for calc_type ring+ladder
                 if green_info.get("chiq_pm") is not None:
@@ -1060,14 +1050,15 @@ class RPA:
 
         if "chi0q" in info_outputfile.keys():
             file_name = os.path.join(path_to_output, info_outputfile["chi0q"])
-            np.savez(file_name,
-                     chi0q = green_info["chi0q"],
-                     freq_index = self.freq_index,
-                     wavevector_unit = self.kvec,
-                     wavevector_index = self.wavenum_table,
-                     # spin-orbital axes are spin-block ordered (spin*norb+orb)
-                     index_convention = "spin_block",
-                     )
+            save_kwargs = dict(
+                chi0q = green_info["chi0q"],
+                wavevector_unit = self.kvec,
+                wavevector_index = self.wavenum_table,
+                # spin-orbital axes are spin-block ordered (spin*norb+orb)
+                index_convention = "spin_block",
+                **_freq_meta_kwargs(green_info["chi0q"]),
+            )
+            np.savez(file_name, **save_kwargs)
             logger.info("save_results: save chi0q in file {}".format(file_name))
 
         pass
@@ -1202,6 +1193,14 @@ class RPA:
 
         validate_chi0q_index_convention(
             data, self.ham_info.enable_spin_orbital, file_name)
+
+        # Keep the frequency metadata of the file that PRODUCED this chi0q:
+        # solve() passes an input chi0q through untouched, so save_results
+        # must not relabel its axis with the current run's freq_index/nmat.
+        self._chi0q_init_meta = {
+            "freq_index": data["freq_index"] if "freq_index" in data else None,
+            "nmat": int(data["nmat"]) if "nmat" in data else None,
+        }
 
         # check size
         if self.calc_scheme == "general":
@@ -1538,9 +1537,6 @@ class RPA:
 
         # Gather using advanced indexing
         # green[jsite, s, a, t, b] -> green_sub[isite, s, aa, t, bb]
-        green_sub = green[jsite_map][:, :, :, :, a_src, :, :][:, :, :, :, :, :, b_src]
-        # Shape: (Nvol, norb, norb, ns, norb, ns, norb) - need to select diagonal
-        # Use explicit indexing for clarity
         green_sub = green[
             jsite_map[:, :, :, np.newaxis, np.newaxis],   # (Nvol, norb, norb, 1, 1)
             np.arange(ns)[np.newaxis, np.newaxis, np.newaxis, :, np.newaxis],  # s

--- a/src/hwave/solver/uhfk.py
+++ b/src/hwave/solver/uhfk.py
@@ -4,6 +4,8 @@ import numpy as np
 import os
 from .base import solver_base
 from .perf import do_profile
+from . import fold
+from ..qlmsio import wan90
 
 logger = logging.getLogger("qlms").getChild("uhfk")
 
@@ -178,6 +180,17 @@ class UHFk(solver_base):
             self.sz_free = True
             self.Nconds = [ ncond ]
         else:
+            if self.enable_spin_orbital:
+                # Sz is not a good quantum number when spin is folded into
+                # the orbital index; block detection would silently assign
+                # the total Ncond to the spin-mixed blocks and ignore the
+                # constraint. Fail fast instead.
+                logger.error(
+                    "2Sz-fixed mode is not supported with "
+                    "enable_spin_orbital; omit 2Sz (Sz-free mode).")
+                raise ValueError(
+                    "2Sz-fixed mode is not supported with "
+                    "enable_spin_orbital; use Sz-free mode.")
             self.sz_free = False
             twosz = self.param_mod["2Sz"]
             self.Nconds = [ (ncond + twosz)//2, (ncond - twosz)//2 ]
@@ -312,108 +325,40 @@ class UHFk(solver_base):
     @do_profile
     def _reshape_geometry(self, geom):
         """Reshape geometry for sublattice structure.
-        
+
         Parameters
         ----------
         geom : dict
             Original geometry definition
-        
+
         Returns
         -------
         dict
-            Reshaped geometry for sublattice
+            Reshaped geometry (see fold.reshape_geometry)
         """
-        Bx,By,Bz = self.subshape
-        bvol = Bx * By * Bz
-
-        norb = geom['norb']
-
-        geom_new = {}
-        geom_new['norb'] = geom['norb'] * bvol
-        geom_new['rvec'] = np.matmul(np.diag([Bx, By, Bz]), geom['rvec'])
-
-        sc = np.array([1.0/Bx, 1.0/By, 1.0/Bz])
-        cw = [ sc * geom['center'][k] for k in range(norb) ]
-
-        centerv = np.zeros((norb * bvol, 3), dtype=np.double)
-        k = 0
-        for bz,by,bx in itertools.product(range(Bz),range(By),range(Bx)):
-            for i in range(norb):
-                centerv[k] = cw[i] + np.array([bx, by, bz]) * sc
-                k += 1
-        geom_new['center'] = centerv
-
-        return geom_new
+        return fold.reshape_geometry(geom, self.subshape)
 
     @do_profile
     def _reshape_interaction(self, ham, enable_spin_orbital):
         """Reshape interaction terms for sublattice.
-        
+
         Parameters
         ----------
         ham : dict
             Original interaction terms
         enable_spin_orbital : bool
-            Whether spin-orbital coupling is enabled
-        
+            Whether THIS table uses spin-orbital indices (Transfer in SO mode)
+
         Returns
         -------
         dict
-            Reshaped interaction terms
+            Reshaped interaction terms (see fold.reshape_interaction)
         """
-        Bx,By,Bz = self.subshape
-        nx,ny,nz = self.shape
-
-        norb_orig = self.param_ham_orig["Geometry"]["norb"]
-
-        def _reshape_orbit_(a, x):
-            return a + self.norb_orig * ( x[0] + Bx * (x[1] + By * (x[2])))
-
-        def _reshape_orbit_spin(a, x):
-            a_, s_ = a%norb_orig, a//norb_orig
-            return a_ + norb_orig * ( x[0] + Bx * (x[1] + By * (x[2] + Bz * s_)))
-
-        if enable_spin_orbital:
-            _reshape_orbit = _reshape_orbit_spin
-        else:
-            _reshape_orbit = _reshape_orbit_
-
-        def _round(x, n):
-            return x % n
-
-        ham_new = {}
-        for (irvec,orbvec), v in ham.items():
-            rx,ry,rz = irvec
-            alpha,beta = orbvec
-
-            for bz,by,bx in itertools.product(range(Bz),range(By),range(Bx)):
-
-                # original cell index of both endes
-                #   x0 -> x1=x0+r
-                x0,y0,z0 = bx, by, bz
-                x1,y1,z1 = x0 + rx, y0 + ry, z0 + rz
-
-                # decompose into supercell-index and cell-index within supercell
-                #   x0 = 0 + x0
-                #   x1 = X + xr
-                xx1,xr1 = x1 // Bx, x1 % Bx
-                yy1,yr1 = y1 // By, y1 % By
-                zz1,zr1 = z1 // Bz, z1 % Bz
-
-                # find orbital index within supercell
-                aa = _reshape_orbit(alpha,(x0,y0,z0))
-                bb = _reshape_orbit(beta, (xr1,yr1,zr1))
-
-                # Wrap-around can map distinct original R-vectors onto the same
-                # folded (ir, ov) key (e.g. when the hopping range reaches the
-                # cell size, allowed under relax_checks); accumulate so such
-                # contributions are summed rather than overwritten.
-                ir = (_round(xx1, nx), _round(yy1, ny), _round(zz1, nz))
-                ov = (aa, bb)
-
-                ham_new[(ir, ov)] = ham_new.get((ir, ov), 0.0) + v
-
-        return ham_new
+        return fold.reshape_interaction(
+            ham, self.subshape, self.shape,
+            norb_so_orig=self.param_ham_orig["Geometry"]["norb"],
+            norb_phys_orig=self.norb_phys_orig,
+            enable_spin_orbital=enable_spin_orbital)
 
     @do_profile
     def _reshape_green(self, green):
@@ -805,7 +750,7 @@ class UHFk(solver_base):
 
             tab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
             for (irvec,orbvec), v in self.param_ham["Transfer"].items():
-                tab_r[(*irvec, *orbvec)] = v
+                tab_r[(*irvec, *orbvec)] += v
 
             t = np.conjugate(
                     np.transpose(
@@ -1045,7 +990,7 @@ class UHFk(solver_base):
             tab_r = np.zeros((nx,ny,nz,nd,nd), dtype=np.complex128)
 
             for (irvec,orbvec), v in self.param_ham["Transfer"].items():
-                tab_r[(*irvec, *orbvec)] = v
+                tab_r[(*irvec, *orbvec)] += v
 
             # fourier transform
             tab_k = np.fft.ifftn(tab_r, axes=(0,1,2), norm='forward')
@@ -1060,7 +1005,7 @@ class UHFk(solver_base):
             has_spin_dep = False
             for (irvec,orbvec), v in self.param_ham["Transfer"].items():
                 if orbvec[0] < norb and orbvec[1] < norb:
-                    tab_r[(*irvec, *orbvec)] = v
+                    tab_r[(*irvec, *orbvec)] += v
                 else:
                     has_spin_dep = True
             if has_spin_dep:
@@ -1116,6 +1061,9 @@ class UHFk(solver_base):
 
             # assume zvo_ur.dat
             # divide into r=0 (coulomb intra) and r!=0 (coulomb inter)
+            # via the decomposition shared with RPA/FLEX
+            coulomb_intra, coulomb_inter = wan90.split_coulomb(
+                self.param_ham["Coulomb"])
 
             # coulomb intra: diagonal part of r=0 cell
             uab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
@@ -1123,12 +1071,10 @@ class UHFk(solver_base):
             # coulomb inter: off-diagonal part
             vab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 
-            for (irvec,orbvec), v in self.param_ham["Coulomb"].items():
-                alpha, beta = orbvec
-                if irvec == (0,0,0) and alpha == beta:
-                    uab_r[(*irvec,alpha,beta)] = v
-                else:
-                    vab_r[(*irvec,alpha,beta)] = v
+            for (irvec,orbvec), v in coulomb_intra.items():
+                uab_r[(*irvec,*orbvec)] += v
+            for (irvec,orbvec), v in coulomb_inter.items():
+                vab_r[(*irvec,*orbvec)] += v
 
             # coulomb intra
             # interaction coeffs
@@ -1171,7 +1117,7 @@ class UHFk(solver_base):
                 for (irvec,orbvec), v in self.param_ham["CoulombIntra"].items():
                     alpha, beta = orbvec
                     if irvec == (0,0,0) and alpha == beta:
-                        uab_r[(*irvec, *orbvec)] = v
+                        uab_r[(*irvec, *orbvec)] += v
 
                 # interaction coeffs
                 self.inter_table["CoulombIntra"] = uab_r
@@ -1185,7 +1131,7 @@ class UHFk(solver_base):
 
                 for (irvec,orbvec), v in self.param_ham["CoulombInter"].items():
 #                    if irvec != (0,0,0):
-                        vab_r[(*irvec, *orbvec)] = v
+                        vab_r[(*irvec, *orbvec)] += v
 
                 vba = np.conjugate(
                     np.transpose(
@@ -1210,7 +1156,7 @@ class UHFk(solver_base):
             jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 
             for (irvec,orbvec), v in self.param_ham["Hund"].items():
-                jab_r[(*irvec, *orbvec)] = v
+                jab_r[(*irvec, *orbvec)] += v
 
             # J~ab(r) = Jab(r) + Jba(-r)
             jba = np.conjugate(
@@ -1236,7 +1182,7 @@ class UHFk(solver_base):
             jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 
             for (irvec,orbvec), v in self.param_ham["Ising"].items():
-                jab_r[(*irvec, *orbvec)] = v
+                jab_r[(*irvec, *orbvec)] += v
 
             # J~ab(r) = Jab(r) + Jba(-r)
             jba = np.conjugate(
@@ -1264,7 +1210,7 @@ class UHFk(solver_base):
             jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 
             for (irvec,orbvec), v in self.param_ham["PairLift"].items():
-                jab_r[(*irvec, *orbvec)] = v
+                jab_r[(*irvec, *orbvec)] += v
 
             # J~ab(r) = Jab(r) + Jba(-r)
             jba = np.conjugate(
@@ -1290,7 +1236,7 @@ class UHFk(solver_base):
             jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 
             for (irvec,orbvec), v in self.param_ham["Exchange"].items():
-                jab_r[(*irvec, *orbvec)] = v
+                jab_r[(*irvec, *orbvec)] += v
 
             # J~ab(r) = Jab(r) + Jba(-r)
             jba = np.conjugate(
@@ -1316,7 +1262,7 @@ class UHFk(solver_base):
             jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 
             for (irvec,orbvec), v in self.param_ham["PairHop"].items():
-                jab_r[(*irvec, *orbvec)] = v
+                jab_r[(*irvec, *orbvec)] += v
 
             # J~ab(r) = Jab(r) + Jba(-r)
             jba = np.conjugate(
@@ -1361,7 +1307,9 @@ class UHFk(solver_base):
         connectivity = np.zeros((nd, nd), dtype=np.float64)
 
         # 1. Transfer Hamiltonian: sum |ham_trans(k)| over k
-        connectivity += np.sum(np.abs(self.ham_trans), axis=0)
+        # (kept as a local: the 2Sz-fixed spin-flip check below reuses it)
+        trans_conn = np.sum(np.abs(self.ham_trans), axis=0)
+        connectivity += trans_conn
 
         # 2. Interaction terms: expand (norb_inter, norb_inter) x spin(2,2,2,2) -> (nd, nd)
         norb_inter = self.norb_phys if self.enable_spin_orbital else norb
@@ -1414,6 +1362,26 @@ class UHFk(solver_base):
                                 if spin_fock[s, t] > 0:
                                     connectivity[s * norb:(s + 1) * norb,
                                                  t * norb:(t + 1) * norb] += jab_sum
+
+        # 2Sz-fixed mode: each spin sector carries its own electron count
+        # (Ncond +- 2Sz)/2, so the up and down sectors are diagonalized
+        # independently and spin off-diagonal (Fock) entries are not used,
+        # exactly as in the pre-block full-matrix implementation
+        # (einsum 'ksasb->skab' kept only the spin-diagonal blocks).
+        # Interaction terms only produce spin off-diagonal Fock entries via
+        # the spin off-diagonal Green components, which vanish identically in
+        # the spin-diagonal state enforced by the constraint -- so their
+        # potential cross-spin connectivity is masked out here.  Without the
+        # mask, such interaction patterns would merge the two sectors into
+        # one mu-group and the 2Sz constraint would be silently lost.
+        # One-body spin-flip terms, in contrast, genuinely break Sz
+        # conservation, so a fixed 2Sz is ill-defined: reject them.
+        if not self.sz_free and not self.enable_spin_orbital and ns == 2:
+            self._check_spin_flip_with_fixed_sz(trans_conn, norb)
+            spin_diag = np.zeros((nd, nd), dtype=bool)
+            spin_diag[:norb, :norb] = True
+            spin_diag[norb:, norb:] = True
+            connectivity[~spin_diag] = 0.0
 
         # Symmetrize
         connectivity = connectivity + connectivity.T

--- a/src/hwave/solver/uhfr.py
+++ b/src/hwave/solver/uhfr.py
@@ -16,43 +16,6 @@ from .perf import do_profile
 logger = logging.getLogger("qlms").getChild("uhfr")
 
 
-def _split_occupation(occupied, sizes):
-    """Distribute ``occupied`` electrons across sub-blocks of the given sizes.
-
-    Returns non-negative integer occupations that sum exactly to ``occupied``
-    and never exceed the block size, using the largest-remainder method.
-    (The previous proportional rounding ``round(occupied*size/total)`` could
-    over-allocate and leave a negative remainder for the last block.)
-
-    Parameters
-    ----------
-    occupied : int
-        Total electron count to distribute (0 <= occupied <= sum(sizes)).
-    sizes : list of int
-        Sizes of the sub-blocks.
-
-    Returns
-    -------
-    list of int
-        Per-block occupations.
-    """
-    total = sum(sizes)
-    if not (0 <= occupied <= total):
-        raise ValueError(
-            "occupied={} must be in [0, sum(sizes)={}]".format(occupied, total))
-    if total == 0:
-        return [0 for _ in sizes]
-    exact = [occupied * sz / total for sz in sizes]
-    alloc = [int(np.floor(e)) for e in exact]
-    remainder = int(round(occupied - sum(alloc)))
-    # hand out the remaining electrons to the largest fractional parts
-    order = sorted(range(len(sizes)),
-                   key=lambda i: exact[i] - alloc[i], reverse=True)
-    for i in order[:remainder]:
-        alloc[i] += 1
-    return alloc
-
-
 class Interact_UHFr_base:
     """Base class for interaction terms in UHF calculations.
     
@@ -753,17 +716,22 @@ class UHFr(solver_base):
         unique_labels = np.unique(labels)
         if len(unique_labels) <= 1:
             logger.info("Block detection (UHFr): single block (nd={})".format(nd))
+            self._block_mask = self._build_block_mask()
             return
 
         # Build block list
         all_blocks = [np.where(labels == lbl)[0] for lbl in unique_labels]
         all_blocks.sort(key=lambda b: b[0])
 
-        # Refine green_list: split existing blocks into sub-blocks
-        new_green_list = {}
+        # Attach sub-block structure to each green_list block.  The block
+        # keys, labels and per-block electron counts are kept unchanged:
+        # every green_list block remains one electron reservoir with a single
+        # Fermi level, and _diag() merely exploits the sub-block structure to
+        # diagonalize smaller matrices.  (Splitting the electron count across
+        # sub-blocks -- e.g. proportionally to size -- is wrong: it can pin
+        # electrons in high-energy sub-blocks.)
         for k, block_g_info in self.green_list.items():
             g_label = set(block_g_info["label"])
-            occupied = block_g_info["occupied"]
 
             # Find sub-blocks within this green_list block
             sub_blocks = []
@@ -772,31 +740,16 @@ class UHFr(solver_base):
                 if overlap:
                     sub_blocks.append(overlap)
 
-            if len(sub_blocks) <= 1:
-                # No further splitting
-                new_green_list[k] = block_g_info
-            else:
-                # Split this block, keeping per-block occupations non-negative
-                # and summing to the original occupancy.
-                sub_occs = _split_occupation(occupied, [len(s) for s in sub_blocks])
-                for i, sub in enumerate(sub_blocks):
-                    sub_key = "{}_blk{}".format(k, i)
-                    sub_info = {"label": sub, "occupied": sub_occs[i]}
-                    if "value" in block_g_info:
-                        sub_info["value"] = block_g_info["value"]
-                    new_green_list[sub_key] = sub_info
-
+            if len(sub_blocks) > 1:
+                block_g_info["sub_blocks"] = sub_blocks
                 block_desc = ", ".join(
                     ["{}".format(len(s)) for s in sub_blocks])
-                logger.info("Block detection (UHFr): block '{}' split into "
-                            "{} sub-blocks of sizes [{}]".format(
-                                k, len(sub_blocks), block_desc))
+                logger.info("Block detection (UHFr): block '{}' has "
+                            "{} sub-blocks of sizes [{}] (shared Fermi "
+                            "level)".format(k, len(sub_blocks), block_desc))
 
-        self.green_list = new_green_list
-
-        block_desc = ", ".join(
-            ["{}:{}".format(k, len(v["label"])) for k, v in self.green_list.items()])
-        logger.info("Block detection (UHFr): final blocks: {}".format(block_desc))
+        # cache the block mask for the SCF loop (structure is now fixed)
+        self._block_mask = self._build_block_mask()
 
     @do_profile
     def _makeham_const(self):
@@ -806,6 +759,31 @@ class UHFr(solver_base):
         trans = Transfer_UHFr(self.param_ham["Transfer"], self.Nsize)
         trans.check_hermite(self.strict_hermite, self.hermite_tolerance)
         self.Ham_trans = trans.get_data()
+
+        # One-body spin-flip terms genuinely break Sz conservation, so a
+        # fixed 2Sz is ill-defined: reject them (same as UHFk) instead of
+        # silently zeroing them through the spin-block structure.
+        if self.param_mod["2Sz"] is not None:
+            self._check_spin_flip_with_fixed_sz(np.abs(self.Ham_trans),
+                                                self.Nsize)
+
+    def _build_block_mask(self):
+        """Boolean mask of the in-block Hamiltonian entries (None if trivial).
+
+        Fixed once the green_list block/sub-block structure is set, so it is
+        built once and reused by every SCF iteration.
+        """
+        nd = 2 * self.Nsize
+        has_sub_blocks = any("sub_blocks" in info
+                             for info in self.green_list.values())
+        if len(self.green_list) <= 1 and not has_sub_blocks:
+            return None
+        mask = np.zeros((nd, nd), dtype=bool)
+        for info in self.green_list.values():
+            for sub in info.get("sub_blocks", [info["label"]]):
+                idx = np.array(sub)
+                mask[np.ix_(idx, idx)] = True
+        return mask
 
     @do_profile
     def _makeham(self):
@@ -817,11 +795,13 @@ class UHFr(solver_base):
         self.Ham += ham_dot_green.reshape(nd, nd)
 
         # Enforce block structure: zero out cross-block entries
-        if len(self.green_list) > 1:
-            mask = np.zeros((nd, nd), dtype=bool)
-            for info in self.green_list.values():
-                idx = np.array(info["label"])
-                mask[np.ix_(idx, idx)] = True
+        # (mask cached across SCF iterations; the structure is fixed after
+        # _detect_blocks)
+        try:
+            mask = self._block_mask
+        except AttributeError:
+            mask = self._block_mask = self._build_block_mask()
+        if mask is not None:
             self.Ham[~mask] = 0.0
 
     @do_profile
@@ -865,12 +845,38 @@ class UHFr(solver_base):
 
     @do_profile
     def _diag(self):
-        """Diagonalize Hamiltonian."""
+        """Diagonalize Hamiltonian.
+
+        When a green_list block consists of several disconnected sub-blocks,
+        each sub-block is diagonalized independently and the eigenpairs are
+        reassembled (sorted ascending) in the block-local basis, so that the
+        downstream occupation logic (lowest ``occupied`` states, one Fermi
+        level per block) is unaffected by the decomposition.
+        """
         _green_list = self.green_list
         for k, block_g_info in _green_list.items():
             g_label = np.array(block_g_info["label"])
-            mat = self.Ham[np.ix_(g_label, g_label)]
-            w, v = np.linalg.eigh(mat)
+            sub_blocks = block_g_info.get("sub_blocks")
+            if sub_blocks is None:
+                mat = self.Ham[np.ix_(g_label, g_label)]
+                w, v = np.linalg.eigh(mat)
+            else:
+                n = len(g_label)
+                pos = {lab: i for i, lab in enumerate(g_label)}
+                w = np.empty(n, dtype=float)
+                v = np.zeros((n, n), dtype=complex)
+                col = 0
+                for sub in sub_blocks:
+                    idx = np.array(sub)
+                    w_sub, v_sub = np.linalg.eigh(self.Ham[np.ix_(idx, idx)])
+                    rows = np.array([pos[lab] for lab in sub])
+                    m = len(sub)
+                    w[col:col + m] = w_sub
+                    v[np.ix_(rows, np.arange(col, col + m))] = v_sub
+                    col += m
+                order = np.argsort(w, kind="stable")
+                w = w[order]
+                v = v[:, order]
             self.green_list[k]["eigenvalue"] = w
             self.green_list[k]["eigenvector"] = v
 

--- a/tests/test_block_matrix.py
+++ b/tests/test_block_matrix.py
@@ -9,42 +9,6 @@ import unittest
 import numpy as np
 
 
-class TestUHFrOccupationSplit(unittest.TestCase):
-    """Splitting a block's electron count across detected sub-blocks must give
-    non-negative integer occupations that sum to the original (the previous
-    proportional-rounding split could produce negative occupations)."""
-
-    def test_no_negative_occupation(self):
-        from hwave.solver.uhfr import _split_occupation
-        # 6 electrons over 8 size-1 sub-blocks: the buggy round() split gave -1
-        occ = _split_occupation(6, [1] * 8)
-        self.assertEqual(sum(occ), 6)
-        self.assertTrue(all(o >= 0 for o in occ), "occupations must be >= 0")
-        self.assertTrue(all(o <= 1 for o in occ), "occupation cannot exceed block size")
-
-    def test_sum_preserved_various(self):
-        from hwave.solver.uhfr import _split_occupation
-        for occupied, sizes in [(3, [2, 2]), (5, [3, 1, 4]), (0, [2, 3]),
-                                (7, [7]), (4, [1, 1, 1, 1])]:
-            occ = _split_occupation(occupied, sizes)
-            self.assertEqual(sum(occ), occupied)
-            self.assertTrue(all(0 <= o <= s for o, s in zip(occ, sizes)))
-
-    def test_proportional_allocation(self):
-        from hwave.solver.uhfr import _split_occupation
-        # equal sizes, divisible -> equal split
-        self.assertEqual(_split_occupation(4, [2, 2]), [2, 2])
-
-    def test_invalid_occupied_raises(self):
-        from hwave.solver.uhfr import _split_occupation
-        with self.assertRaises(ValueError):
-            _split_occupation(5, [2, 2])     # occupied > total
-        with self.assertRaises(ValueError):
-            _split_occupation(-1, [2, 2])    # negative occupied
-        with self.assertRaises(ValueError):
-            _split_occupation(1, [])         # empty sizes, nonzero occupied
-
-
 class TestRPABlockSolveDenseChi0q(unittest.TestCase):
     """Block-solving the RPA equation is only valid when neither chi0q nor ham
     couples indices across blocks. If ham is block-diagonal but chi0q has
@@ -1434,9 +1398,11 @@ class TestUHFkDetectBlocks(unittest.TestCase):
         self.assertTrue(hasattr(stub, "group_nconds"))
         self.assertEqual(sum(stub.group_nconds), 2)
 
-    def test_2sz_fixed_single_mixed_block_ok(self):
-        """A single mixed block spanning the whole system is allowed: it takes
-        the total ncond and does not over-count."""
+    def test_2sz_fixed_single_mixed_block_rejected(self):
+        """Spin-flip one-body terms break Sz conservation, so 2Sz-fixed mode
+        must reject them even when they merge the whole system into a single
+        mixed block (accepting it with the total ncond would silently ignore
+        the requested 2Sz)."""
         norb, ns, nvol = 2, 2, 1
         nd = norb * ns
         ham_trans = np.zeros((nvol, nd, nd), dtype=np.complex128)
@@ -1448,12 +1414,13 @@ class TestUHFkDetectBlocks(unittest.TestCase):
         ham_trans[:, norb, norb + 1] = 0.5; ham_trans[:, norb + 1, norb] = 0.5  # dn0-dn1
         stub = self._make_uhfk_stub(norb, ns, nvol, ham_trans,
                                     sz_free=False, Nconds=[2, 1])
-        stub._detect_blocks()  # must not raise
-        self.assertEqual(len(stub.block_info), 1)
-        self.assertEqual(sum(stub.group_nconds), 3)  # ncond_up + ncond_down
+        with self.assertRaises(ValueError):
+            stub._detect_blocks()
 
-    def test_2sz_fixed_multiple_mixed_blocks_ok(self):
-        """Several mixed blocks (no pure block) are allowed (no over-count)."""
+    def test_2sz_fixed_multiple_mixed_blocks_rejected(self):
+        """Several spin-mixed blocks are rejected in 2Sz-fixed mode for the
+        same reason: the one-body spin-flip terms make a fixed 2Sz
+        ill-defined."""
         norb, ns, nvol = 2, 2, 1
         nd = norb * ns
         ham_trans = np.zeros((nvol, nd, nd), dtype=np.complex128)
@@ -1464,11 +1431,67 @@ class TestUHFkDetectBlocks(unittest.TestCase):
         ham_trans[:, 1, norb + 1] = 0.5; ham_trans[:, norb + 1, 1] = 0.5
         stub = self._make_uhfk_stub(norb, ns, nvol, ham_trans,
                                     sz_free=False, Nconds=[1, 1])
+        with self.assertRaises(ValueError):
+            stub._detect_blocks()
+
+    def test_2sz_fixed_tolerates_noise_level_spin_flip(self):
+        """Wannier-derived transfers carry ~1e-14 cross-spin residues from
+        numerical noise; summing |ham_trans| over many k-points amplifies
+        them above any absolute threshold.  The 2Sz-fixed spin-flip guard
+        must compare against the transfer SCALE, not an absolute epsilon,
+        so noise-level entries are masked (not fatal)."""
+        norb, ns, nvol = 2, 2, 4096
+        nd = norb * ns
+        rng = np.random.RandomState(7)
+        ham_trans = np.zeros((nvol, nd, nd), dtype=np.complex128)
+        for i in range(nd):
+            ham_trans[:, i, i] = 1.0
+        # noise-level cross-spin residues on every k-point
+        noise = 1.0e-14 * rng.rand(nvol)
+        ham_trans[:, 0, norb] = noise
+        ham_trans[:, norb, 0] = noise
+        stub = self._make_uhfk_stub(norb, ns, nvol, ham_trans,
+                                    sz_free=False, Nconds=[2, 2])
+        stub._detect_blocks()  # must NOT raise
+        for blk in stub.block_info:
+            all_up = all(idx < norb for idx in blk)
+            all_dn = all(idx >= norb for idx in blk)
+            self.assertTrue(all_up or all_dn,
+                            "noise must be masked, sectors kept pure")
+
+    def test_2sz_fixed_spin_connecting_interaction_keeps_sectors(self):
+        """Interaction patterns that could couple the spin sectors through
+        the Fock term (e.g. CoulombIntra) must NOT merge the sectors in
+        2Sz-fixed mode: the constrained state is spin-diagonal, so those
+        Fock entries vanish identically and each sector keeps its own
+        electron count."""
+        norb, ns, nvol = 2, 2, 1
+        nd = norb * ns
+        ham_trans = np.zeros((nvol, nd, nd), dtype=np.complex128)
+        for i in range(nd):
+            ham_trans[:, i, i] = 1.0
+
+        # CoulombIntra: Hartree/Fock spin pattern couples up<->down
+        uab = np.zeros((nvol, norb, norb), dtype=np.complex128)
+        uab[:, 0, 0] = 2.0
+        uab[:, 1, 1] = 2.0
+        ci_spin = np.zeros((2, 2, 2, 2), dtype=int)
+        ci_spin[0, 1, 1, 0] = 1
+        ci_spin[1, 0, 0, 1] = 1
+
+        stub = self._make_uhfk_stub(norb, ns, nvol, ham_trans,
+                                    inter_table={"CoulombIntra": uab},
+                                    spin_table={"CoulombIntra": ci_spin},
+                                    iflag_fock=True,
+                                    sz_free=False, Nconds=[2, 1])
         stub._detect_blocks()  # must not raise
-        self.assertEqual(len(stub.block_info), 2)
-        # both blocks are mixed -> a single mu-group holding the total ncond
-        self.assertEqual(list(stub.block_to_group), [0, 0])
-        self.assertEqual(sum(stub.group_nconds), 2)
+        # every block is pure spin, and the two mu-groups carry [2, 1]
+        for blk in stub.block_info:
+            all_up = all(idx < norb for idx in blk)
+            all_dn = all(idx >= norb for idx in blk)
+            self.assertTrue(all_up or all_dn,
+                            "2Sz-fixed must keep spin sectors separate")
+        self.assertEqual(sorted(stub.group_nconds), [1, 2])
 
     # ----------------------------------------------------------------
     # Pattern 16: Partial orbital mixing via interaction only
@@ -1816,10 +1839,11 @@ class TestUHFrDetectBlocks(unittest.TestCase):
         self.assertEqual(len(stub.green_list), 2)
 
     def test_diagonal_transfer_orbital_split(self):
-        """Diagonal transfer splits into individual site blocks.
+        """Diagonal transfer splits into individual site sub-blocks.
 
         Nsize=3, nd=6, sz-free mode. Diagonal transfer only.
-        No interactions -> 6 independent blocks.
+        No interactions -> 6 independent sub-blocks within the single
+        'sz-free' reservoir (keys and electron counts stay unchanged).
         """
         Nsize = 3
         nd = 2 * Nsize
@@ -1831,8 +1855,13 @@ class TestUHFrDetectBlocks(unittest.TestCase):
                                     TwoSz=None, Ncond=3)
         stub._detect_blocks()
 
-        self.assertEqual(len(stub.green_list), nd,
-                         "Diagonal transfer -> {} blocks".format(nd))
+        self.assertEqual(list(stub.green_list.keys()), ["sz-free"],
+                         "block keys must stay unchanged")
+        info = stub.green_list["sz-free"]
+        self.assertEqual(info["occupied"], 3,
+                         "the reservoir electron count must stay unchanged")
+        self.assertEqual(len(info["sub_blocks"]), nd,
+                         "Diagonal transfer -> {} sub-blocks".format(nd))
 
     def test_interaction_connects_spins(self):
         """Interaction term connects spin-up and spin-down sites.
@@ -1858,10 +1887,13 @@ class TestUHFrDetectBlocks(unittest.TestCase):
                                     TwoSz=None, Ncond=2)
         stub._detect_blocks()
 
-        self.assertEqual(len(stub.green_list), 2,
-                         "Interaction connects spin pairs -> 2 blocks")
-        for k, info in stub.green_list.items():
-            self.assertEqual(len(info["label"]), 2)
+        self.assertEqual(list(stub.green_list.keys()), ["sz-free"],
+                         "block keys must stay unchanged")
+        info = stub.green_list["sz-free"]
+        self.assertEqual(len(info["sub_blocks"]), 2,
+                         "Interaction connects spin pairs -> 2 sub-blocks")
+        for sub in info["sub_blocks"]:
+            self.assertEqual(len(sub), 2)
 
     def test_partial_transfer_coupling(self):
         """Transfer couples sites 0-1 within spin-up, 2-3 within spin-down.
@@ -1893,9 +1925,12 @@ class TestUHFrDetectBlocks(unittest.TestCase):
                                     TwoSz=1, Ncond=3)
         stub._detect_blocks()
 
-        self.assertEqual(len(stub.green_list), 4,
-                         "Partial coupling -> 4 sub-blocks")
-        sizes = sorted([len(v["label"]) for v in stub.green_list.values()])
+        self.assertEqual(sorted(stub.green_list.keys()),
+                         ["spin-down", "spin-up"],
+                         "block keys must stay unchanged")
+        sizes = sorted(len(sub)
+                       for v in stub.green_list.values()
+                       for sub in v["sub_blocks"])
         self.assertEqual(sizes, [1, 1, 2, 2])
 
     def test_full_coupling_single_block(self):
@@ -1920,10 +1955,10 @@ class TestUHFrDetectBlocks(unittest.TestCase):
                          "Fully coupled -> single block")
 
     def test_ncond_preserved_after_split(self):
-        """Total occupied count is preserved after block splitting.
+        """Total occupied count is preserved after sub-block detection.
 
         Nsize=4, nd=8. sz-free mode with Ncond=6.
-        Diagonal transfer -> 8 blocks with Ncond summing to 6.
+        Diagonal transfer -> 8 sub-blocks; the reservoir keeps Ncond=6.
         """
         Nsize = 4
         nd = 2 * Nsize

--- a/tests/test_chi0q_index_convention.py
+++ b/tests/test_chi0q_index_convention.py
@@ -82,13 +82,13 @@ class TestLoadChi0qSC(unittest.TestCase):
     def test_so_spin_block_accepted(self):
         tmp = tempfile.mkdtemp()
         _write_npz(os.path.join(tmp, "chi0q.npz"), with_convention=True)
-        chi0q = _load_chi0q(self._input_dict(tmp, enable_spin_orbital=True))
+        chi0q, _ = _load_chi0q(self._input_dict(tmp, enable_spin_orbital=True))
         self.assertEqual(chi0q.shape, (1, 1, 2, 2))
 
     def test_non_so_missing_convention_accepted(self):
         tmp = tempfile.mkdtemp()
         _write_npz(os.path.join(tmp, "chi0q.npz"), with_convention=False)
-        chi0q = _load_chi0q(self._input_dict(tmp, enable_spin_orbital=False))
+        chi0q, _ = _load_chi0q(self._input_dict(tmp, enable_spin_orbital=False))
         self.assertEqual(chi0q.shape, (1, 1, 2, 2))
 
 

--- a/tests/test_flex_chi0q_convention_tag.py
+++ b/tests/test_flex_chi0q_convention_tag.py
@@ -1,0 +1,64 @@
+"""Regression test: FLEX chi0q.npz must carry the index_convention tag.
+
+FLEX chi0q is produced by the same spin-block RPA internals as RPA chi0q,
+and the chi0q consumers (RPA.read_chi0q, hwave_sc._load_chi0q) reject
+untagged files in spin-orbital mode as "predating the convention fix".
+FLEX.save_results must therefore write index_convention='spin_block' just
+like RPA.save_results does.
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from hwave.solver.flex import FLEX
+from hwave.solver.rpa import validate_chi0q_index_convention
+
+
+def _make_flex_stub(nmat, freq_index):
+    flex = FLEX.__new__(FLEX)
+    flex._init_wavevec = lambda: None
+    flex.nmat = nmat
+    flex.freq_index = freq_index
+    flex.kvec = np.eye(3)
+    flex.wavenum_table = np.zeros((2, 3))
+    flex._flex_general = False
+    return flex
+
+
+class TestFlexChi0qConventionTag(unittest.TestCase):
+    def test_chi0q_npz_carries_spin_block_tag(self):
+        flex = _make_flex_stub(4, np.arange(4))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            flex.save_results(
+                {"path_to_output": tmp, "chi0q": "chi0q"},
+                {"chi0q": np.zeros((4, 2, 2, 2), dtype=np.complex128)})
+            data = np.load(os.path.join(tmp, "chi0q.npz"))
+            self.assertIn(
+                "index_convention", data,
+                "FLEX chi0q.npz must carry the index_convention tag")
+            self.assertEqual(str(data["index_convention"]), "spin_block")
+            # the SO-mode validator must accept a FLEX-written file
+            validate_chi0q_index_convention(
+                data, enable_spin_orbital=True, file_name="chi0q.npz")
+
+    def test_chi0q_npz_freq_metadata_matches_full_grid(self):
+        # FLEX never applies the matsubara_frequency filter to its outputs
+        # (unlike RPA), so the saved freq_index must describe the FULL grid
+        # actually stored, not the restricted user option; otherwise the
+        # strict hwave_sc loader rejects a perfectly valid file.
+        flex = _make_flex_stub(4, np.array([2]))  # e.g. "center"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            flex.save_results(
+                {"path_to_output": tmp, "chi0q": "chi0q"},
+                {"chi0q": np.zeros((4, 2, 2, 2), dtype=np.complex128)})
+            data = np.load(os.path.join(tmp, "chi0q.npz"))
+            np.testing.assert_array_equal(data["freq_index"], np.arange(4))
+            self.assertEqual(int(data["nmat"]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_spin_diag_sigma.py
+++ b/tests/test_flex_spin_diag_sigma.py
@@ -1,0 +1,93 @@
+"""Regression test: FLEX spin-diag self-energy must pair each Green block
+with its own spin slot of V_eff.
+
+In spin-diag mode the up/down chi0q blocks are inflated onto distinct spin
+diagonals of V_eff (block g -> slot (g, g)), so the self-energy of Green
+block g must be built from V_eff slot g.  Truncating the spin-inflated
+sigma with [..., :nd_block, :nd_block] instead selects the up-spin vertex
+for BOTH spin blocks.
+
+The check uses linearity: with identical up/down Green blocks and
+V_down = 2 * V_up (elementwise), the down self-energy must be exactly
+twice the up self-energy.
+"""
+import unittest
+
+import numpy as np
+
+from hwave.solver.flex import FLEX
+
+
+def _make_flex_stub(shape, nmat, norb, ns):
+    flex = FLEX.__new__(FLEX)
+
+    class LatticeStub:
+        pass
+
+    flex.lattice = LatticeStub()
+    flex.lattice.shape = shape
+    flex.lattice.nvol = shape[0] * shape[1] * shape[2]
+    flex.nmat = nmat
+    flex.norb = norb
+    flex.ns = ns
+    flex.nd = norb * ns
+    return flex
+
+
+class TestFlexSpinDiagSelfEnergy(unittest.TestCase):
+    def test_down_block_uses_down_spin_vertex(self):
+        shape = (2, 1, 1)
+        nmat, norb, ns = 4, 1, 2
+        nvol = 2
+        nd = norb * ns
+        flex = _make_flex_stub(shape, nmat, norb, ns)
+
+        rng = np.random.default_rng(42)
+        g_block = (rng.standard_normal((nmat, nvol, norb, norb))
+                   + 1j * rng.standard_normal((nmat, nvol, norb, norb)))
+        green_kw = np.stack([g_block, g_block])  # identical up/down blocks
+
+        v_up = (rng.standard_normal((nmat, nvol, norb, norb))
+                + 1j * rng.standard_normal((nmat, nvol, norb, norb)))
+        v_eff = np.zeros((nmat, nvol, nd, nd), dtype=np.complex128)
+        v_eff[..., :norb, :norb] = v_up
+        v_eff[..., norb:, norb:] = 2.0 * v_up
+
+        sigma = flex._calc_self_energy(green_kw, v_eff, beta=10.0)
+
+        self.assertEqual(sigma.shape, (2, nmat, nvol, norb, norb))
+        self.assertGreater(np.max(np.abs(sigma[0])), 1e-12)
+        np.testing.assert_allclose(
+            sigma[1], 2.0 * sigma[0], rtol=0.0, atol=1e-12,
+            err_msg="down-spin self-energy must use the down-spin V_eff slot")
+
+    def test_spin_free_single_block_unchanged(self):
+        # spin-free: one Green block, both V_eff spin slots identical;
+        # the result must equal the elementwise product path.
+        shape = (2, 1, 1)
+        nmat, norb, ns = 4, 2, 2
+        nvol = 2
+        nd = norb * ns
+        flex = _make_flex_stub(shape, nmat, norb, ns)
+
+        rng = np.random.default_rng(7)
+        green_kw = (rng.standard_normal((1, nmat, nvol, norb, norb))
+                    + 1j * rng.standard_normal((1, nmat, nvol, norb, norb)))
+        v_orb = (rng.standard_normal((nmat, nvol, norb, norb))
+                 + 1j * rng.standard_normal((nmat, nvol, norb, norb)))
+        v_eff = np.zeros((nmat, nvol, nd, nd), dtype=np.complex128)
+        for s in range(ns):
+            sl = slice(s * norb, (s + 1) * norb)
+            v_eff[..., sl, sl] = v_orb
+
+        sigma = flex._calc_self_energy(green_kw, v_eff, beta=10.0)
+
+        # reference: same-shape elementwise path (nd_block == nd_v)
+        flex_ref = _make_flex_stub(shape, nmat, norb, 1)
+        sigma_ref = flex_ref._calc_self_energy(green_kw, v_orb, beta=10.0)
+
+        np.testing.assert_allclose(sigma, sigma_ref, rtol=0.0, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_coulomb_keyword.py
+++ b/tests/test_rpa_coulomb_keyword.py
@@ -1,0 +1,129 @@
+"""Regression test: the combined 'Coulomb' interaction keyword in RPA/FLEX.
+
+'Coulomb' is accepted by the shared k-space input reader and handled by UHFk
+(split into the r=0 diagonal part = CoulombIntra and the rest = CoulombInter).
+RPA's Interaction must apply the same decomposition instead of silently
+ignoring the term (which yielded chiq without any Coulomb interaction).
+"""
+import unittest
+
+import numpy as np
+
+from hwave.solver.rpa import Interaction
+
+
+class _FakeLattice:
+    def __init__(self, shape):
+        self.shape = shape
+        self.nvol = shape[0] * shape[1] * shape[2]
+
+
+def _make_bare_interaction(norb, shape, param_ham):
+    obj = object.__new__(Interaction)
+    obj.lattice = _FakeLattice(shape)
+    obj.norb = norb
+    obj.param_ham = param_ham
+    obj._has_interaction = False
+    obj._has_interaction_coulomb = False
+    obj._has_interaction_exchange = False
+    obj._has_interaction_pairhop = False
+    return obj
+
+
+class TestRPACoulombKeyword(unittest.TestCase):
+    def test_coulomb_equals_intra_plus_inter(self):
+        norb = 2
+        shape = (2, 1, 1)
+        coulomb = {
+            ((0, 0, 0), (0, 0)): 2.0,   # r=0 diagonal -> CoulombIntra
+            ((0, 0, 0), (1, 1)): 1.5,   # r=0 diagonal -> CoulombIntra
+            ((0, 0, 0), (0, 1)): 0.3,   # r=0 off-diagonal -> CoulombInter
+            ((0, 0, 0), (1, 0)): 0.3,
+            ((1, 0, 0), (0, 0)): 0.5,   # r!=0 -> CoulombInter
+            ((1, 0, 0), (1, 1)): 0.5,
+        }
+        intra = {k: v for k, v in coulomb.items()
+                 if k[0] == (0, 0, 0) and k[1][0] == k[1][1]}
+        inter = {k: v for k, v in coulomb.items() if k not in intra}
+
+        obj_c = _make_bare_interaction(norb, shape, {"Coulomb": dict(coulomb)})
+        obj_c._make_ham_inter()
+
+        obj_ref = _make_bare_interaction(
+            norb, shape, {"CoulombIntra": intra, "CoulombInter": inter})
+        obj_ref._make_ham_inter()
+
+        self.assertTrue(obj_c.has_interaction(),
+                        "'Coulomb' must register as an interaction")
+        self.assertTrue(obj_c.has_interaction_coulomb())
+        self.assertGreater(np.max(np.abs(obj_c.ham_inter_q)), 1e-12)
+        np.testing.assert_allclose(
+            obj_c.ham_inter_q, obj_ref.ham_inter_q, rtol=0.0, atol=1e-12,
+            err_msg="'Coulomb' must equal CoulombIntra + CoulombInter")
+
+    def test_coulomb_conflicts_with_explicit_terms(self):
+        norb = 1
+        shape = (1, 1, 1)
+        obj = _make_bare_interaction(
+            norb, shape,
+            {"Coulomb": {((0, 0, 0), (0, 0)): 2.0},
+             "CoulombIntra": {((0, 0, 0), (0, 0)): 1.0}})
+        with self.assertRaises(SystemExit):
+            obj._make_ham_inter()
+
+
+class TestHwaveScCoulombKeyword(unittest.TestCase):
+    """hwave_sc must consume the combined 'Coulomb' keyword like the solvers
+    (silently dropping it would build the Eliashberg vertex without the
+    interaction the same TOML just used for chi0q/chiq)."""
+
+    def _write_w90(self, filename, entries, norb):
+        with open(filename, "w") as f:
+            f.write("comment\n{}\n{}\n".format(norb, len(entries)))
+            f.write(" ".join(["1"] * len(entries)) + "\n")
+            for (r, a, b, v) in entries:
+                f.write("  {:3d} {:3d} {:3d} {:3d} {:3d}  {:.6f}  0.0\n".format(
+                    r[0], r[1], r[2], a + 1, b + 1, v))
+
+    def test_coulomb_keyword_split_into_intra_and_inter(self):
+        import os
+        import shutil
+        import tempfile
+        from hwave.sc import _read_interaction_files
+
+        d = tempfile.mkdtemp(prefix="sc_coulomb_")
+        try:
+            with open(os.path.join(d, "geom.dat"), "w") as f:
+                f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n")
+                f.write("2\n0.0 0.0 0.0\n0.0 0.0 0.0\n")
+            self._write_w90(os.path.join(d, "transfer.dat"),
+                            [((1, 0, 0), 0, 0, 1.0), ((-1, 0, 0), 0, 0, 1.0)],
+                            norb=2)
+            self._write_w90(os.path.join(d, "coulomb.dat"),
+                            [((0, 0, 0), 0, 0, 2.0),   # r=0 diag -> intra
+                             ((0, 0, 0), 0, 1, 0.3),   # r=0 offdiag -> inter
+                             ((1, 0, 0), 0, 0, 0.5)],  # r!=0 -> inter
+                            norb=2)
+            input_dict = {
+                "file": {"input": {"interaction": {
+                    "path_to_input": d,
+                    "Geometry": "geom.dat",
+                    "Transfer": "transfer.dat",
+                    "Coulomb": "coulomb.dat",
+                }}},
+            }
+            geom, hr, interactions = _read_interaction_files(input_dict)
+            self.assertIn("CoulombIntra", interactions)
+            self.assertIn("CoulombInter", interactions)
+            self.assertEqual(
+                interactions["CoulombIntra"][((0, 0, 0), (0, 0))], 2.0)
+            self.assertEqual(
+                interactions["CoulombInter"][((0, 0, 0), (0, 1))], 0.3)
+            self.assertEqual(
+                interactions["CoulombInter"][((1, 0, 0), (0, 0))], 0.5)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_fold_collision.py
+++ b/tests/test_rpa_fold_collision.py
@@ -1,0 +1,61 @@
+"""Regression test: RPA sublattice fold must accumulate wrap-around collisions.
+
+When the hopping range reaches the folded supercell size, distinct original
+R-vectors (e.g. +r and -r) fold onto the same (R, orbital) key.  UHFk
+canonicalizes the folded R to [0, n) and SUMS such contributions; RPA's
+Interaction._reshape_interaction must do the same -- keeping negative R keys
+means the consumer's numpy scatter (tab_r[ir] = v, negative index wrapping)
+silently overwrites one contribution with the other.
+"""
+import unittest
+
+import numpy as np
+
+from hwave.solver.rpa import Interaction
+
+
+class _FakeLattice:
+    def __init__(self, shape, subshape):
+        self.shape = shape
+        self.subshape = subshape
+
+
+class TestRPAFoldCollision(unittest.TestCase):
+    def _make_interaction(self, geom_norb_orig, subshape, shape):
+        obj = object.__new__(Interaction)
+        obj.enable_spin_orbital = False
+        obj.lattice = _FakeLattice(shape=shape, subshape=subshape)
+        obj.param_ham_orig = {"Geometry": {"norb": geom_norb_orig}}
+        return obj
+
+    def test_wraparound_collisions_are_summed(self):
+        # CellShape [4,1,1], SubShape [2,1,1] -> folded shape nx=2.
+        # Hops r=+2 and r=-2 are distinct original R-vectors that fold onto
+        # the same canonical (R=1, orbital) keys.
+        obj = self._make_interaction(1, subshape=(2, 1, 1), shape=(2, 1, 1))
+        ham = {
+            ((2, 0, 0), (0, 0)): 1.0,
+            ((-2, 0, 0), (0, 0)): 0.5,
+        }
+        out = obj._reshape_interaction(ham, enable_spin_orbital=False)
+
+        # all folded R components canonical (non-negative, within shape)
+        for (ir, _ov) in out.keys():
+            self.assertTrue(0 <= ir[0] < 2 and ir[1] == 0 and ir[2] == 0,
+                            "folded R must be canonicalized, got {}".format(ir))
+
+        # collisions summed, not overwritten
+        self.assertTrue(
+            np.isclose(out[((1, 0, 0), (0, 0))], 1.5),
+            "colliding +r/-r contributions must be summed: got {}".format(
+                out.get(((1, 0, 0), (0, 0)))))
+
+        # total weight preserved: each original entry appears subvol times
+        total_in = sum(ham.values()) * 2
+        total_out = sum(out.values())
+        self.assertTrue(np.isclose(total_out, total_in),
+                        "fold must preserve the total interaction weight")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_output.py
+++ b/tests/test_rpa_output.py
@@ -20,6 +20,7 @@ class TestRPASaveChiqPm(unittest.TestCase):
         solver = RPA.__new__(RPA)
         solver._init_wavevec = lambda: None  # bypass heavy wavevector setup
         solver.calc_chiq = True
+        solver.nmat = 1
         solver.freq_index = np.array([0])
         solver.kvec = np.zeros((1, 3))
         solver.wavenum_table = np.zeros((1, 3), dtype=int)
@@ -40,6 +41,86 @@ class TestRPASaveChiqPm(unittest.TestCase):
             # spin-orbital axis ordering must be recorded for downstream consumers
             self.assertIn("index_convention", data.files)
             self.assertEqual(str(data["index_convention"]), "spin_block")
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestRPAChi0qPassthroughMetadata(unittest.TestCase):
+    """A chi0q loaded via chi0q_init and re-saved must keep the frequency
+    metadata of the file that PRODUCED it: stamping the current run's
+    freq_index/nmat mislabels the axis for the strict hwave_sc loader."""
+
+    def _make_solver(self):
+        solver = RPA.__new__(RPA)
+        solver._init_wavevec = lambda: None
+        solver.calc_chiq = False
+        solver.nmat = 16
+        solver.freq_index = np.arange(16)
+        solver.kvec = np.zeros((1, 3))
+        solver.wavenum_table = np.zeros((1, 3), dtype=int)
+        return solver
+
+    def _save_and_load(self, solver, tmpdir):
+        green_info = {"chi0q": np.ones((5, 1, 1, 1), dtype=complex)}
+        solver.save_results({"path_to_output": tmpdir, "chi0q": "chi0q"},
+                            green_info)
+        return np.load(os.path.join(tmpdir, "chi0q.npz"))
+
+    def test_passthrough_keeps_producing_run_metadata(self):
+        solver = self._make_solver()
+        solver._chi0q_init_meta = {"freq_index": np.arange(2, 7), "nmat": 8}
+        tmpdir = tempfile.mkdtemp()
+        try:
+            data = self._save_and_load(solver, tmpdir)
+            np.testing.assert_array_equal(data["freq_index"], np.arange(2, 7))
+            self.assertEqual(int(data["nmat"]), 8)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_passthrough_of_legacy_file_describes_axis_without_nmat(self):
+        # the documented file format guarantees a freq_index key, so a
+        # legacy passthrough must still write one -- describing the stored
+        # axis (0..n-1) without fabricating an nmat claim (downstream then
+        # treats it explicitly as ambiguous unless Nmat matches)
+        solver = self._make_solver()
+        solver._chi0q_init_meta = {"freq_index": None, "nmat": None}
+        tmpdir = tempfile.mkdtemp()
+        try:
+            data = self._save_and_load(solver, tmpdir)
+            np.testing.assert_array_equal(data["freq_index"], np.arange(5))
+            self.assertNotIn("nmat", data.files)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_own_chi0q_uses_current_run_metadata(self):
+        solver = self._make_solver()
+        solver._chi0q_init_meta = None  # chi0q computed by this run
+        tmpdir = tempfile.mkdtemp()
+        try:
+            data = self._save_and_load(solver, tmpdir)
+            np.testing.assert_array_equal(data["freq_index"], np.arange(16))
+            self.assertEqual(int(data["nmat"]), 16)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_chiq_from_chi0q_init_keeps_producing_run_metadata(self):
+        # chiq is computed FROM the chi0q input, so its frequency axis is
+        # inherited from the chi0q_init file, not the current run
+        solver = self._make_solver()
+        solver.calc_chiq = True
+        solver._chi0q_init_meta = {"freq_index": np.arange(2, 7), "nmat": 8}
+        tmpdir = tempfile.mkdtemp()
+        try:
+            green_info = {"chiq": np.ones((5, 1, 1, 1), dtype=complex)}
+            solver.save_results({"path_to_output": tmpdir, "chiq": "chiq"},
+                                green_info)
+            data = np.load(os.path.join(tmpdir, "chiq.npz"))
+            np.testing.assert_array_equal(data["freq_index"], np.arange(2, 7))
+            self.assertEqual(int(data["nmat"]), 8)
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -1244,7 +1244,7 @@ class TestChi0qConversion(unittest.TestCase):
         chi0q_hwave = np.random.randn(nmat, nvol, norb, norb) + \
                       1j * np.random.randn(nmat, nvol, norb, norb)
 
-        chi0q_ref = _convert_chi0q_to_ref_format(chi0q_hwave, norb, Nx, Ny, Nz, nmat)
+        chi0q_ref = _convert_chi0q_to_ref_format(chi0q_hwave, norb, Nx, Ny, Nz)
         self.assertEqual(chi0q_ref.shape, (norb, norb, Nx, Ny, Nz, nmat))
 
         # Verify mapping: chi0q_hwave[w, vol_idx, a, b] == chi0q_ref[a, b, ix, iy, iz, w]
@@ -2314,7 +2314,10 @@ class TestChi0qInternal(unittest.TestCase):
 
             # Load it back
             from hwave.sc import _load_chi0q
-            chi0q_loaded = _load_chi0q(input_dict)
+            chi0q_loaded, static_index = _load_chi0q(input_dict)
+            self.assertIsNone(static_index,
+                              "metadata-less file: the caller slices the "
+                              "center of its actual frequency axis")
 
             npt.assert_allclose(chi0q_calc, chi0q_loaded, atol=1e-15,
                                 err_msg="Loaded chi0q should exactly match computed chi0q")
@@ -2449,7 +2452,7 @@ class TestChi0q4Index(unittest.TestCase):
         rng = np.random.default_rng(42)
         chi0q_hw = rng.standard_normal((nmat, nvol, norb, norb, norb, norb))
 
-        chi0q_ref = _convert_chi0q_to_ref_format(chi0q_hw, norb, Nx, Ny, Nz, nmat)
+        chi0q_ref = _convert_chi0q_to_ref_format(chi0q_hw, norb, Nx, Ny, Nz)
 
         # Should be (norb, norb, norb, norb, Nx, Ny, Nz, nmat)
         self.assertEqual(chi0q_ref.shape,
@@ -2496,8 +2499,8 @@ class TestChi0q4Index(unittest.TestCase):
             nmat = 32
 
             # Convert to ref format
-            chi0q_gen_ref = _convert_chi0q_to_ref_format(chi0q_gen, norb, Nx, Ny, Nz, nmat)
-            chi0q_red_ref = _convert_chi0q_to_ref_format(chi0q_red, norb, Nx, Ny, Nz, nmat)
+            chi0q_gen_ref = _convert_chi0q_to_ref_format(chi0q_gen, norb, Nx, Ny, Nz)
+            chi0q_red_ref = _convert_chi0q_to_ref_format(chi0q_red, norb, Nx, Ny, Nz)
 
             U_k = np.zeros((norb, norb, Nx, Ny, Nz), dtype=complex)
             U_k[0, 0] = 3.0
@@ -3071,7 +3074,7 @@ class TestKanamoriInteraction(unittest.TestCase):
 
             # Compute chi0q in sc.py ref format
             chi0q_ref = _convert_chi0q_to_ref_format(
-                chi0q_rpa, norb, Nx, Ny, Nz, nmat)
+                chi0q_rpa, norb, Nx, Ny, Nz)
 
             # Build interaction in k-space for sc.py
             inter_k = self._make_inter_k(norb, Nx, Ny, Nz,

--- a/tests/test_sc_static_freq.py
+++ b/tests/test_sc_static_freq.py
@@ -1,0 +1,278 @@
+"""Regression tests: hwave_sc must locate the static (zero bosonic frequency)
+chi0q slice via the freq_index metadata, not blindly at nmat//2.
+
+RPA's matsubara_frequency option can restrict the frequency axis of
+chi0q.npz; freq_index records the original indices (zero frequency sits at
+original index Nmat//2).  Loading such a file and slicing at nfreq//2
+silently uses a finite-frequency chi0 as the static limit.
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from hwave.sc import (
+    _static_freq_position,
+    _load_chi0q,
+    _compute_vertices_simple,
+)
+
+
+class TestStaticFreqPosition(unittest.TestCase):
+    def test_full_grid(self):
+        freq_index = np.arange(8)
+        self.assertEqual(_static_freq_position(freq_index, 8, 8, "f"), 4)
+
+    def test_full_grid_with_file_nmat_ignores_mismatched_config(self):
+        # a full-grid file with nmat metadata resolves regardless of the
+        # hwave_sc config Nmat (e.g. RPA Nmat=2048, Eliashberg Nmat=1024);
+        # without nmat metadata this case is indistinguishable from a
+        # [0,K] restriction and raises (see
+        # test_indices_exceeding_config_raises)
+        freq_index = np.arange(2048)
+        self.assertEqual(
+            _static_freq_position(freq_index, 2048, 1024, "f",
+                                  file_nmat=2048), 1024)
+
+    def test_restricted_range_containing_zero(self):
+        # original Nmat=8, restricted to indices 2..6: zero (index 4) at pos 2
+        freq_index = np.arange(2, 7)
+        self.assertEqual(_static_freq_position(freq_index, 5, 8, "f"), 2)
+
+    def test_file_nmat_takes_precedence_over_config(self):
+        # file records its own nmat=8; the (wrong) config Nmat is ignored
+        freq_index = np.arange(2, 7)
+        self.assertEqual(
+            _static_freq_position(freq_index, 5, 1024, "f", file_nmat=8), 2)
+
+    def test_restricted_range_missing_zero_raises(self):
+        freq_index = np.arange(0, 4)  # zero frequency (index 4) not included
+        with self.assertRaises(ValueError):
+            _static_freq_position(freq_index, 4, 8, "f", file_nmat=8)
+
+    def test_indices_exceeding_config_raises(self):
+        # freq_index = 0..2047 with config Nmat=1024: not a restriction of
+        # the config grid, but ALSO not provably a full grid (it could be a
+        # [0,2047] restriction of an even larger run) -- the zero-frequency
+        # position is unknowable without nmat metadata, so it must fail
+        # with instructions instead of silently assuming a full grid
+        freq_index = np.arange(0, 2048)
+        with self.assertRaises(ValueError):
+            _static_freq_position(freq_index, 2048, 1024, "f")
+
+    def test_non_zero_based_range_exceeding_config_raises(self):
+        # legacy restricted range [512,1536] with config Nmat=1024: the
+        # indices reach past the config grid, so the config-based lookup is
+        # disproven; silently returning the position of 512 (=1024//2, at
+        # position 0!) would slice a finite frequency
+        freq_index = np.arange(512, 1537)
+        with self.assertRaises(ValueError):
+            _static_freq_position(freq_index, 1025, 1024, "f")
+
+    def test_zero_based_range_without_provable_reading_raises(self):
+        # legacy file (no nmat metadata) with freq_index = 0..3 and config
+        # Nmat=8: EITHER a full 4-grid (zero at 2) OR a [0,3] restriction of
+        # the 8-grid (which contains NO zero frequency) -- silently picking
+        # the full-grid reading would return a finite frequency for the
+        # restricted file, so it must fail with instructions
+        freq_index = np.arange(0, 4)
+        with self.assertRaises(ValueError):
+            _static_freq_position(freq_index, 4, 8, "f")
+
+    def test_ambiguous_zero_based_range_raises(self):
+        # legacy file with freq_index = 0..600 and config Nmat=1024: this is
+        # EITHER a full 601-grid (zero at 300) OR a [0,600] restriction of
+        # the 1024-grid (zero at 512) -- silently picking either one is
+        # wrong for the other, so it must fail with instructions
+        freq_index = np.arange(0, 601)
+        with self.assertRaises(ValueError):
+            _static_freq_position(freq_index, 601, 1024, "f")
+
+    def test_empty_freq_index_raises_value_error(self):
+        # matsubara_frequency="none" output: must be a clean ValueError,
+        # not an IndexError from the error-message formatting
+        with self.assertRaises(ValueError):
+            _static_freq_position(np.array([], dtype=int), 0, 8, "f")
+
+    def test_empty_freq_index_with_data_raises(self):
+        # empty metadata beats the length-mismatch fallback: it must fail
+        # cleanly even when a data axis exists
+        with self.assertRaises(ValueError):
+            _static_freq_position(np.array([], dtype=int), 8, 8, "f")
+
+    def test_legacy_file_without_freq_index_delegates_to_data_axis(self):
+        # no metadata: the caller must slice the center of the ACTUAL data
+        # axis (which only the caller can identify, e.g. 6D ref format)
+        self.assertIsNone(_static_freq_position(None, 8, 8, "f"))
+
+    def test_inconsistent_length_delegates_to_data_axis(self):
+        # legacy FLEX chi0q files store the FULL grid but a restricted
+        # freq_index; the DATA axis is authoritative, so the caller slices
+        # its center (with a warning) exactly as before the metadata
+        # handling was introduced
+        self.assertIsNone(_static_freq_position(np.arange(5), 8, 8, "f"))
+
+
+class TestLoadChi0qStaticIndex(unittest.TestCase):
+    def _write_and_load(self, nmat_config, freq_index, nfreq, file_nmat=None,
+                        shape=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            if shape is None:
+                shape = (nfreq, 4, 1, 1)
+            chi0q = np.zeros(shape, dtype=np.complex128)
+            kwargs = {"chi0q": chi0q, "index_convention": "spin_block"}
+            if freq_index is not None:
+                kwargs["freq_index"] = np.asarray(freq_index)
+            if file_nmat is not None:
+                kwargs["nmat"] = file_nmat
+            np.savez(os.path.join(tmp, "chi0q.npz"), **kwargs)
+            input_dict = {
+                "mode": {"param": {"Nmat": nmat_config}},
+                "file": {"output": {"path_to_output": tmp}},
+            }
+            return _load_chi0q(input_dict)
+
+    def test_restricted_file_returns_true_static_index(self):
+        chi0q, static_index = self._write_and_load(8, np.arange(2, 7), 5)
+        self.assertEqual(static_index, 2)
+
+    def test_full_file_returns_center(self):
+        chi0q, static_index = self._write_and_load(8, np.arange(8), 8)
+        self.assertEqual(static_index, 4)
+
+    def test_full_file_with_larger_grid_than_config_raises_without_nmat(self):
+        # a legacy full-grid file bigger than the config Nmat cannot be
+        # proven full (could be a [0,K] restriction of a still larger run):
+        # fail with instructions; with nmat metadata it resolves cleanly
+        # (see test_restricted_file_with_nmat_metadata_ignores_config)
+        with self.assertRaises(ValueError):
+            self._write_and_load(1024, np.arange(2048), 2048)
+
+    def test_full_file_with_larger_grid_and_nmat_metadata_works(self):
+        chi0q, static_index = self._write_and_load(
+            1024, np.arange(2048), 2048, file_nmat=2048)
+        self.assertEqual(static_index, 1024)
+
+    def test_legacy_flex_4d_restricted_freq_index_delegates(self):
+        # legacy FLEX 4D file: FULL 16-point grid on axis 0 but a restricted
+        # 2-entry freq_index that happens to match the LAST axis length
+        # (norb=2); the frequency axis of the 4D raw layout is ALWAYS axis 0,
+        # so this is a length mismatch -> delegate (None), never a binding
+        # of freq_index to the orbital axis
+        chi0q, static_index = self._write_and_load(
+            1024, np.array([7, 8]), 16, shape=(16, 4, 2, 2))
+        self.assertIsNone(static_index)
+
+    def test_small_legacy_file_with_default_config_raises_with_guidance(self):
+        # a legacy 8-point file (no nmat key) under the default config
+        # Nmat=1024 cannot be disambiguated from a [0,7] restriction that
+        # lacks the zero frequency; the error tells the user to set
+        # Nmat=8 if the file holds a full grid
+        with self.assertRaises(ValueError):
+            self._write_and_load(1024, np.arange(8), 8)
+
+    def test_restricted_file_with_nmat_metadata_ignores_config(self):
+        chi0q, static_index = self._write_and_load(
+            1024, np.arange(2, 7), 5, file_nmat=8)
+        self.assertEqual(static_index, 2)
+
+    def test_file_without_zero_frequency_raises(self):
+        with self.assertRaises(ValueError):
+            self._write_and_load(8, np.arange(0, 4), 4, file_nmat=8)
+
+    def test_ref_format_6d_freq_axis_detected(self):
+        # reference-format file (norb, norb, Nx, Ny, Nz, nmat): the frequency
+        # axis is LAST; freq_index length must resolve the right axis
+        chi0q, static_index = self._write_and_load(
+            8, np.arange(8), 8, shape=(2, 2, 2, 1, 1, 8))
+        self.assertEqual(static_index, 4)
+
+    def test_ref_format_6d_without_metadata_delegates(self):
+        # a metadata-less reference-format file must NOT get a static index
+        # guessed from the wrong axis (shape[0] = norb); returning None lets
+        # the caller slice the center of the axis it actually uses
+        chi0q, static_index = self._write_and_load(
+            1024, None, 8, shape=(2, 2, 2, 1, 1, 8))
+        self.assertIsNone(static_index)
+
+    def test_legacy_file_without_metadata_delegates(self):
+        chi0q, static_index = self._write_and_load(1024, None, 8)
+        self.assertIsNone(static_index)
+
+
+class TestLoadFlexSusceptibilitiesStaticSlice(unittest.TestCase):
+    def test_restricted_rpa_chiq_uses_metadata_for_static_slice(self):
+        # RPA chiq.npz with matsubara_frequency=[400,600] of Nmat=1024:
+        # the zero bosonic frequency (original index 512) sits at stored
+        # position 112, NOT at the axis center (100)
+        from hwave.sc import _load_flex_susceptibilities
+
+        with tempfile.TemporaryDirectory() as tmp:
+            nfreq, nvol, nd = 201, 2, 1
+            freq_index = np.arange(400, 601)
+            # encode the stored position in the value so the selected
+            # slice is observable
+            chiq = np.zeros((nfreq, nvol, nd, nd), dtype=np.complex128)
+            for i in range(nfreq):
+                chiq[i] = float(i)
+            for name in ("chiq_s.npz", "chiq_c.npz"):
+                np.savez(os.path.join(tmp, name),
+                         chiq=chiq, freq_index=freq_index, nmat=1024,
+                         chi_convention="kuroki")
+            input_dict = {
+                "mode": {"param": {"Nmat": 1024}},
+                "file": {"input": {"path_to_flex_output": tmp},
+                         "output": {"path_to_output": tmp}},
+            }
+            chis, chic, green_dressed, conv = _load_flex_susceptibilities(
+                input_dict, norb=1, Nx=2, Ny=1, Nz=1)
+            self.assertEqual(chis.flat[0].real, 112.0,
+                             "static slice must come from freq_index/nmat "
+                             "metadata, not the axis center")
+            self.assertEqual(chic.flat[0].real, 112.0)
+
+    def test_legacy_chiq_without_metadata_uses_data_axis_center(self):
+        from hwave.sc import _load_flex_susceptibilities
+
+        with tempfile.TemporaryDirectory() as tmp:
+            nfreq, nvol, nd = 8, 2, 1
+            chiq = np.zeros((nfreq, nvol, nd, nd), dtype=np.complex128)
+            for i in range(nfreq):
+                chiq[i] = float(i)
+            for name in ("chiq_s.npz", "chiq_c.npz"):
+                np.savez(os.path.join(tmp, name),
+                         chiq=chiq, chi_convention="kuroki")
+            input_dict = {
+                "mode": {"param": {"Nmat": 1024}},
+                "file": {"input": {"path_to_flex_output": tmp},
+                         "output": {"path_to_output": tmp}},
+            }
+            chis, chic, green_dressed, conv = _load_flex_susceptibilities(
+                input_dict, norb=1, Nx=2, Ny=1, Nz=1)
+            self.assertEqual(chis.flat[0].real, 4.0,
+                             "metadata-less file: center of the data axis")
+
+
+class TestComputeVerticesStaticIndex(unittest.TestCase):
+    def test_simple_vertices_use_static_index(self):
+        norb, Nx, Ny, Nz, nmat = 1, 2, 1, 1, 8
+        rng = np.random.default_rng(3)
+        chi0q = 0.1 * (rng.standard_normal((norb, norb, Nx, Ny, Nz, nmat))
+                       + 1j * rng.standard_normal((norb, norb, Nx, Ny, Nz, nmat)))
+        inter_k = {"CoulombIntra": np.full((norb, norb, Nx, Ny, Nz), 2.0,
+                                           dtype=complex)}
+
+        ref = _compute_vertices_simple(chi0q, inter_k, norb, Nx, Ny, Nz, nmat)
+
+        # restricted file: keep frequency slices 2..6 (zero frequency at pos 2)
+        chi0q_res = chi0q[..., 2:7]
+        got = _compute_vertices_simple(chi0q_res, inter_k, norb, Nx, Ny, Nz,
+                                       chi0q_res.shape[-1], static_index=2)
+
+        np.testing.assert_allclose(got[0], ref[0], rtol=0.0, atol=1e-12)
+        np.testing.assert_allclose(got[1], ref[1], rtol=0.0, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uhfk_block_2sz.py
+++ b/tests/test_uhfk_block_2sz.py
@@ -49,16 +49,24 @@ class TestUHFk2SzFixedBlocks(unittest.TestCase):
             os.chdir(cur)
 
     def test_2sz_constraint_honored_with_coulombintra(self):
+        # NOTE: no total-energy assertion here.  With the exactly degenerate
+        # non-interacting start, the converged SCF branch depends on the
+        # LAPACK implementation (macOS and Linux find different, equally
+        # Sz-constrained solutions), so only platform-independent invariants
+        # of the constraint are checked: the converged Sz, the total electron
+        # count, and the per-spin-sector electron counts (Ncond +- 2Sz)/2.
         solver = self._run_coulombintra_2sz4()
         self.assertTrue(
             np.isclose(solver.physics["Sz"], 2.0, rtol=0.0, atol=1.0e-8),
             "converged Sz = {} but 2Sz = 4 was requested".format(
                 solver.physics["Sz"]))
         self.assertTrue(
-            np.isclose(solver.physics["Ene"]["Total"], 0.21957524103017434,
-                       rtol=0.0, atol=1.0e-6),
-            "converged energy {} differs from the 2Sz-fixed reference".format(
-                solver.physics["Ene"]["Total"]))
+            np.isclose(solver.physics["NCond"], 16.0, rtol=0.0, atol=1.0e-8),
+            "converged NCond = {} but Ncond = 16 was requested".format(
+                solver.physics["NCond"]))
+        self.assertEqual(
+            sorted(solver.group_nconds), [6, 10],
+            "spin sectors must carry (Ncond +- 2Sz)/2 = 10 and 6 electrons")
 
     def test_2sz_fixed_blocks_are_pure_spin(self):
         solver = self._run_coulombintra_2sz4()

--- a/tests/test_uhfk_block_2sz.py
+++ b/tests/test_uhfk_block_2sz.py
@@ -7,7 +7,7 @@ therefore never merge the up and down sectors into one mu-group in 2Sz-fixed
 mode; doing so silently replaces the constrained solution by the Sz-free one.
 
 Reference values are from the pre-block-detection implementation (main,
-c0b0a3c) on tests/uhfk/coulombintra with 2Sz = 4 and no initial green.
+c0b0a3c) on tests/uhfk/CoulombIntra with 2Sz = 4 and no initial green.
 """
 import os
 import tempfile
@@ -26,7 +26,7 @@ class TestUHFk2SzFixedBlocks(unittest.TestCase):
         if cls._solver_cache is not None:
             return cls._solver_cache
         cur = os.getcwd()
-        os.chdir("tests/uhfk/coulombintra")
+        os.chdir("tests/uhfk/CoulombIntra")
         try:
             with open("input.toml", "rb") as f:
                 params = tomli.load(f)

--- a/tests/test_uhfk_block_2sz.py
+++ b/tests/test_uhfk_block_2sz.py
@@ -1,0 +1,76 @@
+"""Regression tests: block detection must honor the 2Sz-fixed constraint.
+
+In 2Sz-fixed mode the UHFk mean-field Hamiltonian is treated as spin-block
+diagonal (spin off-diagonal Fock entries are not used), and each spin sector
+is filled with its own electron count (Ncond +- 2Sz)/2.  Block detection must
+therefore never merge the up and down sectors into one mu-group in 2Sz-fixed
+mode; doing so silently replaces the constrained solution by the Sz-free one.
+
+Reference values are from the pre-block-detection implementation (main,
+c0b0a3c) on tests/uhfk/coulombintra with 2Sz = 4 and no initial green.
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import tomli
+
+
+class TestUHFk2SzFixedBlocks(unittest.TestCase):
+    _solver_cache = None
+
+    @classmethod
+    def _run_coulombintra_2sz4(cls):
+        # both tests assert on the same converged state; run the SCF once
+        if cls._solver_cache is not None:
+            return cls._solver_cache
+        cur = os.getcwd()
+        os.chdir("tests/uhfk/coulombintra")
+        try:
+            with open("input.toml", "rb") as f:
+                params = tomli.load(f)
+            params["mode"]["param"]["2Sz"] = 4
+            params["file"]["input"].pop("initial", None)
+
+            from hwave.qlmsio import read_input_k
+            from hwave.solver.uhfk import UHFk
+
+            read_io = read_input_k.QLMSkInput(params["file"]["input"])
+            ham_info = read_io.get_param("ham")
+            green_info = read_io.get_param("green")
+
+            solver = UHFk(ham_info, params["log"], params["mode"])
+            with tempfile.TemporaryDirectory() as tmp:
+                solver.solve(green_info, tmp)
+            cls._solver_cache = solver
+            return solver
+        finally:
+            os.chdir(cur)
+
+    def test_2sz_constraint_honored_with_coulombintra(self):
+        solver = self._run_coulombintra_2sz4()
+        self.assertTrue(
+            np.isclose(solver.physics["Sz"], 2.0, rtol=0.0, atol=1.0e-8),
+            "converged Sz = {} but 2Sz = 4 was requested".format(
+                solver.physics["Sz"]))
+        self.assertTrue(
+            np.isclose(solver.physics["Ene"]["Total"], 0.21957524103017434,
+                       rtol=0.0, atol=1.0e-6),
+            "converged energy {} differs from the 2Sz-fixed reference".format(
+                solver.physics["Ene"]["Total"]))
+
+    def test_2sz_fixed_blocks_are_pure_spin(self):
+        solver = self._run_coulombintra_2sz4()
+        norb = solver.norb
+        for blk in solver.block_info:
+            blk = np.asarray(blk)
+            n_up = np.sum(blk < norb)
+            n_down = np.sum(blk >= norb)
+            self.assertTrue(
+                n_up == 0 or n_down == 0,
+                "2Sz-fixed mode produced a spin-mixed block: {}".format(blk))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uhfk_folding.py
+++ b/tests/test_uhfk_folding.py
@@ -20,6 +20,7 @@ class TestReshapeInteractionAccumulation(unittest.TestCase):
         solver.subshape = (1, 1, 1)
         solver.shape = (1, 1, 1)
         solver.norb_orig = 1
+        solver.norb_phys_orig = 1
         solver.param_ham_orig = {"Geometry": {"norb": 1}}
         return solver
 

--- a/tests/test_uhfk_so_sublattice_interaction.py
+++ b/tests/test_uhfk_so_sublattice_interaction.py
@@ -1,0 +1,132 @@
+"""Regression test: UHFk spin-orbital + sublattice + two-body interaction.
+
+In enable_spin_orbital mode the two-body interaction files use PHYSICAL
+orbital indices [0, norb/2), and _make_ham_inter sizes its tables with
+norb_phys = norb_phys_orig * subvol (layout a + norb_phys_orig * cellidx).
+The sublattice fold of the interaction terms must therefore use the
+physical-orbital stride norb_phys_orig, not the spin-orbital count
+norb_orig: folding with the wrong stride crashes with IndexError (subvol=2)
+or silently misplaces interaction terms.
+
+The check runs the full SCF with an on-site U and asserts the converged
+total energy is sublattice-invariant (SubShape [1,1,1] vs [2,1,1]), which
+holds because the zero initial Green keeps the trajectory symmetric.
+"""
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+
+def _write_inputs(d, norb_phys=1):
+    nso = 2 * norb_phys  # spin-orbital count (geometry norb in SO mode)
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("  1.0   0.0   0.0\n  0.0   1.0   0.0\n  0.0   0.0   1.0\n")
+        f.write("{}\n".format(nso))
+        for _ in range(nso):
+            f.write("   0.0   0.0   0.0\n")
+    rows = []
+    # inter-cell spin-diagonal hops in x for all SO states
+    for so in range(1, nso + 1):
+        rows.append((1, 0, 0, so, so, 1.0))
+        rows.append((-1, 0, 0, so, so, 1.0))
+    with open(os.path.join(d, "transfer.dat"), "w") as f:
+        f.write("Transfer SO\n{}\n1\n 1\n".format(nso))
+        for (rx, ry, rz, a, b, v) in rows:
+            f.write("  {:3d} {:3d} {:3d} {:3d} {:3d}  {:.6f}  0.0\n".format(
+                rx, ry, rz, a, b, v))
+    with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+        f.write("CoulombIntra\n{}\n1\n 1\n".format(norb_phys))
+        for p in range(1, norb_phys + 1):
+            f.write("   0    0    0  {0:3d}  {0:3d}   2.000000   0.0\n".format(p))
+
+
+def _run_energy(d, subshape, cellshape, norb_phys):
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.uhfk as uhfk_module
+
+    info_mode = {
+        'mode': 'UHFk',
+        'param': {'Ncond': 2 * norb_phys, 'T': 0.1, 'CellShape': cellshape,
+                  'SubShape': subshape, 'IterationMax': 500, 'EPS': 10,
+                  'Mix': 0.5, 'RndSeed': 1},
+        'enable_spin_orbital': True,
+    }
+    info_input = {
+        'path_to_input': d,
+        'interaction': {'path_to_input': d, 'Geometry': 'geom.dat',
+                        'Transfer': 'transfer.dat',
+                        'CoulombIntra': 'coulombintra.dat'},
+    }
+    read_io = read_input_k.QLMSkInput(info_input)
+    info_log = {"print_level": 0, "print_step": 100}
+    solver = uhfk_module.UHFk(read_io.get_param("ham"), info_log, info_mode)
+    out = tempfile.mkdtemp(prefix="uhfk_so_out_")
+    try:
+        solver.solve(read_io.get_param("green"), out)
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+    return solver.physics["Ene"]["Total"].real
+
+
+class TestUHFkSOSublatticeInteraction(unittest.TestCase):
+    def _check_invariant(self, norb_phys, cellshape, subshape):
+        d = tempfile.mkdtemp(prefix="uhfk_so_int_")
+        try:
+            _write_inputs(d, norb_phys=norb_phys)
+            e1 = _run_energy(d, [1, 1, 1], cellshape, norb_phys)
+            e2 = _run_energy(d, subshape, cellshape, norb_phys)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+        self.assertTrue(
+            np.isclose(e1, e2, rtol=0.0, atol=1e-8),
+            "SO+interaction energy must be sublattice-invariant: "
+            "E[1,1,1]={} vs E{}={}".format(e1, subshape, e2))
+
+    def test_energy_invariant_1orb_subvol2(self):
+        self._check_invariant(norb_phys=1, cellshape=[4, 1, 1],
+                              subshape=[2, 1, 1])
+
+    def test_energy_invariant_2orb_subvol2(self):
+        self._check_invariant(norb_phys=2, cellshape=[4, 1, 1],
+                              subshape=[2, 1, 1])
+
+
+class TestUHFkSORejects2Sz(unittest.TestCase):
+    def test_2sz_fixed_rejected_in_spin_orbital_mode(self):
+        """Sz is not a good quantum number when spin is folded into the
+        orbital index, so a fixed 2Sz cannot be enforced: block detection
+        would silently assign the total Ncond to the spin-mixed blocks and
+        ignore the constraint.  Fail fast instead."""
+        import hwave.qlmsio.read_input_k as read_input_k
+        import hwave.solver.uhfk as uhfk_module
+
+        d = tempfile.mkdtemp(prefix="uhfk_so_2sz_")
+        try:
+            _write_inputs(d, norb_phys=1)
+            info_mode = {
+                'mode': 'UHFk',
+                'param': {'Ncond': 2, '2Sz': 0, 'T': 0.1,
+                          'CellShape': [4, 1, 1], 'IterationMax': 100,
+                          'EPS': 8, 'Mix': 0.5, 'RndSeed': 1},
+                'enable_spin_orbital': True,
+            }
+            info_input = {
+                'path_to_input': d,
+                'interaction': {'path_to_input': d, 'Geometry': 'geom.dat',
+                                'Transfer': 'transfer.dat',
+                                'CoulombIntra': 'coulombintra.dat'},
+            }
+            read_io = read_input_k.QLMSkInput(info_input)
+            info_log = {"print_level": 0, "print_step": 100}
+            with self.assertRaises(ValueError):
+                uhfk_module.UHFk(read_io.get_param("ham"), info_log,
+                                 info_mode)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uhfr_block_occupation.py
+++ b/tests/test_uhfr_block_occupation.py
@@ -1,0 +1,214 @@
+"""Regression test: UHFr block splitting must fill states by energy.
+
+When block detection splits a spin sector into disconnected sub-blocks, the
+electrons of that sector must still occupy the lowest eigenvalues of the
+whole sector (a single Fermi level per sector), not a per-sub-block quota.
+
+System: 3 sites, no interaction.
+  site 0: on-site energy +10 (isolated)
+  sites 1,2: on-site energy -10, hopping matrix element -1 (levels -11, -9)
+Ncond = 2, 2Sz = 2, T = 0: both electrons are spin-up and must occupy the
+levels -11 and -9, giving total energy -20.  A size-proportional split
+instead pins one electron on the +10 site (energy -1).
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlms
+
+
+def _write_trans(filename):
+    # H = - sum t_{isjt} c^dag_{is} c_{jt}  (Transfer coeff = -1)
+    rows = []
+    for s in range(2):
+        rows.append((0, s, 0, s, -10.0))   # on-site +10
+        rows.append((1, s, 1, s, +10.0))   # on-site -10
+        rows.append((2, s, 2, s, +10.0))   # on-site -10
+        rows.append((1, s, 2, s, +1.0))    # hop -1
+        rows.append((2, s, 1, s, +1.0))
+    with open(filename, "w") as f:
+        f.write("========================\n")
+        f.write("NTransfer {}\n".format(len(rows)))
+        f.write("========================\n")
+        f.write("========i_j_s_tijs======\n")
+        f.write("========================\n")
+        for i, s, j, t, v in rows:
+            f.write("{} {} {} {} {:.12f} 0.0\n".format(i, s, j, t, v))
+
+
+def _read_energy(filename):
+    tbl = {}
+    with open(filename, "r") as f:
+        for line in f.read().splitlines():
+            if "=" in line:
+                k, v = line.split("=")
+                tbl[k.strip().lower()] = float(v)
+    return tbl
+
+
+class TestUHFr2SzSpinFlipRejected(unittest.TestCase):
+    def test_spin_flip_transfer_with_fixed_2sz_raises(self):
+        """A one-body spin-flip term breaks Sz conservation, so a fixed 2Sz
+        is ill-defined.  UHFk rejects it; UHFr must too (previously the
+        cross-spin Hamiltonian entries were silently zeroed every SCF step,
+        so the two solvers disagreed on the same input, one of them
+        silently)."""
+        cur = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            try:
+                rows = []
+                for s in range(2):
+                    rows.append((0, s, 1, s, 1.0))
+                    rows.append((1, s, 0, s, 1.0))
+                # spin-flip on site 0: up <-> down
+                rows.append((0, 0, 0, 1, 0.3))
+                rows.append((0, 1, 0, 0, 0.3))
+                with open("trans.def", "w") as f:
+                    f.write("========================\n")
+                    f.write("NTransfer {}\n".format(len(rows)))
+                    f.write("========================\n")
+                    f.write("========i_j_s_tijs======\n")
+                    f.write("========================\n")
+                    for i, s, j, t, v in rows:
+                        f.write("{} {} {} {} {:.12f} 0.0\n".format(
+                            i, s, j, t, v))
+                params = {
+                    "log": {"print_level": 1, "print_step": 1},
+                    "mode": {
+                        "mode": "UHFr",
+                        "param": {
+                            "Nsite": 2,
+                            "Ncond": 2,
+                            "2Sz": 0,
+                            "IterationMax": 100,
+                            "EPS": 8,
+                            "Mix": 0.5,
+                            "RndSeed": 123456789,
+                            "T": 0.0,
+                        },
+                    },
+                    "file": {
+                        "input": {
+                            "path_to_input": "",
+                            "interaction": {"Trans": "trans.def"},
+                        },
+                        "output": {
+                            "path_to_output": "output",
+                            "energy": "energy.dat",
+                        },
+                    },
+                }
+                with self.assertRaises(ValueError):
+                    hwave.qlms.run(input_dict=params)
+            finally:
+                os.chdir(cur)
+
+
+class TestUHFr2SzNoiseTolerated(unittest.TestCase):
+    def test_noise_level_spin_flip_does_not_abort(self):
+        """Noise-level cross-spin entries (relative ~1e-11 of the hopping
+        scale) must be masked, not fatal: the guard compares against the
+        transfer scale."""
+        cur = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            try:
+                rows = []
+                for s in range(2):
+                    rows.append((0, s, 1, s, 1.0))
+                    rows.append((1, s, 0, s, 1.0))
+                # numerical-noise spin flip, 11 orders below the hopping
+                rows.append((0, 0, 0, 1, 1.0e-11))
+                rows.append((0, 1, 0, 0, 1.0e-11))
+                with open("trans.def", "w") as f:
+                    f.write("========================\n")
+                    f.write("NTransfer {}\n".format(len(rows)))
+                    f.write("========================\n")
+                    f.write("========i_j_s_tijs======\n")
+                    f.write("========================\n")
+                    for i, s, j, t, v in rows:
+                        f.write("{} {} {} {} {:.14g} 0.0\n".format(
+                            i, s, j, t, v))
+                params = {
+                    "log": {"print_level": 1, "print_step": 1},
+                    "mode": {
+                        "mode": "UHFr",
+                        "param": {
+                            "Nsite": 2,
+                            "Ncond": 2,
+                            "2Sz": 0,
+                            "IterationMax": 100,
+                            "EPS": 8,
+                            "Mix": 0.5,
+                            "RndSeed": 123456789,
+                            "T": 0.0,
+                        },
+                    },
+                    "file": {
+                        "input": {
+                            "path_to_input": "",
+                            "interaction": {"Trans": "trans.def"},
+                        },
+                        "output": {
+                            "path_to_output": "output",
+                            "energy": "energy.dat",
+                        },
+                    },
+                }
+                hwave.qlms.run(input_dict=params)  # must NOT raise
+                self.assertTrue(os.path.exists("output/energy.dat"))
+            finally:
+                os.chdir(cur)
+
+
+class TestUHFrBlockOccupation(unittest.TestCase):
+    def test_sector_electrons_fill_lowest_levels_across_sub_blocks(self):
+        cur = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            try:
+                _write_trans("trans.def")
+                params = {
+                    "log": {"print_level": 1, "print_step": 1},
+                    "mode": {
+                        "mode": "UHFr",
+                        "param": {
+                            "Nsite": 3,
+                            "Ncond": 2,
+                            "2Sz": 2,
+                            "IterationMax": 100,
+                            "EPS": 8,
+                            "Mix": 0.5,
+                            "RndSeed": 123456789,
+                            "T": 0.0,
+                        },
+                    },
+                    "file": {
+                        "input": {
+                            "path_to_input": "",
+                            "interaction": {"Trans": "trans.def"},
+                        },
+                        "output": {
+                            "path_to_output": "output",
+                            "energy": "energy.dat",
+                        },
+                    },
+                }
+                hwave.qlms.run(input_dict=params)
+                result = _read_energy("output/energy.dat")
+                self.assertTrue(
+                    np.isclose(result["energy_total"], -20.0,
+                               rtol=0.0, atol=1.0e-8),
+                    "expected ground-state energy -20.0 (both spin-up "
+                    "electrons in the low-energy sub-block), got {}".format(
+                        result["energy_total"]))
+            finally:
+                os.chdir(cur)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uhfr_fij_output.py
+++ b/tests/test_uhfr_fij_output.py
@@ -1,0 +1,86 @@
+"""Regression test: UHFr fij/eigen output after sub-block detection.
+
+save_results looks up the fixed green_list keys ('sz-free', 'spin-up',
+'spin-down').  Block detection must not rename these keys even when a block
+splits into disconnected sub-blocks, otherwise a standard mVMC workflow
+(Trans-only system, fij output) dies with KeyError after the SCF loop and
+the per-key eigen npz files change names.
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlms
+
+
+def _write_trans(filename):
+    # Two decoupled sites (diagonal on-site energies): the sz-free block
+    # splits into 4 disconnected sub-blocks.
+    rows = []
+    for s in range(2):
+        rows.append((0, s, 0, s, 1.0))    # on-site -1
+        rows.append((1, s, 1, s, -1.0))   # on-site +1
+    with open(filename, "w") as f:
+        f.write("========================\n")
+        f.write("NTransfer {}\n".format(len(rows)))
+        f.write("========================\n")
+        f.write("========i_j_s_tijs======\n")
+        f.write("========================\n")
+        for i, s, j, t, v in rows:
+            f.write("{} {} {} {} {:.12f} 0.0\n".format(i, s, j, t, v))
+
+
+class TestUHFrFijOutput(unittest.TestCase):
+    def test_fij_and_eigen_written_with_standard_keys(self):
+        cur = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            try:
+                _write_trans("trans.def")
+                params = {
+                    "log": {"print_level": 1, "print_step": 1},
+                    "mode": {
+                        "mode": "UHFr",
+                        "param": {
+                            "Nsite": 2,
+                            "Ncond": 2,
+                            "IterationMax": 100,
+                            "EPS": 8,
+                            "Mix": 0.5,
+                            "RndSeed": 123456789,
+                            "T": 0.0,
+                        },
+                    },
+                    "file": {
+                        "input": {
+                            "path_to_input": "",
+                            "interaction": {"Trans": "trans.def"},
+                        },
+                        "output": {
+                            "path_to_output": "output",
+                            "energy": "energy.dat",
+                            "eigen": "eigen.dat",
+                            "fij": "fij.dat",
+                        },
+                    },
+                }
+                hwave.qlms.run(input_dict=params)
+                self.assertTrue(
+                    os.path.exists("output/sz-free_fij.dat"),
+                    "fij output must be written under the 'sz-free' key")
+                self.assertTrue(
+                    os.path.exists("output/sz-free_eigen.dat.npz"),
+                    "eigen npz must keep the 'sz-free' key name")
+                # eigenvalues must cover the whole block, sorted ascending
+                data = np.load("output/sz-free_eigen.dat.npz")
+                ev = data["eigenvalue"]
+                self.assertEqual(ev.shape, (4,))
+                np.testing.assert_array_equal(ev, np.sort(ev))
+            finally:
+                os.chdir(cur)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wraparound_hopping.py
+++ b/tests/test_wraparound_hopping.py
@@ -1,0 +1,129 @@
+"""Regression test: wrap-around hopping must accumulate in H(k) scatter.
+
+On a small periodic lattice (e.g. L=2 in x), the hops R=+1 and R=-1 are
+physically distinct bonds that map onto the same array slot of the
+real-space transfer table (index -1 wraps to L-1).  The scatter
+``tab_r[R] = v`` silently overwrites one bond with the other, halving the
+band width: for a 1-orbital ring with t=1 the true H(k) = 2 t cos(k) gives
+bands {-2, +2} on the L=2 grid, not {-1, +1}.
+
+Both UHFk and RPA build H(k) this way; they must agree with the analytic
+result (and hence with each other).
+"""
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+
+def _write_l2_chain(d):
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("  1.0   0.0   0.0\n  0.0   1.0   0.0\n  0.0   0.0   1.0\n")
+        f.write("1\n   0.0   0.0   0.0\n")
+    with open(os.path.join(d, "transfer.dat"), "w") as f:
+        f.write("Transfer L2\n1\n2\n 1 1\n")
+        f.write("   1    0    0    1    1  1.000000  0.0\n")
+        f.write("  -1    0    0    1    1  1.000000  0.0\n")
+
+
+class TestWraparoundHoppingUHFk(unittest.TestCase):
+    def test_l2_ring_band_is_pm_2t(self):
+        import hwave.qlmsio.read_input_k as read_input_k
+        import hwave.solver.uhfk as uhfk_module
+
+        d = tempfile.mkdtemp(prefix="uhfk_l2_")
+        try:
+            _write_l2_chain(d)
+            info_mode = {
+                'mode': 'UHFk',
+                'param': {'Ncond': 1, 'T': 0.5, 'CellShape': [2, 1, 1],
+                          'IterationMax': 1, 'EPS': 8, 'Mix': 0.5,
+                          'RndSeed': 1,
+                          # +-1 hops on L=2 exceed the strict range check
+                          # (width 3 > 2); this test targets the wrap-around
+                          # accumulation of the relaxed path
+                          'trustme_interaction_range': True},
+            }
+            info_input = {
+                'path_to_input': d,
+                'interaction': {'path_to_input': d, 'Geometry': 'geom.dat',
+                                'Transfer': 'transfer.dat'},
+            }
+            read_io = read_input_k.QLMSkInput(info_input)
+            info_log = {"print_level": 0, "print_step": 100}
+            solver = uhfk_module.UHFk(read_io.get_param("ham"), info_log,
+                                      info_mode)
+            solver._make_ham_trans()
+            bands = np.sort(np.unique(np.round(
+                np.linalg.eigvalsh(solver.ham_trans).real.ravel(), 8)))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+        np.testing.assert_allclose(
+            bands, [-2.0, 2.0], atol=1e-8,
+            err_msg="L=2 ring with t=1: H(k)=2t cos(k) gives bands +-2")
+
+
+class TestWraparoundExternRPA(unittest.TestCase):
+    def test_extern_wraparound_bonds_are_summed(self):
+        from hwave.solver.rpa import Interaction
+
+        class _FakeLattice:
+            shape = (2, 1, 1)
+            nvol = 2
+
+        obj = object.__new__(Interaction)
+        obj.lattice = _FakeLattice()
+        obj.norb = 1
+        obj.enable_spin_orbital = False
+        obj.param_ham = {
+            "Transfer": {((1, 0, 0), (0, 0)): 1.0,
+                         ((-1, 0, 0), (0, 0)): 1.0},
+            "Extern": {((1, 0, 0), (0, 0)): 0.5,
+                       ((-1, 0, 0), (0, 0)): 0.5},
+        }
+        obj._make_ham_trans()
+
+        # R=+1 and R=-1 wrap onto slot 1 on an L=2 ring and must be summed
+        np.testing.assert_allclose(obj.ham_trans_r[1, 0, 0], 2.0, atol=1e-12)
+        np.testing.assert_allclose(
+            obj.ham_extern_r[1, 0, 0], 1.0, atol=1e-12,
+            err_msg="Extern wrap-around bonds must accumulate like Transfer")
+
+
+class TestWraparoundHoppingRPA(unittest.TestCase):
+    def test_l2_ring_band_is_pm_2t(self):
+        import hwave.qlmsio.read_input_k as read_input_k
+        import hwave.solver.rpa as solver_rpa
+
+        d = tempfile.mkdtemp(prefix="rpa_l2_")
+        try:
+            _write_l2_chain(d)
+            info_mode = {
+                'mode': 'RPA',
+                'param': {'T': 1.0, 'mu': 0.0, 'CellShape': [2, 1, 1],
+                          'Nmat': 16},
+                'calc_scheme': 'reduced',
+            }
+            info_input = {
+                'path_to_input': d,
+                'interaction': {'path_to_input': d, 'Geometry': 'geom.dat',
+                                'Transfer': 'transfer.dat'},
+            }
+            read_io = read_input_k.QLMSkInput(info_input)
+            solver = solver_rpa.RPA(read_io.get_param("ham"), {}, info_mode)
+            hq = solver.ham_info.ham_trans_q
+            bands = np.sort(np.unique(np.round(
+                np.linalg.eigvalsh(hq).real.ravel(), 8)))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+        np.testing.assert_allclose(
+            bands, [-2.0, 2.0], atol=1e-8,
+            err_msg="L=2 ring with t=1: H(k)=2t cos(k) gives bands +-2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A 5-round adversarial multi-agent code review of `develop` (vs `main`) found 10 verified defects; fixing them and re-reviewing the fixes surfaced further issues, converging after 5 rounds. This PR fixes all of them, TDD-style (every fix has a regression test that failed before the fix). Test count grows 527 → 576, all passing.

## Solver core (UHFk / UHFr)

- **UHFk silently ignored a fixed `2Sz`**: block detection merged the up/down sectors into one mu-group for any Fock-connected interaction. Reproduced on `tests/uhfk/coulombintra` with `2Sz = 4`: converged to Sz=3.0 / E=3.5 instead of the correct Sz=2.0 / E=0.2196 (main's values). 2Sz-fixed mode now masks the interaction-derived cross-spin connectivity (matching main's spin-diagonal treatment).
- **UHFr filled sub-blocks proportionally to size instead of by energy**, pinning electrons in high-energy sub-blocks (3-site repro: E=−1.0 instead of −20.0). Sub-blocks are now an internal detail of `_diag()`; each green_list block keeps one Fermi level. This also fixes the `fij`/eigen output `KeyError` caused by the renamed block keys.
- **Consistent fail-fast for ill-defined inputs**: spin-flip one-body terms + fixed 2Sz are rejected in both solvers (shared `solver_base` helper, relative 1e-8 threshold so k-summed numerical noise is masked with a warning, not fatal); `2Sz` + `enable_spin_orbital` is rejected at init.
- **UHFk SO+sublattice interaction fold used the spin-orbital stride** (IndexError for subvol=2, silently misplaced terms otherwise); now folds with the physical stride, and the whole sublattice fold (geometry + R-space tables) lives in a new shared `solver/fold.py` used by both UHFk and RPA — the two hand-mirrored copies had already diverged twice.
- **Wrap-around hopping** (R and R±L on small lattices) was silently overwritten in the consumer scatters (numpy negative indexing); all scatters now accumulate. L=2 ring with t=1 now gives the correct ±2t bands in both UHFk and RPA.

## RPA / FLEX

- **FLEX spin-diag self-energy paired the up-spin vertex with BOTH spin blocks** — wrong self-energy/chiq for any spin-polarized system. Block g now pairs with V_eff spin slot (g, g).
- **The combined `Coulomb` keyword was silently dropped by RPA/FLEX** (and hwave_sc); it is now decomposed via the shared `wan90.split_coulomb` everywhere.
- **RPA sublattice fold dropped wrap-around collisions** (overwrite instead of sum), making H0(k) inconsistent with UHFk for the identical model.
- **FLEX chi0q.npz lacked the `index_convention` tag** (SO-mode validators falsely rejected valid files) and carried a `freq_index` that did not describe the stored axis.
- **chi0q/chiq re-saved from a `chi0q_init` warm start were stamped with the current run's frequency metadata**, mislabeling the inherited axis; the producing file's metadata is now passed through.
- Removed a leftover dead gather in `RPA._reshape_green` that allocated an O(Nvol·norb⁴·ns²) temporary (tens of GB for realistic multi-orbital sublattice runs).

## hwave_sc (Eliashberg)

- **The "static" chi0q/chiq slice was hard-coded at the axis center**, which is wrong for any `matsubara_frequency`-restricted file. RPA/FLEX now record the producing run's grid size (`nmat`) in their npz outputs, and hwave_sc resolves the zero-bosonic-frequency position with an explicit contract: file metadata is authoritative; metadata-less/inconsistent legacy files use the center of the axis actually sliced (previous behavior); every genuinely ambiguous legacy case fails with instructions instead of silently building the pairing vertex from a finite frequency.
- The 6D reference-format input path no longer misreads its frequency axis, and the `Coulomb` keyword is supported.

## Tests

Every fix has a dedicated regression test (12 new test files); tests exercising the previous buggy contracts were updated to the corrected semantics. Full suite: **576 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)