### PR TITLE
fix(sc): resolve FLEX chi spin-orbital layout by convention (norb=2 ambiguity)

### DIFF
--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -453,6 +453,12 @@ The FLEX solver produces NumPy ``.npz`` files with the following contents:
 
 - ``chiq_s`` / ``chiq_c``: Spin / charge susceptibility,
   same shape as ``chi0q``.
+- ``chi_convention``: orbital-layout tag, ``"kuroki"`` for the
+  reduced/squashed schemes (spin-orbital reduced layout) or ``"myo"`` for the
+  general full-vertex scheme (orbital-pair layout). The Eliashberg loader
+  (``hwave_sc``) uses this tag to interpret the orbital indices; it is
+  essential for two-orbital systems, where the spin-orbital and orbital-pair
+  dimensions coincide (both ``4``) and shape alone is ambiguous.
 
 ``sigma.npz``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/source/rpa/tutorial/sc-index.rst
+++ b/docs/en/source/rpa/tutorial/sc-index.rst
@@ -503,6 +503,19 @@ into the directory read by the Eliashberg step:
 - ``green.npz`` -- the **dressed** Green's function
   :math:`G(\mathbf{k}, i\omega_n)`, from which the pair bubble is built.
 
+.. note::
+
+   The FLEX susceptibility files carry a ``chi_convention`` tag (``"kuroki"``
+   for the reduced/squashed schemes, ``"myo"`` for the general full-vertex
+   scheme) that the Eliashberg loader uses to interpret their orbital layout.
+   For **two-orbital** systems (``norb = 2``) the reduced spin-orbital
+   dimension and the orbital-pair dimension coincide (both ``4``), so this tag
+   is what distinguishes them. H-wave versions before this fix inferred the
+   layout from shape alone and mislabeled a ``norb = 2`` reduced (kuroki) chi
+   as orbital-pair, corrupting the pairing vertex; Eliashberg eigenvalues and
+   gap functions for such runs are **corrected (and therefore change)** in this
+   version. Single-orbital and general (myo) results are unaffected.
+
 ``Nmat`` must be even and must match between the FLEX output and the
 ``[mode.param]`` value. If ``frequency = "dynamic"`` is requested without
 ``chi0q_mode = "flex"``, with an odd ``Nmat``, or without a dressed

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -435,6 +435,11 @@ FLEXソルバーは以下の内容を持つNumPy ``.npz`` ファイルを生成�
 
 - ``chiq_s`` / ``chiq_c``: スピン / 電荷感受率、
   ``chi0q`` と同じ形状
+- ``chi_convention``: 軌道レイアウトのタグ。reduced/squashed スキームは
+  ``"kuroki"``（スピン軌道 reduced レイアウト）、general full-vertex スキームは
+  ``"myo"``（orbital-pair レイアウト）。Eliashberg ローダー（``hwave_sc``）はこの
+  タグで軌道インデックスを解釈します。2軌道系ではスピン軌道次元と orbital-pair
+  次元が一致（ともに ``4``）し形状だけでは区別できないため、このタグが必須です。
 
 ``sigma.npz``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -436,10 +436,10 @@ FLEXソルバーは以下の内容を持つNumPy ``.npz`` ファイルを生成�
 - ``chiq_s`` / ``chiq_c``: スピン / 電荷感受率、
   ``chi0q`` と同じ形状
 - ``chi_convention``: 軌道レイアウトのタグ。reduced/squashed スキームは
-  ``"kuroki"``（スピン軌道 reduced レイアウト）、general full-vertex スキームは
-  ``"myo"``（orbital-pair レイアウト）。Eliashberg ローダー（``hwave_sc``）はこの
-  タグで軌道インデックスを解釈します。2軌道系ではスピン軌道次元と orbital-pair
-  次元が一致（ともに ``4``）し形状だけでは区別できないため、このタグが必須です。
+  ``"kuroki"``\ （スピン軌道 reduced レイアウト）、general full-vertex スキームは
+  ``"myo"``\ （orbital-pair レイアウト）。Eliashberg ローダー（\ ``hwave_sc``\ ）は
+  このタグで軌道インデックスを解釈します。2軌道系ではスピン軌道次元と orbital-pair
+  次元が一致（ともに ``4``\ ）し形状だけでは区別できないため、このタグが必須です。
 
 ``sigma.npz``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/ja/source/rpa/tutorial/sc-index.rst
