### PR TITLE
fix(flex): Matsubara tail (coeff_tail) + self-consistent μ; N/Sz output

### DIFF
--- a/docs/en/source/flex/sample/1orb/input.toml
+++ b/docs/en/source/flex/sample/1orb/input.toml
@@ -30,3 +30,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/en/source/flex/sample/2orb/input.toml
+++ b/docs/en/source/flex/sample/2orb/input.toml
@@ -32,3 +32,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/en/source/flex/sample/iron_2orb/input.toml
+++ b/docs/en/source/flex/sample/iron_2orb/input.toml
@@ -33,3 +33,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/en/source/flex/sample/iron_2orb_general/input.toml
+++ b/docs/en/source/flex/sample/iron_2orb_general/input.toml
@@ -34,3 +34,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -266,6 +266,19 @@ in the ``output`` directory:
 - ``chiq.npz``: Combined susceptibility file
 - ``sigma.npz``: Self-energy :math:`\Sigma(\mathbf{k}, i\omega_n)`
 - ``green.npz``: Dressed Green's function :math:`G(\mathbf{k}, i\omega_n)`
+- ``energy.dat``: Text file with the particle number ``NCond``, spin
+  ``Sz``, and the converged ``ChemicalPotential`` :math:`\mu`.
+
+.. note::
+
+   The ``energy.dat`` output (enabled by the ``energy`` key in
+   ``[file.output]``) is written from the final dressed Green function.  In
+   the fixed-:math:`\mu` mode (specify ``mu`` instead of ``filling`` /
+   ``Ncond``) its ``NCond`` line gives the particle number at that
+   :math:`\mu`, so running the solver at several fixed :math:`\mu` values
+   traces the :math:`\mu`-:math:`N` relation.  ``Sz`` is zero for a
+   paramagnetic (spin-free) calculation and non-zero only for
+   spin-dependent (spin-diagonal / spinful) runs.
 
 **Spin susceptibility** :math:`\chi_s(\mathbf{q}, i\nu_0)`:
 

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -203,7 +203,16 @@ Key parameters:
 - ``T = 0.5``: Temperature.
 - ``CellShape = [8, 8, 1]``: 8 x 8 k-point mesh for a 2D system.
 - ``Nmat = 64``: Number of Matsubara frequencies.
-- ``filling = 0.5``: Half filling.
+- ``filling = 0.5``: target electron number per site (half filling). Specifying
+  ``filling`` (or ``Ncond``) makes FLEX re-solve the chemical potential
+  :math:`\mu` from the dressed Green's function at every SCF iteration so the
+  filling is conserved as the self-energy grows; specifying ``mu`` instead holds
+  it fixed.
+- ``coeff_tail = 1.0`` (optional): high-frequency tail-acceleration coefficient
+  for the Matsubara sums. ``coeff_tail = 1`` matches the exact
+  :math:`1/(i\omega_n)` coefficient of :math:`G` (unitarity), so it accelerates
+  convergence in ``Nmat`` without biasing the result. Also supported by the RPA
+  solver.
 - ``IterationMax = 100``: Maximum number of SCF iterations.
 - ``Mix = 0.2``: Mixing parameter for self-energy update
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`).

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -197,6 +197,17 @@ Key parameters:
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`).
 - ``EPS = 6``: Convergence criterion :math:`10^{-6}`.
 
+.. note::
+
+   When the electron number is fixed through ``filling`` / ``Ncond`` (rather than
+   a fixed ``mu``), FLEX re-solves the chemical potential :math:`\mu` from the
+   *dressed* Green function at every SCF iteration so that the target filling is
+   maintained self-consistently as the self-energy grows.  Consequently the
+   converged :math:`\mu` (and the exact iteration count) differ from a
+   calculation that keeps :math:`\mu` fixed at its non-interacting value.  The
+   iteration counts and convergence values shown below are illustrative and may
+   vary slightly with the version and platform.
+
 **Geometry** (``geom.dat``):
 
 .. literalinclude:: ../sample/1orb/geom.dat
@@ -230,15 +241,16 @@ The output log shows the SCF convergence:
 .. code-block:: text
 
     FLEX iteration 1/100
+    FLEX._find_mu_dressed: mu = -0.398893
       convergence: |dSigma|/|Sigma| = 1.000e+00
     FLEX iteration 2/100
-      convergence: |dSigma|/|Sigma| = 9.827e-01
+    FLEX._find_mu_dressed: mu = -0.291966
+      convergence: |dSigma|/|Sigma| = 9.876e-01
     ...
-    FLEX iteration 72/100
-      convergence: |dSigma|/|Sigma| = 1.008e-06
-    FLEX iteration 73/100
-      convergence: |dSigma|/|Sigma| = 8.292e-07
-    FLEX converged after 73 iterations
+    FLEX iteration 64/100
+    FLEX._find_mu_dressed: mu = -0.249146
+      convergence: |dSigma|/|Sigma| = 9.241e-07
+    FLEX converged after 64 iterations
 
 
 Results

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -32,6 +32,18 @@ until convergence:
    FFT convolution.
 7. Check convergence; if not converged, go to step 1.
 
+.. note::
+
+   When the electron number is fixed through ``filling`` / ``Ncond`` (rather
+   than a fixed ``mu``), FLEX re-solves the chemical potential :math:`\mu` from
+   the *dressed* Green function at every SCF iteration so that the target
+   filling is maintained self-consistently as the self-energy grows.  A
+   ``FLEX._find_mu_dressed: mu = ...`` line is therefore printed each iteration,
+   and the converged :math:`\mu` (and the exact iteration count) differ from a
+   calculation that keeps :math:`\mu` fixed at its non-interacting value.  All
+   iteration counts and convergence values shown in this tutorial are
+   illustrative and may vary slightly with the version and platform.
+
 
 Theory
 ----------------------------
@@ -196,17 +208,6 @@ Key parameters:
 - ``Mix = 0.2``: Mixing parameter for self-energy update
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`).
 - ``EPS = 6``: Convergence criterion :math:`10^{-6}`.
-
-.. note::
-
-   When the electron number is fixed through ``filling`` / ``Ncond`` (rather than
-   a fixed ``mu``), FLEX re-solves the chemical potential :math:`\mu` from the
-   *dressed* Green function at every SCF iteration so that the target filling is
-   maintained self-consistently as the self-energy grows.  Consequently the
-   converged :math:`\mu` (and the exact iteration count) differ from a
-   calculation that keeps :math:`\mu` fixed at its non-interacting value.  The
-   iteration counts and convergence values shown below are illustrative and may
-   vary slightly with the version and platform.
 
 **Geometry** (``geom.dat``):
 
@@ -382,15 +383,18 @@ Run the calculation
 .. code-block:: text
 
     FLEX iteration 1/200
+    FLEX._find_mu_dressed: mu = 0.000000
       convergence: |dSigma|/|Sigma| = 1.000e+00
     FLEX iteration 2/200
+    FLEX._find_mu_dressed: mu = 0.000000
       convergence: |dSigma|/|Sigma| = 3.587e-01
     ...
-    FLEX iteration 58/200
-      convergence: |dSigma|/|Sigma| = 1.188e-06
     FLEX iteration 59/200
-      convergence: |dSigma|/|Sigma| = 9.684e-07
+    FLEX._find_mu_dressed: mu = 0.000000
+      convergence: |dSigma|/|Sigma| = 8.870e-07
     FLEX converged after 59 iterations
+
+(This is a particle-hole symmetric half-filled model, so :math:`\mu = 0`.)
 
 
 Results
@@ -631,15 +635,16 @@ Run the calculation
 .. code-block:: text
 
     FLEX iteration 1/200
+    FLEX._find_mu_dressed: mu = 1.562757
       convergence: |dSigma|/|Sigma| = 1.000e+00
     FLEX iteration 2/200
+    FLEX._find_mu_dressed: mu = 1.551623
       convergence: |dSigma|/|Sigma| = 7.139e-01
     ...
     FLEX iteration 62/200
-      convergence: |dSigma|/|Sigma| = 1.055e-06
-    FLEX iteration 63/200
-      convergence: |dSigma|/|Sigma| = 8.419e-07
-    FLEX converged after 63 iterations
+    FLEX._find_mu_dressed: mu = 1.512917
+      convergence: |dSigma|/|Sigma| = 8.716e-07
+    FLEX converged after 62 iterations
 
 
 Results

--- a/docs/en/source/index.rst
+++ b/docs/en/source/index.rst
@@ -15,6 +15,7 @@ Contents
    uhfr/uhfr-index
    uhfk/uhfk-index
    rpa/rpa-index
+   flex/flex-index
    algorithm/al-index
    acknowledgement
    appendix/app-index

--- a/docs/en/source/rpa/filespecification/config/index_config.rst
+++ b/docs/en/source/rpa/filespecification/config/index_config.rst
@@ -188,6 +188,7 @@ Parameters
   **Description :**
   This parameter specifies the magnitude of the correction when correcting the tails of the Fourier transformation.
   After Fourier transforming the diagonalized one-body Green function to the imaginary time representation by subtracting :math:`\texttt{coeff\_tail}/(i \omega_n)`, the term :math:`-\beta/2\cdot\texttt{coeff\_tail}` is added to the one-body Green function.
+  In the FLEX solver the same tail treatment is applied to the *dressed* Green function before the bare susceptibility :math:`\chi_0(q)` is computed, so that ``coeff_tail`` accelerates the frequency summation without changing the physical result. (The FLEX self-energy convolution keeps the full Green function and is unaffected.)
 
 - ``matsubara_frequency``
 

--- a/docs/ja/source/flex/sample/1orb/input.toml
+++ b/docs/ja/source/flex/sample/1orb/input.toml
@@ -30,3 +30,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/ja/source/flex/sample/2orb/input.toml
+++ b/docs/ja/source/flex/sample/2orb/input.toml
@@ -32,3 +32,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/ja/source/flex/sample/iron_2orb/input.toml
+++ b/docs/ja/source/flex/sample/iron_2orb/input.toml
@@ -33,3 +33,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/ja/source/flex/sample/iron_2orb_general/input.toml
+++ b/docs/ja/source/flex/sample/iron_2orb_general/input.toml
@@ -34,3 +34,4 @@
   chiq = "chiq"
   sigma = "sigma"
   green = "green"
+  energy = "energy.dat"

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -186,6 +186,15 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`)
 - ``EPS = 6``: 収束判定基準 :math:`10^{-6}`
 
+.. note::
+
+   電子数を ``filling`` / ``Ncond`` で固定する場合（``mu`` を固定しない場合）、FLEX
+   は各SCF反復で化学ポテンシャル :math:`\mu` を*ドレスされた*Green関数から解き直し、
+   自己エネルギーが成長しても目標フィリングが自己無撞着に保たれるようにします。この
+   ため、収束した :math:`\mu`（および正確な反復回数）は、:math:`\mu` を非相互作用値に
+   固定した計算とは異なります。以下に示す反復回数・収束値は例示であり、バージョンや
+   環境によって多少変わり得ます。
+
 **格子情報** (``geom.dat``):
 
 .. literalinclude:: ../sample/1orb/geom.dat