+++ b/docs/ja/source/rpa/tutorial/sc-index.rst
@@ -497,14 +497,14 @@ Eliashberg ステップが読み込むディレクトリへ以下を書き出す
 .. note::
 
    FLEX の感受率ファイルには ``chi_convention`` タグ（reduced/squashed スキームは
-   ``"kuroki"``、general full-vertex スキームは ``"myo"``）が付与されており、
-   Eliashberg ローダーはこれを用いて軌道レイアウトを解釈します。**2軌道系**
-   （``norb = 2``）では reduced のスピン軌道次元と orbital-pair 次元が一致（ともに
-   ``4``）するため、両者の区別はこのタグに依存します。本修正以前の H-wave は形状のみ
-   からレイアウトを推定し、``norb = 2`` の reduced (kuroki) chi を orbital-pair と
-   誤認して pairing vertex を壊していました。該当する計算の Eliashberg 固有値・ギャップ
-   関数は本バージョンで**修正され（したがって変化します）**。1軌道系および general
-   (myo) の結果は影響を受けません。
+   ``"kuroki"``\ 、general full-vertex スキームは ``"myo"``\ ）が付与されており、
+   Eliashberg ローダーはこれを用いて軌道レイアウトを解釈します。\ **2軌道系**\
+   （\ ``norb = 2``\ ）では reduced のスピン軌道次元と orbital-pair 次元が一致
+   （ともに ``4``\ ）するため、両者の区別はこのタグに依存します。本修正以前の H-wave
+   は形状のみからレイアウトを推定し、``norb = 2`` の reduced (kuroki) chi を
+   orbital-pair と誤認して pairing vertex を壊していました。該当する計算の Eliashberg
+   固有値・ギャップ関数は本バージョンで\ **修正されます（したがって変化します）**\ 。
+   1軌道系および general (myo) の結果は影響を受けません。
 
 ``Nmat`` は偶数で、かつ FLEX 出力と ``[mode.param]`` の値とで一致していなければ
 なりません。``chi0q_mode = "flex"`` なしで ``frequency = "dynamic"`` を指定した

--- a/docs/ja/source/rpa/tutorial/sc-index.rst
+++ b/docs/ja/source/rpa/tutorial/sc-index.rst
@@ -494,6 +494,18 @@ Eliashberg ステップが読み込むディレクトリへ以下を書き出す
 - ``green.npz`` -- **dressed** グリーン関数
   :math:`G(\mathbf{k}, i\omega_n)`\ （これからペアバブルを構成します）。
 
+.. note::
+
+   FLEX の感受率ファイルには ``chi_convention`` タグ（reduced/squashed スキームは
+   ``"kuroki"``、general full-vertex スキームは ``"myo"``）が付与されており、
+   Eliashberg ローダーはこれを用いて軌道レイアウトを解釈します。**2軌道系**
+   （``norb = 2``）では reduced のスピン軌道次元と orbital-pair 次元が一致（ともに
+   ``4``）するため、両者の区別はこのタグに依存します。本修正以前の H-wave は形状のみ
+   からレイアウトを推定し、``norb = 2`` の reduced (kuroki) chi を orbital-pair と
+   誤認して pairing vertex を壊していました。該当する計算の Eliashberg 固有値・ギャップ
+   関数は本バージョンで**修正され（したがって変化します）**。1軌道系および general
+   (myo) の結果は影響を受けません。
+
 ``Nmat`` は偶数で、かつ FLEX 出力と ``[mode.param]`` の値とで一致していなければ
 なりません。``chi0q_mode = "flex"`` なしで ``frequency = "dynamic"`` を指定した
 場合、``Nmat`` が奇数の場合、あるいは dressed ``green.npz`` が無い場合、ソルバーは

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -1261,8 +1261,19 @@ def _expand_flex_chi(chi_raw, norb, Nx, Ny, Nz, convention):
     chi_full = chi_full.reshape(nfreq, Nx, Ny, Nz, nd_chi, nd_chi)
 
     if nd_chi == nd and nd_chi == nd_so:
-        # ambiguous (norb == 2): the convention tag is the only disambiguator.
-        is_spin_orbital = (convention != "myo")
+        # ambiguous (norb == 2): the convention tag is the only disambiguator,
+        # and choosing the wrong branch silently corrupts the pairing vertex, so
+        # require an explicitly known tag rather than defaulting on mismatch.
+        if convention == "kuroki":
+            is_spin_orbital = True
+        elif convention == "myo":
+            is_spin_orbital = False
+        else:
+            raise ValueError(
+                "norb=2 FLEX chi has the shape-ambiguous dimension nd_chi={} "
+                "(norb^2 == norb*ns); a known chi_convention ('myo' or "
+                "'kuroki') is required to resolve the layout, got '{}'.".format(
+                    nd_chi, convention))
     elif nd_chi == nd_so and nd_chi != nd:
         is_spin_orbital = True
     elif nd_chi == nd and nd_chi != nd_so:

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -1180,8 +1180,10 @@ def _load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz):
 
     # Expand the FULL frequency axis (the static slice is selected by the
     # caller). The frequency axis is moved from leading to trailing position.
-    chis_w = np.moveaxis(_expand_flex_chi(chi_s_raw, norb, Nx, Ny, Nz), 0, -1)
-    chic_w = np.moveaxis(_expand_flex_chi(chi_c_raw, norb, Nx, Ny, Nz), 0, -1)
+    chis_w = np.moveaxis(
+        _expand_flex_chi(chi_s_raw, norb, Nx, Ny, Nz, chi_convention), 0, -1)
+    chic_w = np.moveaxis(
+        _expand_flex_chi(chi_c_raw, norb, Nx, Ny, Nz, chi_convention), 0, -1)
 
     green_w = _load_flex_green(input_dict, norb, Nx, Ny, Nz)
     return chis_w, chic_w, green_w, chi_convention
@@ -1223,27 +1225,59 @@ def _read_flex_chi_raw(input_dict):
     return chi_s_raw, chi_c_raw, chi_convention
 
 
-def _expand_flex_chi(chi_raw, norb, Nx, Ny, Nz):
+def _expand_flex_chi(chi_raw, norb, Nx, Ny, Nz, convention):
     """Reshape H-wave chi ``(nfreq, nvol, nd, nd)`` to
     ``(nfreq, Nx, Ny, Nz, nd, nd)`` in the ``nd = norb^2`` Eliashberg space,
-    expanding the spin-orbital block if the file is in spin-orbital space.
+    resolving the spin-orbital-vs-orbital-pair layout from ``convention``.
 
-    The mapping is elementwise in frequency (no mixing across the Matsubara
-    axis), so it may be applied to a single static slice or to the full axis
-    identically -- the static loader slices FIRST to avoid allocating the full
-    spin-orbital-expanded array.
+    The two FLEX conventions have DIFFERENT physical layouts that shape alone
+    cannot always tell apart:
+
+    - ``"myo"`` (general full-vertex FLEX) is already in orbital-pair space
+      ``nd_chi = norb^2``; passed through unchanged.
+    - ``"kuroki"`` (reduced / squashed FLEX) is in spin-orbital reduced space
+      ``nd_chi = norb*ns`` (spin-block ordered ``s*norb + a``); the spin-up
+      orbital block ``[:norb, :norb]`` is extracted and diagonally expanded to
+      ``norb^2 x norb^2``.
+
+    Whether the spin-orbital block must be extracted is decided by ``nd_chi``:
+    ``nd_chi == norb*ns`` means spin-orbital (extract), ``nd_chi == norb^2``
+    means orbital-pair (pass through). These two collide ONLY for ``norb == 2``
+    (``norb^2 == norb*ns == 4``); there the shape is ambiguous and the layout is
+    resolved from ``convention`` (``"kuroki"`` -> spin-orbital extract,
+    ``"myo"`` -> orbital-pair). The previous shape-only heuristic silently
+    treated a norb=2 kuroki spin-orbital chi as orbital-pair, skipping the
+    extraction and building a wrong pairing vertex.
+
+    The mapping is elementwise in frequency, so it may be applied to a single
+    static slice or the full axis identically.
     """
-    nd = norb * norb
+    ns = 2
+    nd = norb * norb          # orbital-pair dimension
+    nd_so = norb * ns         # spin-orbital reduced dimension
     nfreq = chi_raw.shape[0]
     chi_full = chi_raw.reshape(nfreq, Nx, Ny, Nz, -1)
     nd_chi = int(np.sqrt(chi_full.shape[-1]))
     chi_full = chi_full.reshape(nfreq, Nx, Ny, Nz, nd_chi, nd_chi)
 