@@ -218,15 +227,16 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 .. code-block:: text
 
     FLEX iteration 1/100
+    FLEX._find_mu_dressed: mu = -0.398893
       convergence: |dSigma|/|Sigma| = 1.000e+00
     FLEX iteration 2/100
-      convergence: |dSigma|/|Sigma| = 9.827e-01
+    FLEX._find_mu_dressed: mu = -0.291966
+      convergence: |dSigma|/|Sigma| = 9.876e-01
     ...
-    FLEX iteration 72/100
-      convergence: |dSigma|/|Sigma| = 1.008e-06
-    FLEX iteration 73/100
-      convergence: |dSigma|/|Sigma| = 8.292e-07
-    FLEX converged after 73 iterations
+    FLEX iteration 64/100
+    FLEX._find_mu_dressed: mu = -0.249146
+      convergence: |dSigma|/|Sigma| = 9.241e-07
+    FLEX converged after 64 iterations
 
 
 計算結果

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -251,6 +251,17 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 - ``chiq.npz``: 結合感受率ファイル
 - ``sigma.npz``: 自己エネルギー :math:`\Sigma(\mathbf{k}, i\omega_n)`
 - ``green.npz``: ドレスドグリーン関数 :math:`G(\mathbf{k}, i\omega_n)`
+- ``energy.dat``: 粒子数 ``NCond``、スピン ``Sz``、収束した化学ポテンシャル
+  ``ChemicalPotential`` :math:`\mu` を記載したテキストファイル。
+
+.. note::
+
+   ``energy.dat`` 出力（``[file.output]`` の ``energy`` キーで有効化）は最終的な
+   ドレスドグリーン関数から書き出されます。:math:`\mu` 固定モード（``filling`` /
+   ``Ncond`` の代わりに ``mu`` を指定）では ``NCond`` 行がその :math:`\mu` における
+   粒子数を与えるので、複数の固定 :math:`\mu` で計算を実行すれば
+   :math:`\mu`-:math:`N` 関係が得られます。``Sz`` は常磁性（spin-free）計算では 0
+   となり、スピン依存（spin-diagonal / spinful）計算でのみ非ゼロになります。
 
 **スピン感受率** :math:`\chi_s(\mathbf{q}, i\nu_0)`:
 

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -190,7 +190,14 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 - ``T = 0.5``: 温度
 - ``CellShape = [8, 8, 1]``: 2D系の 8 x 8 k点メッシュ
 - ``Nmat = 64``: 松原周波数の数
-- ``filling = 0.5``: ハーフフィリング
+- ``filling = 0.5``: 1サイトあたりの目標電子数（ハーフフィリング）。``filling``
+  （または ``Ncond``）を指定すると、FLEX は各SCF反復でドレスドGreen関数から化学
+  ポテンシャル :math:`\mu` を解き直し、自己エネルギーが成長してもフィリングを保存
+  します。代わりに ``mu`` を指定した場合は固定されます。
+- ``coeff_tail = 1.0``（省略可）: 松原和の高振動数テール加速係数。``coeff_tail = 1``
+  は :math:`G` の厳密な :math:`1/(i\omega_n)` 係数（ユニタリ性）に一致するため、
+  結果を歪めずに ``Nmat`` に対する収束を加速します。RPAソルバーでもサポートされて
+  います。
 - ``IterationMax = 100``: SCF反復の最大回数
 - ``Mix = 0.2``: 自己エネルギー更新の混合パラメータ
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`)

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -26,6 +26,16 @@ FLEXは以下の自己無撞着ループを収束まで繰り返します:
 6. FFT畳み込みにより自己エネルギー :math:`\Sigma(\mathbf{k}, i\omega_n)` を計算
 7. 収束判定; 未収束なら1に戻る
 
+.. note::
+
+   電子数を ``filling`` / ``Ncond`` で固定する場合（``mu`` を固定しない場合）、FLEX
+   は各SCF反復で化学ポテンシャル :math:`\mu` を*ドレスされた*Green関数から解き直し、
+   自己エネルギーが成長しても目標フィリングが自己無撞着に保たれるようにします。この
+   ため各反復で ``FLEX._find_mu_dressed: mu = ...`` の行が出力され、収束した
+   :math:`\mu`（および正確な反復回数）は :math:`\mu` を非相互作用値に固定した計算とは
+   異なります。本チュートリアルに示す反復回数・収束値はすべて例示であり、バージョンや
+   環境によって多少変わり得ます。
+
 
 理論
 ----------------------------
@@ -185,15 +195,6 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 - ``Mix = 0.2``: 自己エネルギー更新の混合パラメータ
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`)
 - ``EPS = 6``: 収束判定基準 :math:`10^{-6}`
-
-.. note::
-
-   電子数を ``filling`` / ``Ncond`` で固定する場合（``mu`` を固定しない場合）、FLEX
-   は各SCF反復で化学ポテンシャル :math:`\mu` を*ドレスされた*Green関数から解き直し、
-   自己エネルギーが成長しても目標フィリングが自己無撞着に保たれるようにします。この
-   ため、収束した :math:`\mu`（および正確な反復回数）は、:math:`\mu` を非相互作用値に
-   固定した計算とは異なります。以下に示す反復回数・収束値は例示であり、バージョンや
-   環境によって多少変わり得ます。
 
 **格子情報** (``geom.dat``):
 
@@ -363,15 +364,18 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 .. code-block:: text
 
     FLEX iteration 1/200
+    FLEX._find_mu_dressed: mu = 0.000000
       convergence: |dSigma|/|Sigma| = 1.000e+00
     FLEX iteration 2/200
+    FLEX._find_mu_dressed: mu = 0.000000
       convergence: |dSigma|/|Sigma| = 3.587e-01
     ...
-    FLEX iteration 58/200
-      convergence: |dSigma|/|Sigma| = 1.188e-06
     FLEX iteration 59/200
-      convergence: |dSigma|/|Sigma| = 9.684e-07
+    FLEX._find_mu_dressed: mu = 0.000000
+      convergence: |dSigma|/|Sigma| = 8.870e-07
     FLEX converged after 59 iterations
+
+（粒子ホール対称なハーフフィリング模型のため :math:`\mu = 0` となります。）
 
 
 計算結果
@@ -611,15 +615,16 @@ Fe-As面を正方格子（1-Fe単位胞）上の :math:`d_{xz}` と
 .. code-block:: text
 
     FLEX iteration 1/200
+    FLEX._find_mu_dressed: mu = 1.562757
       convergence: |dSigma|/|Sigma| = 1.000e+00
     FLEX iteration 2/200
+    FLEX._find_mu_dressed: mu = 1.551623
       convergence: |dSigma|/|Sigma| = 7.139e-01
     ...
     FLEX iteration 62/200
-      convergence: |dSigma|/|Sigma| = 1.055e-06
-    FLEX iteration 63/200
-      convergence: |dSigma|/|Sigma| = 8.419e-07
-    FLEX converged after 63 iterations
+    FLEX._find_mu_dressed: mu = 1.512917
+      convergence: |dSigma|/|Sigma| = 8.716e-07
+    FLEX converged after 62 iterations
 
 
 計算結果

--- a/docs/ja/source/index.rst
+++ b/docs/ja/source/index.rst
@@ -16,6 +16,7 @@ Contents
    uhfr/uhfr-index
    uhfk/uhfk-index
    rpa/rpa-index
+   flex/flex-index
    algorithm/al-index
    acknowledgement
    appendix/app-index

--- a/docs/ja/source/rpa/filespecification/config/index_config.rst
+++ b/docs/ja/source/rpa/filespecification/config/index_config.rst
@@ -149,6 +149,7 @@ TOML形式
 
   **説明 :** フーリエ変換の尾部の補正を行う際の、補正の大きさを指定します。
   対角化された一体Green関数に対して :math:`\texttt{coeff\_tail}/(i \omega_n)` を引き虚時間表示にフーリエ変換した後、:math:`-\beta/2\cdot\texttt{coeff\_tail}` を付加します。
+  FLEXソルバーでは、裸の感受率 :math:`\chi_0(q)` を計算する前に同じ尾部補正をドレスされたGreen関数に対して適用します。これにより ``coeff_tail`` は物理的な結果を変えずに振動数和の収束を加速します（FLEXの自己エネルギー畳み込みは完全なGreen関数を用いるため影響を受けません）。
 
 - ``matsubara_frequency``
 

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -339,6 +339,14 @@ class FLEX(RPA):
             self.mu = mu
         green_kw = self._calc_dressed_green(beta, mu, sigma)
 
+        # Physical observables from the final (consistent) dressed G: particle
+        # number N and spin Sz.  In fixed-mu mode this N is the mu-N single
+        # point; in calc_mu mode it equals the target Ncond.
+        physics = self._calc_physics_dressed(green_kw, mu, beta)
+        self.physics = physics
+        logger.info("FLEX: NCond = {}, Sz = {}, ChemicalPotential = {}".format(
+            physics["NCond"], physics["Sz"], physics["mu"]))
+
         # Store results
         self.sigma = sigma
         self.green_kw = green_kw
@@ -351,6 +359,7 @@ class FLEX(RPA):
         green_info["chiq_c"] = chi_c
         green_info["sigma"] = sigma
         green_info["green"] = green_kw
+        green_info["physics"] = physics
 
         logger.info("End FLEX calculations")
 
@@ -465,6 +474,107 @@ class FLEX(RPA):
         w1 = np.where(mask, w, 0.0)
         v1 = 1.0 / (1.0 + np.exp(w1))
         return np.where(mask, v1, 0.0)