-    if nd_chi == nd:
+    if nd_chi == nd and nd_chi == nd_so:
+        # ambiguous (norb == 2): the convention tag is the only disambiguator.
+        is_spin_orbital = (convention != "myo")
+    elif nd_chi == nd_so and nd_chi != nd:
+        is_spin_orbital = True
+    elif nd_chi == nd and nd_chi != nd_so:
+        is_spin_orbital = False
+    else:
+        raise ValueError(
+            "FLEX chi dimension nd_chi={} matches neither the orbital-pair "
+            "size norb^2={} nor the spin-orbital size norb*ns={}.".format(
+                nd_chi, nd, nd_so))
+
+    if not is_spin_orbital:
         return chi_full
 
-    # Spin-orbital reduced space (nd_chi = norb*ns): extract the spin-up block
-    # (diagonal in spin) and expand to norb^2 x norb^2 (diagonal in l2).
+    # Spin-orbital reduced (spin-block ordered s*norb+a): extract the spin-up
+    # orbital block and scatter it diagonally into norb^2 x norb^2.
     chi_orb = chi_full[:, :, :, :, :norb, :norb]
     out = np.zeros((nfreq, Nx, Ny, Nz, nd, nd), dtype=complex)
     for l2 in range(norb):
@@ -1325,9 +1359,9 @@ def _load_flex_susceptibilities(input_dict, norb, Nx, Ny, Nz):
 
     # Slice the static frequency FIRST, then expand only that single slice.
     chis = _expand_flex_chi(chi_s_raw[center_s:center_s + 1],
-                            norb, Nx, Ny, Nz)[0]
+                            norb, Nx, Ny, Nz, chi_convention)[0]
     chic = _expand_flex_chi(chi_c_raw[center_c:center_c + 1],
-                            norb, Nx, Ny, Nz)[0]
+                            norb, Nx, Ny, Nz, chi_convention)[0]
 
     green_dressed = _load_flex_green(input_dict, norb, Nx, Ny, Nz)
     return chis, chic, green_dressed, chi_convention

--- a/tests/test_eliashberg_dynamic.py
+++ b/tests/test_eliashberg_dynamic.py
@@ -43,8 +43,13 @@ def _write_flex_fixture(tmp_path, nmat=8, norb=1, Nx=2, Ny=2, Nz=1):
     nvol = Nx*Ny*Nz; nd = norb*norb
     rng = np.random.default_rng(3)
     def rc(shape): return rng.standard_normal(shape)+1j*rng.standard_normal(shape)
-    np.savez(tmp_path/"chiq_s.npz", chiq_s=rc((nmat, nvol, nd, nd)))
-    np.savez(tmp_path/"chiq_c.npz", chiq_c=rc((nmat, nvol, nd, nd)))
+    # chi is in orbital-pair space (nd = norb^2), i.e. the general/full-vertex
+    # "myo" convention; tag it so the loader treats it as orbital-pair (no
+    # spin-orbital block extraction).
+    np.savez(tmp_path/"chiq_s.npz", chiq_s=rc((nmat, nvol, nd, nd)),
+             chi_convention="myo")
+    np.savez(tmp_path/"chiq_c.npz", chiq_c=rc((nmat, nvol, nd, nd)),
+             chi_convention="myo")
     np.savez(tmp_path/"green.npz",  green=rc((1, nmat, nvol, norb, norb)))
     return dict(nmat=nmat, norb=norb, Nx=Nx, Ny=Ny, Nz=Nz)
 
@@ -87,6 +92,46 @@ def _write_flex_so_fixture(tmp_path, nmat=8, norb=1, Nx=2, Ny=2, Nz=1):
     np.savez(tmp_path / "chiq_c.npz", chiq_c=rc((nmat, nvol, nd_so, nd_so)))
     np.savez(tmp_path / "green.npz", green=rc((1, nmat, nvol, norb, norb)))
     return dict(nmat=nmat, norb=norb, Nx=Nx, Ny=Ny, Nz=Nz)