+
+    @do_profile
+    def _calc_occupation_dressed(self, green_kw, mu, beta):
+        r"""k-summed occupation per (spin block, orbital) from the dressed G.
+
+        The per-orbital analogue of :meth:`_calc_number_dressed`: the same
+        tail-subtracted Matsubara sum, resolved on each orbital ``a`` instead of
+        traced.  The non-interacting reference is projected onto the orbital
+        basis with the H0 eigenvectors ``V``::
+
+            n_a(k) = sum_j |V_aj|^2 f(eps_j(k) - mu)
+                     + (1/beta) sum_n [ G_aa(k,iwn) - G0_aa(k,iwn) ]
+            G0_aa(k,iwn) = sum_j |V_aj|^2 / (iwn + mu - eps_j(k))
+
+        Summing the result over orbitals recovers ``_calc_number_dressed`` (by
+        unitarity ``sum_a |V_aj|^2 = 1``); it is split per orbital here so N and
+        Sz can be assembled from spin-resolved partial sums.
+
+        Parameters
+        ----------
+        green_kw : ndarray
+            Dressed Green's function, shape (nblock, nmat, nvol, nd_block, nd_block).
+        mu : float
+            Chemical potential.
+        beta : float
+            Inverse temperature.
+
+        Returns
+        -------
+        ndarray
+            Occupation summed over k, shape (nblock, nd_block).
+        """
+        nmat = self.nmat
+        ew = self.H0_eigenvalue                       # (nblock, nvol, nd_block)
+        ev = self.H0_eigenvector                      # (nblock, nvol, a, j)
+        vsq = np.abs(ev) ** 2                          # |V_aj|^2
+
+        # bare per-orbital reference: n0_a = sum_j |V_aj|^2 f(eps_j - mu)
+        f = self._fermi_occupation(1.0 / beta, mu, ew)     # (nblock, nvol, j)
+        n0 = np.einsum('bkaj,bkj->bka', vsq, f)            # (nblock, nvol, a)
+
+        # dressed correction (1/beta) sum_n [G_aa - G0_aa]
+        iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        g_aa = np.einsum('bnkaa->bnka', green_kw)          # (nblock, nmat, nvol, a)
+        denom = ((1j * iomega)[np.newaxis, :, np.newaxis, np.newaxis]
+                 + (mu - ew)[:, np.newaxis, :, :])         # (nblock, nmat, nvol, j)
+        g0_aa = np.einsum('bkaj,bnkj->bnka', vsq, 1.0 / denom)
+        corr = (g_aa - g0_aa).sum(axis=1) / beta           # sum over n -> (nblock, nvol, a)
+
+        nocc = n0 + corr.real
+        return nocc.sum(axis=1)                            # sum over k -> (nblock, nd_block)
+
+    @do_profile
+    def _calc_physics_dressed(self, green_kw, mu, beta):
+        """Assemble the particle number N and spin Sz from the dressed G.
+
+        Uses :meth:`_calc_occupation_dressed` and the FLEX spin-block orbital
+        ordering (``s*norb + a``).  Conventions per spin mode:
+
+        - spin-free (one block computed): ``N = 2 * sum(nocc)``, ``Sz = 0``.
+        - spin-diag (block 0 = up, block 1 = down):
+          ``N = N_up + N_down``, ``Sz = (N_up - N_down)/2``.
+        - spinful (single block, ``nd = 2*norb``, up = orbitals ``[0, norb)``,
+          down = ``[norb, 2*norb)``): ``N = sum(nocc)``,
+          ``Sz = (N_up - N_down)/2``.
+
+        Parameters
+        ----------
+        green_kw : ndarray
+            Dressed Green's function (nblock, nmat, nvol, nd_block, nd_block).
+        mu : float
+            Chemical potential.
+        beta : float
+            Inverse temperature.
+
+        Returns
+        -------
+        dict
+            ``{"NCond": N_total, "Sz": Sz, "mu": mu}`` (plain floats).
+        """
+        nocc = self._calc_occupation_dressed(green_kw, mu, beta)
+        norb = self.norb
+
+        if self.spin_mode == "spin-free":
+            n_total = 2.0 * nocc.sum()
+            sz = 0.0
+        elif self.spin_mode == "spin-diag":
+            n_up = nocc[0].sum()
+            n_down = nocc[1].sum()
+            n_total = n_up + n_down
+            sz = 0.5 * (n_up - n_down)
+        else:  # spinful: spin folded into the orbital index (spin-block order)
+            n_up = nocc[0, :norb].sum()
+            n_down = nocc[0, norb:].sum()
+            n_total = nocc.sum()
+            sz = 0.5 * (n_up - n_down)
+
+        return {"NCond": float(n_total.real if np.iscomplexobj(n_total)
+                               else n_total),
+                "Sz": float(sz.real if np.iscomplexobj(sz) else sz),
+                "mu": float(mu)}
 
     @do_profile
     def _matsubara_number_operator(self, sigma, beta):
@@ -1544,6 +1654,24 @@ class FLEX(RPA):
             logger.warning(
                 "matsubara_frequency is restricted but FLEX outputs always "
                 "hold the full frequency grid; the option is ignored.")
+
+        # Save physical observables (particle number, spin, chemical potential)
+        # as a plain-text energy file, mirroring UHFr/UHFk.  In fixed-mu mode
+        # the NCond line is the mu-N single point for the given mu.
+        if "energy" in info_outputfile:
+            physics = green_info.get("physics", getattr(self, "physics", None))
+            if physics is None:
+                logger.warning("save_results: no physics data to write to "
+                               "'{}'".format(info_outputfile["energy"]))
+            else:
+                file_name = os.path.join(path_to_output,
+                                         info_outputfile["energy"])
+                with open(file_name, "w") as fw:
+                    fw.write("NCond = {}\n".format(physics["NCond"]))
+                    fw.write("Sz = {}\n".format(physics["Sz"]))
+                    fw.write("ChemicalPotential = {}\n".format(physics["mu"]))
+                logger.info("save_results: save energy in file {}".format(
+                    file_name))
 
         # Save chi0q
         if "chi0q" in info_outputfile:

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -503,10 +503,11 @@ class FLEX(RPA):
         lam = np.linalg.eigvals(M)                            # (nb,nmat,nvol,nd)
         return lam, ew
 
-    def _number_from_eigs(self, lam, ew, mu, beta):
-        """Particle number N(mu) from precomputed ``M`` eigenvalues.
+    def _number_from_eigs(self, lam, ew, mu, beta, with_deriv=False):
+        """Particle number N(mu) (and optionally dN/dmu) from precomputed
+        ``M`` eigenvalues.
 
-        Cheap closure evaluated for every trial ``mu`` in the bisection:
+        Cheap closure evaluated for every trial ``mu`` in the mu search:
         identical formula and result as :meth:`_calc_number_dressed` (verified
         to machine precision in the tests), but reusing the eigenvalues from
         :meth:`_matsubara_number_operator` instead of re-inverting G::
@@ -514,6 +515,14 @@ class FLEX(RPA):
             N(mu) = sum_{block,k,a} f(eps_a - mu)
                     + (1/beta) sum_{k,n} [ sum_j 1/(lam_j + mu)
                                            - sum_a 1/(iwn + mu - eps_a) ]
+
+        Because ``sigma`` (hence ``lam``) is FIXED during the search, the
+        derivative is analytic and cheap to evaluate from the same
+        eigenvalues, which lets the search use Newton's method::
+
+            dN/dmu = sum_a (1/T) f_a (1 - f_a)
+                     + (1/beta) sum_{k,n} [ -sum_j 1/(lam_j + mu)^2
+                                            + sum_a 1/(iwn + mu - eps_a)^2 ]
 
         Parameters
         ----------
@@ -526,32 +535,57 @@ class FLEX(RPA):
             Trial chemical potential.
         beta : float
             Inverse temperature.
+        with_deriv : bool, optional
+            If True, return the tuple ``(N, dN/dmu)`` instead of ``N``.
 
         Returns
         -------
-        float
-            Particle number N(mu).
+        float or tuple of float
+            ``N(mu)``, or ``(N(mu), dN/dmu)`` when ``with_deriv`` is True.
         """
         nmat = self.nmat
-        n_ref = self._fermi_occupation(1.0 / beta, mu, ew).sum()
-
+        T = 1.0 / beta
         iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
-        trG = (1.0 / (lam + mu)).sum(axis=-1)                # (nb, nmat, nvol)
-        trG0 = (1.0 / ((1j * iomega)[np.newaxis, :, np.newaxis, np.newaxis]
-                       + (mu - ew)[:, np.newaxis, :, :])).sum(axis=-1)
-        corr = (trG - trG0).sum() / beta
-        return n_ref + corr.real
+
+        f = self._fermi_occupation(T, mu, ew)
+        n_ref = f.sum()
+
+        denomG = lam + mu                                    # (nb, nmat, nvol, nd)
+        denomG0 = ((1j * iomega)[np.newaxis, :, np.newaxis, np.newaxis]
+                   + (mu - ew)[:, np.newaxis, :, :])
+        trG = (1.0 / denomG).sum(axis=-1)                    # (nb, nmat, nvol)
+        trG0 = (1.0 / denomG0).sum(axis=-1)
+        n = n_ref + ((trG - trG0).sum() / beta).real
+
+        if not with_deriv:
+            return n
+
+        # dN/dmu: the Fermi part is +f(1-f)/T; each 1/(x+mu) term contributes
+        # -1/(x+mu)^2 (same trG - trG0 combination, both differentiated).
+        dref = ((1.0 / T) * f * (1.0 - f)).sum()
+        dtrG = (-1.0 / denomG ** 2).sum(axis=-1)
+        dtrG0 = (-1.0 / denomG0 ** 2).sum(axis=-1)
+        dn = dref + ((dtrG - dtrG0).sum() / beta).real
+        return n, dn
 
     @do_profile
     def _find_mu_dressed(self, sigma, beta, Ncond):
         """Re-solve mu so the dressed Green's function carries ``Ncond``.
 
         Holds ``sigma`` fixed and solves ``N(mu) = Ncond``.  The ``M``
-        eigenvalues are computed ONCE via :meth:`_matsubara_number_operator`
-        and every trial ``mu`` is then a cheap :meth:`_number_from_eigs` call
-        (no per-step matrix inversion).  Mirrors :meth:`RPA._find_mu`
-        (bisection, Newton fallback), but the bracket is widened by the
-        self-energy scale because Sigma can push spectral weight outside the
+        eigenvalues are computed ONCE via :meth:`_matsubara_number_operator``,
+        so both ``N(mu)`` and its analytic derivative ``dN/dmu`` are cheap sums
+        over those eigenvalues (:meth:`_number_from_eigs`) -- no per-step matrix
+        inversion.  ``N(mu)`` is smooth and monotonically increasing, so the
+        root is found with a **safeguarded Newton** iteration (Numerical
+        Recipes ``rtsafe``): a Newton step when it stays inside the current
+        bracket and makes progress, otherwise a bisection step.  This gets
+        Newton's quadratic convergence (a handful of evaluations from the
+        previous iteration's mu) while the maintained bracket guarantees
+        convergence even if a Newton step misbehaves.
+
+        The initial bracket is the bare eigenvalue range widened by the
+        self-energy scale, because Sigma can push spectral weight outside the
         bare band edges.
 
         Parameters
@@ -569,8 +603,6 @@ class FLEX(RPA):
         float
             Chemical potential mu such that N(mu) = Ncond.
         """
-        from scipy import optimize
-
         w = self.H0_eigenvalue
         # widen the bracket by the (static) self-energy scale: Sigma shifts the
         # band, so the bare eigenvalue range may not bracket the root.
@@ -582,21 +614,63 @@ class FLEX(RPA):
         # then a cheap sum over eigenvalues (see _matsubara_number_operator).
         lam, ew = self._matsubara_number_operator(sigma, beta)
 
-        def _delta_n(mu):
-            return self._number_from_eigs(lam, ew, mu, beta) - Ncond
+        def _delta_n(mu, with_deriv=False):
+            r = self._number_from_eigs(lam, ew, mu, beta, with_deriv=with_deriv)
+            if with_deriv:
+                return r[0] - Ncond, r[1]
+            return r - Ncond
 
-        is_converged = False
-        if _delta_n(lo) * _delta_n(hi) < 0.0:
-            mu, r = optimize.bisect(_delta_n, lo, hi,
-                                    full_output=True, disp=False)
-            is_converged = r.converged
-        if not is_converged:
-            mu, r = optimize.newton(_delta_n, 0.5 * (lo + hi),
-                                    full_output=True, disp=False)
-            is_converged = r.converged
-        if not is_converged:
-            logger.error("FLEX._find_mu_dressed: not converged. abort")
+        f_lo = _delta_n(lo)
+        f_hi = _delta_n(hi)
+        if f_lo == 0.0:
+            return lo
+        if f_hi == 0.0:
+            return hi
+        if f_lo * f_hi > 0.0:
+            # root not bracketed (should not happen: N spans [0, Nstate] over a
+            # wide enough mu window). Fail loudly rather than return garbage.
+            logger.error("FLEX._find_mu_dressed: root not bracketed on "
+                         "[{}, {}] (N-Ncond = {}, {}). abort".format(
+                             lo, hi, f_lo, f_hi))
             sys.exit(1)
+
+        # orient the bracket so f(lo) < 0 < f(hi) (N increases with mu)
+        if f_lo > 0.0:
+            lo, hi = hi, lo
+
+        mu = 0.5 * (lo + hi)
+        dmu_old = abs(hi - lo)
+        dmu = dmu_old
+        f, df = _delta_n(mu, with_deriv=True)
+
+        xtol = 1.0e-12
+        for _ in range(100):
+            # take bisection when the Newton step leaves the bracket, is not
+            # shrinking the interval fast enough, or the derivative is flat;
+            # otherwise take Newton.  df -> 0 is the CHARGE-GAP regime: N(mu) is
+            # flat across the gap, so a Newton step is unreliable (and f/df ill
+            # defined).  The rtsafe product test below already routes tiny df to
+            # bisection, but guard df == 0 explicitly so f/df is never formed.
+            newton_out = ((mu - hi) * df - f) * ((mu - lo) * df - f) > 0.0
+            slow = abs(2.0 * f) > abs(dmu_old * df)
+            if newton_out or slow or df == 0.0:
+                dmu_old = dmu
+                dmu = 0.5 * (hi - lo)
+                mu = lo + dmu
+            else:
+                dmu_old = dmu
+                dmu = f / df
+                mu = mu - dmu
+
+            if abs(dmu) < xtol:
+                break
+
+            f, df = _delta_n(mu, with_deriv=True)
+            # keep the sign-change bracket [lo, hi] around the root
+            if f < 0.0:
+                lo = mu
+            else:
+                hi = mu
 
         logger.info("FLEX._find_mu_dressed: mu = {}".format(mu))
         return mu

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -327,6 +327,18 @@ class FLEX(RPA):
                            "no results stored.")
             return
 
+        # Final-output consistency: during the loop green_kw was built from the
+        # PRE-mix sigma, while `sigma` below is the POST-mix estimate, so the
+        # stored (mu, green, sigma) triple would not satisfy the Dyson equation
+        # green = [G0^{-1} - sigma]^{-1} (noticeable for non-converged or
+        # IterationMax=1 runs; negligible once converged).  Rebuild the dressed
+        # G from the final stored sigma -- and, for calc_mu, re-solve mu for it
+        # -- so the stored triple is mutually consistent and N(green) == Ncond.
+        if self.calc_mu:
+            mu = self._find_mu_dressed(sigma, beta, Ncond_target)
+            self.mu = mu
+        green_kw = self._calc_dressed_green(beta, mu, sigma)
+
         # Store results
         self.sigma = sigma
         self.green_kw = green_kw
@@ -604,11 +616,6 @@ class FLEX(RPA):
             Chemical potential mu such that N(mu) = Ncond.
         """
         w = self.H0_eigenvalue
-        # widen the bracket by the (static) self-energy scale: Sigma shifts the
-        # band, so the bare eigenvalue range may not bracket the root.
-        pad = float(np.abs(sigma.real).max()) + 1.0
-        lo = float(w.min()) - pad
-        hi = float(w.max()) + pad
 
         # Diagonalize the mu-independent part of G^{-1} once; each trial mu is
         # then a cheap sum over eigenvalues (see _matsubara_number_operator).
@@ -620,18 +627,36 @@ class FLEX(RPA):
                 return r[0] - Ncond, r[1]
             return r - Ncond
 
+        # Initial bracket: the bare band range widened by the self-energy scale.
+        # This is only a starting guess -- a general (multi-orbital, off-diagonal
+        # or non-Hermitian) Sigma can shift the dressed spectral weight, and
+        # hence the root, by more than max|Re Sigma|.  So EXPAND the bracket
+        # (doubling the pad) until N(mu) changes sign, instead of failing on the
+        # first guess.  N(mu) -> 0 as mu -> -inf and -> Nstate as mu -> +inf, so
+        # a finite root is always bracketed after enough expansion.
+        pad = float(np.abs(sigma.real).max()) + 1.0
+        lo = float(w.min()) - pad
+        hi = float(w.max()) + pad
         f_lo = _delta_n(lo)
         f_hi = _delta_n(hi)
-        if f_lo == 0.0:
-            return lo
-        if f_hi == 0.0:
-            return hi
-        if f_lo * f_hi > 0.0:
-            # root not bracketed (should not happen: N spans [0, Nstate] over a
-            # wide enough mu window). Fail loudly rather than return garbage.
-            logger.error("FLEX._find_mu_dressed: root not bracketed on "
-                         "[{}, {}] (N-Ncond = {}, {}). abort".format(
-                             lo, hi, f_lo, f_hi))
+        for _ in range(60):
+            if f_lo == 0.0:
+                return lo
+            if f_hi == 0.0:
+                return hi
+            if f_lo * f_hi < 0.0:
+                break
+            span = hi - lo
+            lo -= span
+            hi += span
+            f_lo = _delta_n(lo)
+            f_hi = _delta_n(hi)
+        else:
+            # 60 doublings span ~1e18 * initial width: a real root cannot be
+            # this far out. Fail loudly rather than return garbage.
+            logger.error("FLEX._find_mu_dressed: root not bracketed after "
+                         "expansion to [{}, {}] (N-Ncond = {}, {}). abort"
+                         .format(lo, hi, f_lo, f_hi))
             sys.exit(1)
 
         # orient the bracket so f(lo) < 0 < f(hi) (N increases with mu)

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -15,7 +15,6 @@ The solver inherits from the RPA class to reuse infrastructure for:
 from __future__ import annotations
 from typing import Optional
 
-import sys
 import os
 import numpy as np
 import numpy.fft as FFT
@@ -763,11 +762,15 @@ class FLEX(RPA):
             f_hi = _delta_n(hi)
         else:
             # 60 doublings span ~1e18 * initial width: a real root cannot be
-            # this far out. Fail loudly rather than return garbage.
-            logger.error("FLEX._find_mu_dressed: root not bracketed after "
-                         "expansion to [{}, {}] (N-Ncond = {}, {}). abort"
-                         .format(lo, hi, f_lo, f_hi))
-            sys.exit(1)
+            # this far out. Fail loudly rather than return garbage. Raise a
+            # catchable exception (not sys.exit) so parameter sweeps, pipelines,
+            # and notebooks can handle/aggregate the failure instead of having
+            # the whole interpreter torn down.
+            raise RuntimeError(
+                "FLEX._find_mu_dressed: chemical-potential root not bracketed "
+                "after expansion to [{}, {}] (N-Ncond = {}, {}). Check the "
+                "target filling/Ncond and temperature.".format(
+                    lo, hi, f_lo, f_hi))
 
         # orient the bracket so f(lo) < 0 < f(hi) (N increases with mu)
         if f_lo > 0.0:

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -194,12 +194,17 @@ class FLEX(RPA):
                 "generalized FLEX solver.".format(self.spin_mode))
 
         if self.calc_mu:
+            # spin-free counts one spin, so the target is halved (as in
+            # RPA._find_mu / RPA.solve).  Ncond_target is reused every SCF
+            # iteration to re-solve mu from the DRESSED Green's function.
             if self.spin_mode == "spin-free":
-                Ncond = self.Ncond / 2
+                Ncond_target = self.Ncond / 2
             else:
-                Ncond = self.Ncond
-            dist, mu = self._find_mu(Ncond, self.T)
+                Ncond_target = self.Ncond
+            # initial mu from the non-interacting bands (Sigma = 0)
+            dist, mu = self._find_mu(Ncond_target, self.T)
         else:
+            Ncond_target = None
             mu = self.mu_value
 
         self.mu = mu
@@ -210,6 +215,32 @@ class FLEX(RPA):
         # Store for reference
         self.green0 = green0
         self.green0_tail = green0_tail
+
+        # High-frequency tail contract (coeff_tail): RPA's tail acceleration
+        # is a two-step pair -- _calc_green subtracts aa/(i w_n) in FREQUENCY
+        # space, and _calc_chi0q subtracts the analytic tau-space constant
+        # green0_tail (= VV† aa beta/2) after the Matsubara FFT.  The dressed
+        # Green's function below comes from _calc_dressed_green, which returns
+        # the FULL physical G, so the frequency-space term must be subtracted
+        # here before handing G to _calc_chi0q; otherwise G(tau) is uniformly
+        # shifted by -aa/2 and chi0q is O(1) wrong.
+        #
+        # The tail subtraction is applied ONLY to the chi0q transform (the one
+        # paired with green0_tail).  The self-energy convolution keeps the
+        # full physical G: its FFT pipeline is an exact cyclic frequency
+        # convolution and needs no tau-space tail reconstruction -- measured
+        # on the 8x8 Hubbard fixture, reconstructing the "true" G(tau) there
+        # does not improve the Nmat convergence of Sigma.
+        aa = self.coeff_tail
+        if aa != 0.0:
+            iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+            ev = self.H0_eigenvector
+            VVt = ev @ np.conj(ev).swapaxes(-2, -1)  # (nblock, nvol, nd, nd)
+            green_tail_w = ((aa / (1j * iomega))[np.newaxis, :, np.newaxis,
+                                                 np.newaxis, np.newaxis]
+                            * VVt[:, np.newaxis])
+        else:
+            green_tail_w = None
 
         # Initialize self-energy to zero
         # Shape: (nblock, nmat, nvol, nd_block, nd_block)
@@ -227,11 +258,29 @@ class FLEX(RPA):
         for iteration in range(self.max_iter):
             logger.info("FLEX iteration {}/{}".format(iteration + 1, self.max_iter))
 
+            # Re-solve mu so the DRESSED G reproduces the target particle
+            # number: as Sigma grows the frozen non-interacting mu no longer
+            # yields Ncond electrons, so the run would otherwise converge to a
+            # different filling than requested.  mu is solved for the current
+            # sigma BEFORE building green_kw so the stored (mu, green_kw) pair
+            # is self-consistent (N(green_kw) == Ncond).  A fixed mu
+            # (calc_mu=False) is left untouched.
+            if self.calc_mu:
+                mu = self._find_mu_dressed(sigma, beta, Ncond_target)
+                self.mu = mu
+
             # Step 3: Compute dressed Green's function G(k, iwn)
             green_kw = self._calc_dressed_green(beta, mu, sigma)
 
+            # Tail-subtracted G for the Matsubara-FFT transforms (see the
+            # coeff_tail contract above); identical to green_kw when aa == 0.
+            if green_tail_w is not None:
+                green_scf = green_kw - green_tail_w
+            else:
+                green_scf = green_kw
+
             # Step 4: Compute chi0(q, ivn) from dressed G
-            chi0q_raw = self._calc_chi0q(green_kw, green0_tail, beta)
+            chi0q_raw = self._calc_chi0q(green_scf, green0_tail, beta)
 
             # Remove spin block dimension
             if self.spin_mode in ["spin-free", "spinful"]:
@@ -341,6 +390,122 @@ class FLEX(RPA):
         green = np.linalg.inv(green_inv)
 
         return green
+
+    @do_profile
+    def _calc_number_dressed(self, sigma, mu, beta):
+        """Particle number carried by the dressed Green's function at ``mu``.
+
+        The self-energy shifts and renormalizes the dressed G, so the actual
+        electron count differs from the non-interacting Fermi count.  The count
+        is evaluated with the standard tail-subtracted Matsubara sum: the
+        non-interacting reference is summed analytically (Fermi function) and
+        only the small, absolutely-convergent difference ``G - G0`` is summed
+        over the finite Matsubara grid::
+
+            N(mu) = sum_{block,k,a} f(eps_a(k) - mu)
+                    + (1/beta) sum_{k,n} Tr[ G(k,iwn) - G0(k,iwn) ]
+
+        Here ``G0(k,iwn) = [(iwn+mu)I - H0(k)]^{-1}`` (same mu), whose analytic
+        occupation is exactly the Fermi term, and ``G - G0 = G0 Sigma G`` decays
+        as ``1/(iwn)^2`` so the residual sum needs no e^{iwn 0+} convergence
+        factor and is real.  At ``Sigma = 0`` the residual vanishes and ``N``
+        reduces exactly to the ``_find_mu`` Fermi count.
+
+        The total is compared against the SAME target convention as
+        :meth:`RPA._find_mu`: the sum runs over all spin blocks, so for
+        spin-free (one block) it is the one-spin count (target ``Ncond/2``).
+
+        Parameters
+        ----------
+        sigma : ndarray
+            Self-energy, shape (nblock, nmat, nvol, nd_block, nd_block).
+        mu : float
+            Trial chemical potential.
+        beta : float
+            Inverse temperature.
+
+        Returns
+        -------
+        float
+            Particle number N(mu).
+        """
+        nmat = self.nmat
+        ew = self.H0_eigenvalue                       # (nblock, nvol, nd_block)
+
+        # analytic non-interacting reference (Fermi function)
+        n_ref = self._fermi_occupation(1.0 / beta, mu, ew).sum()
+
+        # dressed correction Tr[G - G0], summed over the finite Matsubara grid
+        green = self._calc_dressed_green(beta, mu, sigma)
+        iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        trG = np.einsum('bnkaa->bnk', green)          # (nblock, nmat, nvol)
+        trG0 = (1.0 / ((1j * iomega)[np.newaxis, :, np.newaxis, np.newaxis]
+                       + (mu - ew)[:, np.newaxis, :, :])).sum(axis=-1)
+        corr = (trG - trG0).sum() / beta
+
+        return n_ref + corr.real
+
+    @staticmethod
+    def _fermi_occupation(t, mu, ev, ene_cutoff=1.0e2):
+        """Fermi function with the same overflow guard as RPA._find_mu."""
+        w = (ev - mu) / t
+        mask = w < ene_cutoff
+        w1 = np.where(mask, w, 0.0)
+        v1 = 1.0 / (1.0 + np.exp(w1))
+        return np.where(mask, v1, 0.0)
+
+    @do_profile
+    def _find_mu_dressed(self, sigma, beta, Ncond):
+        """Re-solve mu so the dressed Green's function carries ``Ncond``.
+
+        Holds ``sigma`` fixed and solves ``N(mu) = Ncond`` with
+        :meth:`_calc_number_dressed`.  Mirrors :meth:`RPA._find_mu`
+        (bisection, Newton fallback), but the bracket is widened by the
+        self-energy scale because Sigma can push spectral weight outside the
+        bare band edges.
+
+        Parameters
+        ----------
+        sigma : ndarray
+            Current self-energy (fixed during the mu search).
+        beta : float
+            Inverse temperature.
+        Ncond : float
+            Target particle number (already halved for spin-free, matching
+            :meth:`RPA._find_mu`).
+
+        Returns
+        -------
+        float
+            Chemical potential mu such that N(mu) = Ncond.
+        """
+        from scipy import optimize
+
+        w = self.H0_eigenvalue
+        # widen the bracket by the (static) self-energy scale: Sigma shifts the
+        # band, so the bare eigenvalue range may not bracket the root.
+        pad = float(np.abs(sigma.real).max()) + 1.0
+        lo = float(w.min()) - pad
+        hi = float(w.max()) + pad
+
+        def _delta_n(mu):
+            return self._calc_number_dressed(sigma, mu, beta) - Ncond
+
+        is_converged = False
+        if _delta_n(lo) * _delta_n(hi) < 0.0:
+            mu, r = optimize.bisect(_delta_n, lo, hi,
+                                    full_output=True, disp=False)
+            is_converged = r.converged
+        if not is_converged:
+            mu, r = optimize.newton(_delta_n, 0.5 * (lo + hi),
+                                    full_output=True, disp=False)
+            is_converged = r.converged
+        if not is_converged:
+            logger.error("FLEX._find_mu_dressed: not converged. abort")
+            sys.exit(1)
+
+        logger.info("FLEX._find_mu_dressed: mu = {}".format(mu))
+        return mu
 
     @do_profile
     def _flex_compute_veff(self, chi0q_raw, ham_orig):
@@ -906,6 +1071,11 @@ class FLEX(RPA):
         1. Transform G and V_eff to (r, tau) space
         2. Multiply in (r, tau) space: Sigma(r,tau) = V(r,tau) * G(r,tau)
         3. Transform back to (k, iwn) space
+
+        ``green_kw`` is the FULL physical Green's function (NOT the
+        tail-subtracted one used for chi0q): the self-energy convolution is an
+        exact cyclic frequency convolution and needs no tau-space tail
+        reconstruction.
 
         Parameters
         ----------

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -455,11 +455,101 @@ class FLEX(RPA):
         return np.where(mask, v1, 0.0)
 
     @do_profile
+    def _matsubara_number_operator(self, sigma, beta):
+        r"""Eigenvalues of the mu-independent part of ``G^{-1}``, for the mu
+        search.
+
+        During the chemical-potential search ``sigma`` is held FIXED, so
+
+            G^{-1}(k, iwn; mu) = (iwn + mu) I - H0(k) - Sigma(k, iwn)
+                               = M(k, iwn) + mu I,
+            M(k, iwn) = iwn I - H0(k) - Sigma(k, iwn)   (mu-independent).
+
+        Diagonalizing ``M`` ONCE then gives ``Tr[G(mu)] = sum_j 1/(lam_j + mu)``
+        for ANY trial ``mu`` -- one eigenvalue decomposition per iteration
+        instead of one full matrix inversion per bisection step (the mu search
+        was ~50% of solve()).  ``M`` is non-Hermitian, but its eigenvalues sit
+        at ``lam_j ~ iwn - (real band+Sigma)``, i.e. ``|Im(lam_j)| ~ |wn| >=
+        pi/beta > 0``, so ``lam_j + mu`` (mu real) never touches zero: the
+        1/(lam+mu) sum is well conditioned.
+
+        Parameters
+        ----------
+        sigma : ndarray
+            Self-energy, shape (nblock, nmat, nvol, nd_block, nd_block).
+        beta : float
+            Inverse temperature.
+
+        Returns
+        -------
+        lam : ndarray
+            Eigenvalues of ``M``, shape (nblock, nmat, nvol, nd_block).
+        ew : ndarray
+            H0 band energies ``self.H0_eigenvalue`` (returned for convenience,
+            used by :meth:`_number_from_eigs` for the analytic reference).
+        """
+        ew = self.H0_eigenvalue
+        ev = self.H0_eigenvector
+        nblock, nvol, nd = ew.shape
+        nmat = self.nmat
+
+        iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        H0_k = np.matmul(ev * ew[:, :, np.newaxis, :],
+                         np.conj(ev).swapaxes(-2, -1))       # (nb, nvol, nd, nd)
+        eye = np.eye(nd, dtype=np.complex128)
+        iw = 1j * iomega[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis]
+        M = iw * eye - H0_k[:, np.newaxis, :, :, :] - sigma  # (nb,nmat,nvol,nd,nd)
+
+        lam = np.linalg.eigvals(M)                            # (nb,nmat,nvol,nd)
+        return lam, ew
+
+    def _number_from_eigs(self, lam, ew, mu, beta):
+        """Particle number N(mu) from precomputed ``M`` eigenvalues.
+
+        Cheap closure evaluated for every trial ``mu`` in the bisection:
+        identical formula and result as :meth:`_calc_number_dressed` (verified
+        to machine precision in the tests), but reusing the eigenvalues from
+        :meth:`_matsubara_number_operator` instead of re-inverting G::
+
+            N(mu) = sum_{block,k,a} f(eps_a - mu)
+                    + (1/beta) sum_{k,n} [ sum_j 1/(lam_j + mu)
+                                           - sum_a 1/(iwn + mu - eps_a) ]
+
+        Parameters
+        ----------
+        lam : ndarray
+            ``M`` eigenvalues from :meth:`_matsubara_number_operator`,
+            shape (nblock, nmat, nvol, nd_block).
+        ew : ndarray
+            H0 band energies, shape (nblock, nvol, nd_block).
+        mu : float
+            Trial chemical potential.
+        beta : float
+            Inverse temperature.
+
+        Returns
+        -------
+        float
+            Particle number N(mu).
+        """
+        nmat = self.nmat
+        n_ref = self._fermi_occupation(1.0 / beta, mu, ew).sum()
+
+        iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        trG = (1.0 / (lam + mu)).sum(axis=-1)                # (nb, nmat, nvol)
+        trG0 = (1.0 / ((1j * iomega)[np.newaxis, :, np.newaxis, np.newaxis]
+                       + (mu - ew)[:, np.newaxis, :, :])).sum(axis=-1)
+        corr = (trG - trG0).sum() / beta
+        return n_ref + corr.real
+
+    @do_profile
     def _find_mu_dressed(self, sigma, beta, Ncond):
         """Re-solve mu so the dressed Green's function carries ``Ncond``.
 
-        Holds ``sigma`` fixed and solves ``N(mu) = Ncond`` with
-        :meth:`_calc_number_dressed`.  Mirrors :meth:`RPA._find_mu`
+        Holds ``sigma`` fixed and solves ``N(mu) = Ncond``.  The ``M``
+        eigenvalues are computed ONCE via :meth:`_matsubara_number_operator`
+        and every trial ``mu`` is then a cheap :meth:`_number_from_eigs` call
+        (no per-step matrix inversion).  Mirrors :meth:`RPA._find_mu`
         (bisection, Newton fallback), but the bracket is widened by the
         self-energy scale because Sigma can push spectral weight outside the
         bare band edges.
@@ -488,8 +578,12 @@ class FLEX(RPA):
         lo = float(w.min()) - pad
         hi = float(w.max()) + pad
 
+        # Diagonalize the mu-independent part of G^{-1} once; each trial mu is
+        # then a cheap sum over eigenvalues (see _matsubara_number_operator).
+        lam, ew = self._matsubara_number_operator(sigma, beta)
+
         def _delta_n(mu):
-            return self._calc_number_dressed(sigma, mu, beta) - Ncond
+            return self._number_from_eigs(lam, ew, mu, beta) - Ncond
 
         is_converged = False
         if _delta_n(lo) * _delta_n(hi) < 0.0:

--- a/tests/test_flex_coeff_tail.py
+++ b/tests/test_flex_coeff_tail.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+"""Tests for the Matsubara high-frequency tail (coeff_tail) handling in FLEX.
+
+RPA's tail acceleration is a two-step contract:
+  1. _calc_green subtracts aa/(i w_n) in frequency space, and
+  2. _calc_chi0q subtracts the analytic tau-space constant green0_tail.
+FLEX builds its Green's function via _calc_dressed_green instead of
+_calc_green, so step 1 must be applied by FLEX itself before handing the
+Green's function to _calc_chi0q / the self-energy convolution.  These tests
+pin that contract: with coeff_tail != 0 the FLEX results must remain a small
+tail-acceleration *correction*, not a change of physics.
+"""
+
+import os
+import unittest
+import numpy as np
+
+
+def _make_solver(mode_cls, Lx=8, Ly=8, Nmat=64, T=2.0, mu=0.0,
+                 coeff_tail=0.0, iteration_max=1, mix=1.0):
+    """Create an RPA or FLEX solver on the shared 1-orbital Hubbard fixture."""
+    info_log = {}
+    info_mode = {
+        'mode': mode_cls,
+        'param': {
+            'T': T,
+            'mu': mu,
+            'CellShape': [Lx, Ly, 1],
+            'SubShape': [1, 1, 1],
+            'Nmat': Nmat,
+            'coeff_tail': coeff_tail,
+            'IterationMax': iteration_max,
+            'Mix': mix,
+        },
+        'calc_scheme': 'reduced',
+    }
+    info_file_input = {
+        'path_to_input': 'tests/rpa/input',
+        'interaction': {
+            'path_to_input': 'tests/rpa/input',
+            'Geometry': 'geom.dat',
+            'Transfer': 'transfer.dat',
+            'CoulombIntra': 'coulombintra.dat',
+        },
+    }
+
+    import hwave.qlmsio.read_input_k as read_input_k
+    read_io = read_input_k.QLMSkInput(info_file_input)
+    ham_info = read_io.get_param("ham")
+    green_info = read_io.get_param("green")
+
+    if mode_cls == "FLEX":
+        import hwave.solver.flex as solver_flex
+        solver = solver_flex.FLEX(ham_info, info_log, info_mode)
+    else:
+        import hwave.solver.rpa as solver_rpa
+        solver = solver_rpa.RPA(ham_info, info_log, info_mode)
+
+    return solver, green_info
+
+
+def _run_flex(Nmat, coeff_tail):
+    """Run one FLEX iteration (Sigma_in = 0) and return green_info."""
+    solver, green_info = _make_solver("FLEX", Nmat=Nmat,
+                                      coeff_tail=coeff_tail,
+                                      iteration_max=1, mix=1.0)
+    os.makedirs('tests/flex/output', exist_ok=True)
+    solver.solve(green_info, 'tests/flex/output')
+    return green_info
+
+
+class TestFlexCoeffTail(unittest.TestCase):
+    """coeff_tail must be a small acceleration correction in FLEX, as in RPA."""
+
+    def test_chi0q_first_iteration_matches_rpa(self):
+        """With Sigma=0 the FLEX chi0q must equal the RPA chi0q for the SAME
+        coeff_tail: both describe the identical bare bubble, so any deviation
+        beyond matrix-inversion roundoff means the tail contract is broken."""
+        coeff_tail = 1.0
+
+        rpa, rpa_info = _make_solver("RPA", coeff_tail=coeff_tail)
+        beta = 1.0 / rpa.T
+        rpa._calc_epsilon_k(rpa_info)
+        green0, green0_tail = rpa._calc_green(beta, rpa.mu_value)
+        chi0q_rpa = rpa._calc_chi0q(green0, green0_tail, beta)[0]
+
+        flex_info = _run_flex(Nmat=64, coeff_tail=coeff_tail)
+        # FLEX outputs the spin-inflated chi0q; the orbital block sits on the
+        # spin-diagonal (1 orbital here: element [0, 0] of the 2x2 block).
+        chi0q_flex = flex_info["chi0q"][..., 0:1, 0:1]
+
+        np.testing.assert_allclose(chi0q_flex, chi0q_rpa,
+                                   rtol=0.0, atol=1.0e-10)
+
+    def test_chi0q_coeff_tail_is_small_correction(self):
+        """chi0q(coeff_tail=1) vs chi0q(coeff_tail=0) must differ only by the
+        finite-Nmat truncation error (~1e-2 here), never by O(1)."""
+        chi0q_0 = _run_flex(Nmat=64, coeff_tail=0.0)["chi0q"]
+        chi0q_1 = _run_flex(Nmat=64, coeff_tail=1.0)["chi0q"]
+
+        scale = np.abs(chi0q_0).max()
+        diff = np.abs(chi0q_1 - chi0q_0).max()
+        self.assertLess(diff, 0.05 * scale,
+                        "coeff_tail changed chi0q by {:.3e} (scale {:.3e}); "
+                        "tail handling is inconsistent".format(diff, scale))
+
+    def test_sigma_converges_to_same_limit_regardless_of_coeff_tail(self):
+        """coeff_tail must not change the physical self-energy.  The self-energy
+        convolution keeps the full physical G (no tail reconstruction), so at a
+        large Nmat the two conventions must agree to the finite-Nmat truncation
+        error -- i.e. coeff_tail leaves Sigma essentially unchanged, never O(1)
+        wrong (the pre-fix bug shifted G(tau) by -aa/2 for chi0q; this guards
+        that the sigma path is not similarly corrupted)."""
+        n_big = 512
+        sigma_0 = _run_flex(Nmat=n_big, coeff_tail=0.0)["sigma"]
+        sigma_1 = _run_flex(Nmat=n_big, coeff_tail=1.0)["sigma"]
+
+        scale = np.abs(sigma_0).max()
+        diff = np.abs(sigma_1 - sigma_0).max()
+        self.assertLess(diff, 0.02 * scale,
+                        "coeff_tail changed the self-energy by {:.3e} "
+                        "(scale {:.3e}); the sigma path is tail-corrupted"
+                        .format(diff, scale))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_flex_mu_update.py
+++ b/tests/test_flex_mu_update.py
@@ -119,6 +119,33 @@ class TestFlexMuUpdate(unittest.TestCase):
 
         self.assertAlmostEqual(n_ref, n_eig, places=10)
 
+    def test_number_derivative_matches_finite_difference(self):
+        """dN/dmu returned by _number_from_eigs(with_deriv=True) must match a
+        central finite difference -- Sigma is fixed during the mu search, so
+        the derivative is analytic and drives a Newton solve."""
+        # T != 1 so a wrong 1/T coefficient in dN_ref/dmu cannot hide
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64, T=2.0)
+        beta = 1.0 / solver.T
+        solver._calc_epsilon_k(green_info)
+        nblock, nvol, nd_block = solver.H0_eigenvalue.shape
+
+        rng = np.random.default_rng(3)
+        sigma = 0.3 * (rng.standard_normal((nblock, solver.nmat, nvol,
+                                            nd_block, nd_block))
+                       + 1j * rng.standard_normal((nblock, solver.nmat, nvol,
+                                                   nd_block, nd_block)))
+        sigma = 0.5 * (sigma + sigma.conj().swapaxes(-1, -2))
+        lam, ew = solver._matsubara_number_operator(sigma, beta)
+
+        h = 1.0e-6
+        for mu in (-2.0, -0.5, 0.3, 1.5):
+            _, dN = solver._number_from_eigs(lam, ew, mu, beta,
+                                             with_deriv=True)
+            fd = (solver._number_from_eigs(lam, ew, mu + h, beta)
+                  - solver._number_from_eigs(lam, ew, mu - h, beta)) / (2 * h)
+            self.assertAlmostEqual(dN, fd, places=5,
+                                   msg="dN/dmu mismatch at mu={}".format(mu))
+
     def test_particle_number_conserved_after_scf_doped(self):
         """After a converging FLEX run at a doped filling with U>0, the stored
         dressed Green's function must carry exactly Ncond electrons -- the
@@ -145,6 +172,39 @@ class TestFlexMuUpdate(unittest.TestCase):
         solver.solve(green_info, 'tests/flex/output')
 
         self.assertEqual(solver.mu, mu_in)
+
+    def test_mu_search_in_charge_gap_is_flat_safe(self):
+        """When a charge gap makes N(mu) flat (dN/dmu -> 0) at the target
+        filling, the Newton-based mu search must not blow up (f/df with a
+        vanishing derivative): it must still return a finite mu inside the gap
+        with N(mu) == Ncond.  Built on a synthetic gapped spectrum (half the
+        k-points at -1, half at +1 -> spectral gap (-1, +1)) filled to the gap
+        edge, at low T so the plateau is sharp."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64, T=0.02)
+        solver._calc_epsilon_k(green_info)
+        nb, nv, nd = solver.H0_eigenvalue.shape
+
+        ew = np.zeros((nb, nv, nd))
+        ew[0, :nv // 2, 0] = -1.0
+        ew[0, nv // 2:, 0] = +1.0
+        solver.H0_eigenvalue = ew
+        solver.H0_eigenvector = np.ones((nb, nv, nd, nd), dtype=np.complex128)
+
+        beta = 1.0 / solver.T
+        sigma = np.zeros((nb, solver.nmat, nv, nd, nd), dtype=np.complex128)
+        Ncond_target = float(nv // 2)   # fill the lower group -> mu in the gap
+
+        lam, ewr = solver._matsubara_number_operator(sigma, beta)
+        _, slope = solver._number_from_eigs(lam, ewr, 0.0, beta,
+                                            with_deriv=True)
+        self.assertLess(abs(slope), 1.0e-6)   # confirm the gap is actually flat
+
+        mu = solver._find_mu_dressed(sigma, beta, Ncond_target)
+        n_at_mu = solver._number_from_eigs(lam, ewr, mu, beta)
+
+        self.assertTrue(np.isfinite(mu))
+        self.assertTrue(-1.0 < mu < 1.0, "mu={} not inside the gap".format(mu))
+        self.assertAlmostEqual(n_at_mu, Ncond_target, places=6)
 
 
 if __name__ == '__main__':

--- a/tests/test_flex_mu_update.py
+++ b/tests/test_flex_mu_update.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+"""Tests for the self-consistent chemical-potential update in FLEX.
+
+Standard self-consistent FLEX re-solves the chemical potential mu every SCF
+iteration so that the DRESSED Green's function reproduces the target particle
+number N = Ncond.  If mu is frozen at its non-interacting value, the growing
+self-energy makes the actual particle number drift away from Ncond, so the
+converged solution describes a different filling than the user requested.
+
+These tests pin:
+1. The dressed particle-number formula reduces to the analytic Fermi count at
+   Sigma = 0 (correctness of the tail-corrected Matsubara sum).
+2. After a full FLEX run with calc_mu=True and U > 0 on a DOPED (non
+   particle-hole-symmetric) filling, the dressed Green's function carries
+   exactly Ncond electrons.
+3. When mu is fixed (calc_mu=False), it is NOT re-solved (behavior unchanged).
+"""
+
+import os
+import unittest
+import numpy as np
+
+
+def _make_solver(fixing, Lx=8, Ly=8, Nmat=128, T=1.0, U=3.0,
+                 iteration_max=1, mix=1.0):
+    """Create a FLEX solver.  ``fixing`` is either {'mu': value} or
+    {'Ncond': value} to select fixed-mu vs particle-number modes."""
+    info_log = {}
+    param = {
+        'T': T,
+        'CellShape': [Lx, Ly, 1],
+        'SubShape': [1, 1, 1],
+        'Nmat': Nmat,
+        'IterationMax': iteration_max,
+        'Mix': mix,
+    }
+    param.update(fixing)
+    info_mode = {'mode': 'FLEX', 'param': param, 'calc_scheme': 'reduced'}
+    info_file_input = {
+        'path_to_input': 'tests/rpa/input',
+        'interaction': {
+            'path_to_input': 'tests/rpa/input',
+            'Geometry': 'geom.dat',
+            'Transfer': 'transfer.dat',
+            'CoulombIntra': 'coulombintra.dat',
+        },
+    }
+
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as solver_flex
+    read_io = read_input_k.QLMSkInput(info_file_input)
+    ham_info = read_io.get_param("ham")
+    green_info = read_io.get_param("green")
+    solver = solver_flex.FLEX(ham_info, info_log, info_mode)
+    return solver, green_info
+
+
+def _fermi(T, mu, ev, cutoff=1.0e2):
+    w = (ev - mu) / T
+    mask = w < cutoff
+    w1 = np.where(mask, w, 0.0)
+    return np.where(mask, 1.0 / (1.0 + np.exp(w1)), 0.0)
+
+
+def _number_from_green(solver, green_kw, mu, beta):
+    """Reference particle count from a stored dressed Green's function:
+    N = sum_a f(eps_a - mu) + (1/beta) sum_{k,n} Tr[G - G0(mu)]."""
+    nmat = green_kw.shape[1]
+    ew = solver.H0_eigenvalue
+    n_ref = _fermi(1.0 / beta, mu, ew).sum()
+    iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+    trG = np.einsum('bnkaa->bnk', green_kw)
+    trG0 = (1.0 / ((1j * iomega)[np.newaxis, :, np.newaxis, np.newaxis]
+                   + (mu - ew)[:, np.newaxis, :, :])).sum(axis=-1)
+    return n_ref + ((trG - trG0).sum() / beta).real
+
+
+class TestFlexMuUpdate(unittest.TestCase):
+
+    def test_dressed_number_reduces_to_fermi_at_zero_sigma(self):
+        """_calc_number_dressed with Sigma=0 must equal the analytic Fermi
+        count that _find_mu uses (the tail-corrected sum is exact there)."""
+        solver, green_info = _make_solver({'Ncond': 48.0})
+        beta = 1.0 / solver.T
+        solver._calc_epsilon_k(green_info)
+        nblock, nvol, nd_block = solver.H0_eigenvalue.shape
+        sigma0 = np.zeros((nblock, solver.nmat, nvol, nd_block, nd_block),
+                          dtype=np.complex128)
+        mu = 0.37
+
+        n_dressed = solver._calc_number_dressed(sigma0, mu, beta)
+        n_fermi = _fermi(solver.T, mu, solver.H0_eigenvalue).sum()
+
+        self.assertAlmostEqual(n_dressed, n_fermi, places=10)
+
+    def test_particle_number_conserved_after_scf_doped(self):
+        """After a converging FLEX run at a doped filling with U>0, the stored
+        dressed Green's function must carry exactly Ncond electrons -- the
+        whole point of re-solving mu each iteration."""
+        Ncond = 40.0   # Nstate = 8*8*2 = 128 -> filling 0.3125 (doped)
+        solver, green_info = _make_solver({'Ncond': Ncond}, U=3.0,
+                                          iteration_max=60, mix=0.4)
+        os.makedirs('tests/flex/output', exist_ok=True)
+        solver.solve(green_info, 'tests/flex/output')
+
+        beta = 1.0 / solver.T
+        green_kw = green_info["green"]
+        # spin-free counts one spin -> target is Ncond/2
+        n_actual = _number_from_green(solver, green_kw, solver.mu, beta)
+
+        self.assertAlmostEqual(n_actual, Ncond / 2.0, places=4)
+
+    def test_fixed_mu_is_not_resolved(self):
+        """calc_mu=False: mu stays at the user value through the whole run."""
+        mu_in = 0.5
+        solver, green_info = _make_solver({'mu': mu_in}, U=3.0,
+                                          iteration_max=5, mix=0.5)
+        os.makedirs('tests/flex/output', exist_ok=True)
+        solver.solve(green_info, 'tests/flex/output')
+
+        self.assertEqual(solver.mu, mu_in)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_flex_mu_update.py
+++ b/tests/test_flex_mu_update.py
@@ -94,6 +94,31 @@ class TestFlexMuUpdate(unittest.TestCase):
 
         self.assertAlmostEqual(n_dressed, n_fermi, places=10)
 
+    def test_eig_number_matches_dressed_number(self):
+        """The eigenvalue-accelerated particle count used inside the mu search
+        must equal the reference inversion-based _calc_number_dressed to
+        machine precision, for a NON-trivial (frequency-dependent, complex)
+        self-energy.  This pins the optimization: G^{-1}(mu) = M + mu*I with M
+        fixed, so Tr[G(mu)] = sum_j 1/(lam_j(M) + mu) needs the eigenvalues of
+        M only once, not one inversion per trial mu."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64)
+        beta = 1.0 / solver.T
+        solver._calc_epsilon_k(green_info)
+        nblock, nvol, nd_block = solver.H0_eigenvalue.shape
+
+        rng = np.random.default_rng(1)
+        sigma = 0.3 * (rng.standard_normal((nblock, solver.nmat, nvol,
+                                            nd_block, nd_block))
+                       + 1j * rng.standard_normal((nblock, solver.nmat, nvol,
+                                                   nd_block, nd_block)))
+        mu = 0.42
+
+        n_ref = solver._calc_number_dressed(sigma, mu, beta)
+        lam, ew = solver._matsubara_number_operator(sigma, beta)
+        n_eig = solver._number_from_eigs(lam, ew, mu, beta)
+
+        self.assertAlmostEqual(n_ref, n_eig, places=10)
+
     def test_particle_number_conserved_after_scf_doped(self):
         """After a converging FLEX run at a doped filling with U>0, the stored
         dressed Green's function must carry exactly Ncond electrons -- the

--- a/tests/test_flex_mu_update.py
+++ b/tests/test_flex_mu_update.py
@@ -52,6 +52,12 @@ def _make_solver(fixing, Lx=8, Ly=8, Nmat=128, T=1.0, U=3.0,
     read_io = read_input_k.QLMSkInput(info_file_input)
     ham_info = read_io.get_param("ham")
     green_info = read_io.get_param("green")
+    # The fixture's CoulombIntra file pins U=4; override every on-site entry so
+    # the requested U actually drives the interacting behavior under test
+    # (otherwise the U argument would be silently ignored).
+    if "CoulombIntra" in ham_info:
+        ham_info["CoulombIntra"] = {k: complex(U)
+                                    for k in ham_info["CoulombIntra"]}
     solver = solver_flex.FLEX(ham_info, info_log, info_mode)
     return solver, green_info
 
@@ -162,6 +168,49 @@ class TestFlexMuUpdate(unittest.TestCase):
         n_actual = _number_from_green(solver, green_kw, solver.mu, beta)
 
         self.assertAlmostEqual(n_actual, Ncond / 2.0, places=4)
+
+    def test_output_triple_is_consistent(self):
+        """The stored (mu, green, sigma) must satisfy the Dyson equation:
+        rebuilding G from green_info['sigma'] at solver.mu must reproduce the
+        stored green AND carry Ncond electrons -- even for a short (non-fully-
+        converged) run.  Guards the final-consistency rebuild."""
+        Ncond = 40.0
+        solver, green_info = _make_solver({'Ncond': Ncond}, U=3.0,
+                                          iteration_max=3, mix=0.4)
+        os.makedirs('tests/flex/output', exist_ok=True)
+        solver.solve(green_info, 'tests/flex/output')
+
+        beta = 1.0 / solver.T
+        green_from_sigma = solver._calc_dressed_green(beta, solver.mu,
+                                                      green_info["sigma"])
+        # stored green equals G rebuilt from the stored sigma at the stored mu
+        np.testing.assert_allclose(green_from_sigma, green_info["green"],
+                                   rtol=0.0, atol=1.0e-12)
+        # and that consistent triple carries the target particle number
+        n_from_sigma = _number_from_green(solver, green_from_sigma, solver.mu,
+                                          beta)
+        self.assertAlmostEqual(n_from_sigma, Ncond / 2.0, places=4)
+
+    def test_find_mu_brackets_root_beyond_initial_guess(self):
+        """A near-empty target pushes mu far below the initial bracket
+        [band_min - pad, ...]; _find_mu_dressed must EXPAND the bracket and
+        still return a finite mu with N(mu) == target, not sys.exit.  This
+        exercises the adaptive-bracket path that also covers multi-orbital /
+        off-diagonal self-energies whose root moves beyond max|Re Sigma|."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64, T=1.0)
+        solver._calc_epsilon_k(green_info)
+        beta = 1.0 / solver.T
+        nb, nv, nd = solver.H0_eigenvalue.shape
+        sigma = np.zeros((nb, solver.nmat, nv, nd, nd), dtype=np.complex128)
+
+        target = 1.0e-3   # nearly empty -> mu far below band_min - 1
+        mu = solver._find_mu_dressed(sigma, beta, target)
+        n_at_mu = solver._number_from_eigs(
+            *solver._matsubara_number_operator(sigma, beta), mu, beta)
+
+        self.assertTrue(np.isfinite(mu))
+        self.assertLess(mu, float(solver.H0_eigenvalue.min()) - 1.0)
+        self.assertAlmostEqual(n_at_mu, target, places=6)
 
     def test_fixed_mu_is_not_resolved(self):
         """calc_mu=False: mu stays at the user value through the whole run."""

--- a/tests/test_flex_mu_update.py
+++ b/tests/test_flex_mu_update.py
@@ -212,6 +212,21 @@ class TestFlexMuUpdate(unittest.TestCase):
         self.assertLess(mu, float(solver.H0_eigenvalue.min()) - 1.0)
         self.assertAlmostEqual(n_at_mu, target, places=6)
 
+    def test_find_mu_unbracketable_target_raises(self):
+        """A target above the total number of states can never be bracketed
+        (N(mu) -> Nstate < target as mu -> +inf).  _find_mu_dressed must raise
+        a catchable RuntimeError (not sys.exit, which would tear down the whole
+        interpreter and break sweeps/notebooks)."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64, T=1.0)
+        solver._calc_epsilon_k(green_info)
+        beta = 1.0 / solver.T
+        nb, nv, nd = solver.H0_eigenvalue.shape
+        sigma = np.zeros((nb, solver.nmat, nv, nd, nd), dtype=np.complex128)
+
+        nstate = int(np.prod(solver.H0_eigenvalue.shape))
+        with self.assertRaises(RuntimeError):
+            solver._find_mu_dressed(sigma, beta, float(nstate) * 10.0)
+
     def test_fixed_mu_is_not_resolved(self):
         """calc_mu=False: mu stays at the user value through the whole run."""
         mu_in = 0.5

--- a/tests/test_flex_mu_update.py
+++ b/tests/test_flex_mu_update.py
@@ -256,5 +256,110 @@ class TestFlexMuUpdate(unittest.TestCase):
         self.assertAlmostEqual(n_at_mu, Ncond_target, places=6)
 
 
+class TestFlexPhysicsOutput(unittest.TestCase):
+    """N (particle number) and Sz reporting from the dressed Green function."""
+
+    def test_occupation_sum_matches_number_dressed(self):
+        """Per-orbital occupation summed over orbitals must equal the traced
+        _calc_number_dressed to machine precision (nonzero sigma): the
+        occupation is just the trace resolved per orbital."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64)
+        beta = 1.0 / solver.T
+        solver._calc_epsilon_k(green_info)
+        nblock, nvol, nd_block = solver.H0_eigenvalue.shape
+
+        rng = np.random.default_rng(7)
+        sigma = 0.3 * (rng.standard_normal((nblock, solver.nmat, nvol,
+                                            nd_block, nd_block))
+                       + 1j * rng.standard_normal((nblock, solver.nmat, nvol,
+                                                   nd_block, nd_block)))
+        mu = 0.35
+        green_kw = solver._calc_dressed_green(beta, mu, sigma)
+
+        nocc = solver._calc_occupation_dressed(green_kw, mu, beta)
+        n_ref = solver._calc_number_dressed(sigma, mu, beta)
+
+        self.assertAlmostEqual(nocc.sum(), n_ref, places=10)
+
+    def test_physics_spin_free_N_and_zero_Sz(self):
+        """Spin-free run: NCond == 2 * one-spin count, Sz == 0 by construction."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, U=3.0,
+                                          iteration_max=5, mix=0.4)
+        os.makedirs('tests/flex/output', exist_ok=True)
+        solver.solve(green_info, 'tests/flex/output')
+
+        beta = 1.0 / solver.T
+        physics = green_info["physics"]
+        n_one_spin = solver._calc_number_dressed(green_info["sigma"],
+                                                 solver.mu, beta)
+
+        self.assertAlmostEqual(physics["NCond"], 2.0 * n_one_spin, places=8)
+        self.assertEqual(physics["Sz"], 0.0)
+        self.assertEqual(physics["mu"], solver.mu)
+
+    def test_physics_N_equals_Ncond_after_calc_mu(self):
+        """Converged calc_mu doped run: reported NCond equals the target Ncond."""
+        Ncond = 40.0
+        solver, green_info = _make_solver({'Ncond': Ncond}, U=3.0,
+                                          iteration_max=60, mix=0.4)
+        os.makedirs('tests/flex/output', exist_ok=True)
+        solver.solve(green_info, 'tests/flex/output')
+
+        self.assertAlmostEqual(green_info["physics"]["NCond"], Ncond, places=4)
+
+    def test_fixed_mu_outputs_N_to_energy_file(self):
+        """calc_mu=False (fixed mu) writes energy.dat with a finite NCond and
+        ChemicalPotential == the input mu -- one point of the mu-N curve."""
+        mu_in = 0.5
+        solver, green_info = _make_solver({'mu': mu_in}, U=3.0,
+                                          iteration_max=5, mix=0.5)
+        out_dir = 'tests/flex/output'
+        os.makedirs(out_dir, exist_ok=True)
+        solver.solve(green_info, out_dir)
+        solver.save_results({'path_to_output': out_dir, 'energy': 'energy.dat'},
+                            green_info)
+
+        with open(os.path.join(out_dir, 'energy.dat')) as fr:
+            lines = dict(line.split('=', 1) for line in fr
+                         if '=' in line)
+        ncond = float(lines['NCond '])
+        mu_out = float(lines['ChemicalPotential '])
+
+        self.assertTrue(np.isfinite(ncond))
+        self.assertGreater(ncond, 0.0)
+        self.assertAlmostEqual(mu_out, mu_in, places=12)
+
+    def test_physics_spin_diag_Sz(self):
+        """Spin-diag: Sz == (N_up - N_down)/2 with N_up/N_down the per-block
+        counts.  Built on a synthetic magnetized 2-block spectrum (up/down bands
+        split) so N_up != N_down, checked against the analytic Fermi counts."""
+        solver, green_info = _make_solver({'Ncond': 40.0}, Nmat=64, T=0.5)
+        solver._calc_epsilon_k(green_info)
+        _, nvol, _ = solver.H0_eigenvalue.shape
+
+        # spin-diag: 2 blocks (up, down), one orbital, split bands -> magnetized
+        solver.spin_mode = "spin-diag"
+        solver.norb = 1
+        eps_up = np.linspace(-2.0, 2.0, nvol) - 0.5     # up band shifted down
+        eps_down = np.linspace(-2.0, 2.0, nvol) + 0.5   # down band shifted up
+        ew = np.stack([eps_up[:, None], eps_down[:, None]])   # (2, nvol, 1)
+        solver.H0_eigenvalue = ew
+        solver.H0_eigenvector = np.ones((2, nvol, 1, 1), dtype=np.complex128)
+
+        beta = 1.0 / solver.T
+        mu = 0.0
+        sigma = np.zeros((2, solver.nmat, nvol, 1, 1), dtype=np.complex128)
+        green_kw = solver._calc_dressed_green(beta, mu, sigma)
+
+        physics = solver._calc_physics_dressed(green_kw, mu, beta)
+
+        # analytic reference at Sigma=0: N_spin = sum_k f(eps_spin - mu)
+        n_up = _fermi(solver.T, mu, eps_up).sum()
+        n_down = _fermi(solver.T, mu, eps_down).sum()
+        self.assertAlmostEqual(physics["NCond"], n_up + n_down, places=8)
+        self.assertAlmostEqual(physics["Sz"], 0.5 * (n_up - n_down), places=8)
+        self.assertNotAlmostEqual(physics["Sz"], 0.0, places=3)  # truly magnetized
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes two Matsubara-sum bugs in the FLEX solver, speeds up the chemical-potential search, and adds particle-number / spin output.

### Bug fixes
- **`coeff_tail` tail contract.** FLEX built its dressed Green function without the frequency-space `aa/(iωn)` subtraction that `_calc_chi0q` pairs with, so with `coeff_tail ≠ 0` the bare susceptibility χ₀ was O(1) wrong (~3× its own scale). The tail is now subtracted from the dressed G before χ₀ only; the self-energy convolution keeps the full physical G (verified this is the correct choice — reconstructing G(τ) there does not improve Nmat convergence). Default `coeff_tail = 0` is bit-identical to before.
- **Self-consistent μ.** In fixed-filling mode (`Ncond` / `filling`) μ was frozen at the non-interacting value, so the dressed-G particle number drifted as Σ grew (doped 8×8, U=3: target N=20 → actual N=23.1, +15.6%). μ is now re-solved from the dressed G every SCF iteration.

### Performance
μ search rewritten: since Σ is fixed during the search, `G⁻¹(μ) = M + μI`, so one eigen-decomposition per iteration gives `Tr[G(μ)] = Σⱼ 1/(λⱼ+μ)` for any trial μ; combined with a safeguarded Newton step using the analytic `dN/dμ`. `_find_mu_dressed` 1160 → 62 ms, `solve()` 2138 → 897 ms. Charge-gap (flat-N, `dN/dμ→0`) safe via the rtsafe bisection fallback.

### N/Sz output (new)
Writes a UHFr/UHFk-style `energy.dat` (`NCond`, `Sz`, `ChemicalPotential`) when `[file.output].energy` is set. In fixed-μ mode the `NCond` line is the μ-N single point, so sweeping μ across runs traces the μ-N relation. `Sz` is 0 for spin-free and non-zero only for spin-diagonal / spinful runs.

### Review & tests
Driven through a Codex (code) + Antigravity (docs) review cycle to convergence: adaptive μ-bracket expansion for multi-orbital / non-Hermitian Σ, final `(μ, green, Σ)` Dyson consistency, and docs (FLEX toctree entry, `coeff_tail` FLEX note, μ self-consistency tutorial notes). New tests in `test_flex_coeff_tail.py` and `test_flex_mu_update.py`; all FLEX tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