+
+
+def test_expand_flex_chi_kuroki_norb2_extracts_spin_orbital_block():
+    """A norb=2 reduced (kuroki) FLEX chi has nd_chi = norb*ns = 4 = norb^2, so
+    the spin-orbital layout is INDISTINGUISHABLE from an orbital-pair layout by
+    shape alone. _expand_flex_chi must use the 'kuroki' convention to extract
+    the spin-up orbital block and diagonally expand it -- not treat the raw 4x4
+    spin-orbital matrix as an orbital-pair susceptibility."""
+    import hwave.sc as sc
+    norb, ns, Nx, Ny, Nz, nfreq = 2, 2, 2, 2, 1, 3
+    nvol, nd_so, nd = Nx * Ny * Nz, norb * 2, norb * norb
+    rng = np.random.default_rng(11)
+    chi_raw = (rng.standard_normal((nfreq, nvol, nd_so, nd_so))
+               + 1j * rng.standard_normal((nfreq, nvol, nd_so, nd_so)))
+
+    out = sc._expand_flex_chi(chi_raw, norb, Nx, Ny, Nz, convention="kuroki")
+
+    # expected: extract up-spin orbital block [:norb, :norb], scatter diagonally
+    chi6 = chi_raw.reshape(nfreq, Nx, Ny, Nz, nd_so, nd_so)
+    orb = chi6[:, :, :, :, :norb, :norb]
+    expected = np.zeros((nfreq, Nx, Ny, Nz, nd, nd), dtype=complex)
+    for l2 in range(norb):
+        expected[:, :, :, :, l2::norb, l2::norb] = orb
+    np.testing.assert_allclose(out, expected)
+    # and it must NOT equal the raw 4x4 (the buggy orbital-pair interpretation)
+    assert not np.allclose(out, chi6)
+
+
+def test_expand_flex_chi_myo_norb2_is_orbital_pair():
+    """A norb=2 general (myo) FLEX chi is already orbital-pair (nd_chi=norb^2);
+    _expand_flex_chi must pass it through unchanged."""
+    import hwave.sc as sc
+    norb, Nx, Ny, Nz, nfreq = 2, 2, 2, 1, 3
+    nvol, nd = Nx * Ny * Nz, norb * norb
+    rng = np.random.default_rng(12)
+    chi_raw = (rng.standard_normal((nfreq, nvol, nd, nd))
+               + 1j * rng.standard_normal((nfreq, nvol, nd, nd)))
+
+    out = sc._expand_flex_chi(chi_raw, norb, Nx, Ny, Nz, convention="myo")
+    np.testing.assert_allclose(out, chi_raw.reshape(nfreq, Nx, Ny, Nz, nd, nd))
 
 
 def _flex_input(tmp_path, nmat):

--- a/tests/test_eliashberg_dynamic.py
+++ b/tests/test_eliashberg_dynamic.py
@@ -134,6 +134,61 @@ def test_expand_flex_chi_myo_norb2_is_orbital_pair():
     np.testing.assert_allclose(out, chi_raw.reshape(nfreq, Nx, Ny, Nz, nd, nd))
 
 
+def test_expand_flex_chi_norb2_unknown_convention_raises():
+    """For the shape-ambiguous norb=2 case, an unknown/typo convention must
+    raise -- not silently fall through to the spin-orbital extraction (which
+    would corrupt the pairing vertex)."""
+    import hwave.sc as sc
+    norb, Nx, Ny, Nz, nfreq = 2, 2, 2, 1, 2
+    nvol, nd = Nx * Ny * Nz, norb * norb
+    chi_raw = np.zeros((nfreq, nvol, nd, nd), dtype=complex)
+    with pytest.raises(ValueError, match="chi_convention"):
+        sc._expand_flex_chi(chi_raw, norb, Nx, Ny, Nz, convention="bogus")
+
+
+def test_expand_flex_chi_dimension_matches_neither_raises():
+    """A chi dimension matching neither norb^2 nor norb*ns must raise clearly
+    (e.g. norb=3 with nd_chi=5)."""
+    import hwave.sc as sc
+    norb, Nx, Ny, Nz, nfreq = 3, 2, 1, 1, 2
+    nvol, nd_bad = Nx * Ny * Nz, 5
+    chi_raw = np.zeros((nfreq, nvol, nd_bad, nd_bad), dtype=complex)
+    with pytest.raises(ValueError, match="matches neither"):
+        sc._expand_flex_chi(chi_raw, norb, Nx, Ny, Nz, convention="kuroki")
+
+
+def test_static_loader_untagged_norb2_defaults_kuroki_and_extracts(tmp_path):
+    """A legacy untagged norb=2 chi (nd_chi=4) defaults to 'kuroki' and MUST be
+    spin-orbital-extracted at the loader level -- the regression the shape-only
+    heuristic missed."""
+    import hwave.sc as sc
+    norb, ns, Nx, Ny, Nz, nmat = 2, 2, 2, 1, 1, 4
+    nvol, nd_so, nd = Nx * Ny * Nz, norb * 2, norb * norb
+    rng = np.random.default_rng(21)
+
+    def rc(shape):
+        return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+    # no chi_convention tag -> _read_flex_chi_raw defaults to "kuroki"
+    np.savez(tmp_path / "chiq_s.npz", chiq_s=rc((nmat, nvol, nd_so, nd_so)))
+    np.savez(tmp_path / "chiq_c.npz", chiq_c=rc((nmat, nvol, nd_so, nd_so)))
+    inp = {"mode": {"param": {"Nmat": nmat}},
+           "file": {"output": {"path_to_output": str(tmp_path)}},
+           "eliashberg": {"chi0q_mode": "flex"}}
+
+    chis, chic, _, conv = sc._load_flex_susceptibilities(inp, norb, Nx, Ny, Nz)
+    assert conv == "kuroki"
+    assert chis.shape == (Nx, Ny, Nz, nd, nd)
+    # verify it is the spin-orbital extraction, not the raw 4x4 passthrough
+    raw_s = np.load(tmp_path / "chiq_s.npz")["chiq_s"]
+    chi6 = raw_s.reshape(nmat, Nx, Ny, Nz, nd_so, nd_so)[nmat // 2]
+    orb = chi6[:, :, :, :norb, :norb]
+    expected = np.zeros((Nx, Ny, Nz, nd, nd), dtype=complex)
+    for l2 in range(norb):
+        expected[:, :, :, l2::norb, l2::norb] = orb
+    np.testing.assert_allclose(chis, expected)
+
+
 def _flex_input(tmp_path, nmat):
     return {"mode": {"param": {"Nmat": nmat}},
             "file": {"output": {"path_to_output": str(tmp_path)}},


### PR DESCRIPTION
## Summary

Fixes a **pre-existing** correctness bug in the FLEX → Eliashberg susceptibility
loader (`_load_flex_susceptibilities` / `_load_flex_susceptibilities_full` in
`src/hwave/sc.py`): the spin-orbital-vs-orbital-pair layout of the FLEX `chi_s`
/ `chi_c` was inferred purely from shape (`nd_chi != norb^2` ⇒ extract the
spin-orbital block).

For **`norb = 2`** the orbital-pair dimension `norb^2 = 4` and the spin-orbital
reduced dimension `norb*ns = 4` **collide**, so a reduced (`kuroki`) two-orbital
chi was silently treated as orbital-pair: the spin-up block extraction was
skipped and the pairing vertex was built from the wrong tensor. Verified on the
2-orbital FLEX sample (`chiq_s` shape `(nmat, nvol, 4, 4)`, `chi_convention =
"kuroki"`).

## Fix

`_expand_flex_chi` now decides the layout by dimension where shape is
unambiguous (`norb ≠ 2`) and falls back to the `chi_convention` tag only for the
`norb = 2` collision:

- `"kuroki"` (reduced / squashed FLEX) → spin-orbital reduced → extract the
  spin-up orbital block and diagonally expand to `norb²`.
- `"myo"` (general full-vertex FLEX) → already orbital-pair → pass through.

The convention is threaded from `_read_flex_chi_raw` through both the full and
static loaders. A dimension matching neither `norb²` nor `norb*ns` now raises.

## Notes

- This bug is **independent of** the dynamic-Eliashberg loader refactor in
  #40; it was surfaced by a Codex review of that PR. It exists on `develop` too
  (static Eliashberg + a `norb = 2` reduced FLEX run).
- **Stacked on #40**: this branch builds on `feature/eliashberg-dynamic-clean`
  because the fix targets the `_expand_flex_chi` helper introduced there. Merge
  #40 first (or retarget this PR to `develop` after #40 lands).

New tests: `kuroki` norb=2 extracts the spin-orbital block; `myo` norb=2 passes
through. 614 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
