### PR TITLE
feat(flex): IR-basis Matsubara axis for the FLEX SCF (matsubara_basis=ir, Stage 2)

### DIFF
--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -212,7 +212,7 @@ Key parameters:
   for the Matsubara sums. ``coeff_tail = 1`` matches the exact
   :math:`1/(i\omega_n)` coefficient of :math:`G` (unitarity), so it accelerates
   convergence in ``Nmat`` without biasing the result. Also supported by the RPA
-  solver.
+  solver. Ignored (unnecessary) when ``matsubara_basis = "ir"``.
 - ``IterationMax = 100``: Maximum number of SCF iterations.
 - ``Mix = 0.2``: Mixing parameter for self-energy update
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`).
@@ -651,6 +651,32 @@ The FLEX solver accepts the following parameters in the
 
 All other parameters (``T``, ``CellShape``, ``Nmat``, ``filling``, etc.)
 are shared with the RPA solver. See :ref:`Ch:Config_rpa` for details.
+
+.. note::
+
+   **Running FLEX on the IR basis.** Install the optional dependency once
+   (``pip install sparse-ir``), then add a single line under
+   ``[mode.param]`` of any existing FLEX input — every other line, including
+   ``Nmat``, stays as it is:
+
+   .. code-block:: toml
+
+      [mode]
+      mode = "FLEX"
+      calc_scheme = "reduced"     # or "squashed"; "general" stays uniform
+      [mode.param]
+      CellShape = [64, 64, 1]
+      T = 0.05
+      Nmat = 4096                 # still required: the output grid
+      matsubara_basis = "ir"      # opt in to the sparse-IR axis
+      # ir_tol = 1e-8             # optional: basis cutoff accuracy
+      # ir_wmax = 30.0            # optional: bandwidth (auto-estimated)
+
+   The SCF then runs on a few dozen sparse nodes instead of ``Nmat``
+   frequencies (e.g. 4096 -> 42 at :math:`T=0.05`), while all output files
+   are densified back onto the ``Nmat`` grid, so downstream tools (including
+   the dynamic Eliashberg solver) work unchanged. ``coeff_tail`` is ignored
+   on this path — the IR basis carries the :math:`1/(i\omega)` tail exactly.
 
 .. note::
 

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -597,6 +597,38 @@ The FLEX solver accepts the following parameters in the
      - History depth :math:`m` of the Anderson acceleration. Memory grows by
        :math:`2m` sigma-sized arrays (kept on the device under GPU
        execution).
+   * - ``matsubara_basis``
+     - str
+     - "uniform"
+     - Matsubara-axis representation: ``"uniform"`` (default, unchanged) or
+       ``"ir"`` (the sparse-ir intermediate representation; chi0 and Sigma
+       are computed NATIVELY on sparse nodes, so the uniform-FFT
+       :math:`O(\beta/N_{\mathrm{mat}})` discretization artifacts do not
+       arise by construction). ``Nmat`` keeps its role as the output grid
+       (all output files are densified onto it). Not combinable with
+       ``calc_scheme = "general"`` (v1). Requires the optional
+       `sparse-ir <https://sparse-ir.readthedocs.io>`_ package. The mu
+       search becomes the basis evaluation of
+       :math:`n = -\mathrm{Tr}\,G(\tau=\beta^-)`, and ``coeff_tail`` is
+       unnecessary (ignored).
+   * - ``ir_tol``
+     - float
+     - 1e-8
+     - IR basis cutoff accuracy.
+   * - ``ir_wmax``
+     - float
+     - auto
+     - Real-frequency bandwidth of the IR basis (same energy units as the
+       Hamiltonian); auto-estimated from the band range and interaction
+       scale when omitted (a fail-fast error asks for an explicit value if
+       the estimate cannot be formed). An always-on coefficient-decay
+       diagnostic warns when the bandwidth is insufficient.
+   * - ``sigma_init_on_error``
+     - str
+     - "warn"
+     - Behavior when the IR fit residual of a (uniform-grid) ``sigma_init``
+       exceeds 100x ``ir_tol``: ``"warn"`` (use it, warn), ``"abort"``, or
+       ``"zero"`` (fall back to the zero start).
    * - ``gpu``
      - bool
      - false

--- a/docs/en/source/howtouse/ho-index.rst
+++ b/docs/en/source/howtouse/ho-index.rst
@@ -18,7 +18,8 @@ Basic usage
     `CuPy installation guide <https://docs.cupy.dev/en/stable/install.html>`_.
     Without CuPy, ``gpu = true`` falls back to the CPU path with a warning.)
   - sparse-ir module (optional; only for the IR-basis Matsubara axis of the
-    dynamic Eliashberg solver, ``[eliashberg] matsubara_basis = "ir"``.
+    dynamic Eliashberg solver, ``[eliashberg] matsubara_basis = "ir"``, and
+    of the FLEX solver, ``[mode.param] matsubara_basis = "ir"``.
     Install with ``pip install sparse-ir``; without it, ``"ir"`` is a
     fail-fast error with this install hint.)
 

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -564,6 +564,34 @@ FLEXソルバーは ``[mode.param]`` セクションで以下のパラメータ�
      - 5
      - Anderson 加速の履歴の深さ :math:`m`。メモリは :math:`\Sigma` サイズの
        配列 :math:`2m` 本分増加します（GPU実行時はデバイス上に保持）。
+   * - ``matsubara_basis``
+     - str
+     - "uniform"
+     - 松原軸の表現。``"uniform"``（デフォルト、従来どおり）または ``"ir"``
+       （sparse-ir の中間表現基底。χ₀ と Σ をスパースノード上でネイティブに
+       計算するため、一様FFT由来の :math:`O(\beta/N_{\mathrm{mat}})`
+       離散化アーティファクトが原理的に生じません）。``Nmat`` は出力グリッド
+       として従来どおり必要で、出力ファイルは一様グリッドへ密評価されます。
+       ``calc_scheme = "general"`` とは併用できません（v1）。オプションの
+       `sparse-ir <https://sparse-ir.readthedocs.io>`_ が必要です。μ探索は
+       :math:`n = -\mathrm{Tr}\,G(\tau=\beta^-)` の基底評価に置き換わり、
+       ``coeff_tail`` は不要（無視）になります。
+   * - ``ir_tol``
+     - float
+     - 1e-8
+     - IR基底の打ち切り精度 :math:`\varepsilon`。
+   * - ``ir_wmax``
+     - float
+     - auto
+     - IR基底の実周波数バンド幅（ハミルトニアンと同じエネルギー単位）。
+       省略時はバンド幅と相互作用スケールから自動推定（推定不能なら明示指定を
+       求めるエラー）。係数テールの減衰診断が常時走り、帯域不足は警告されます。
+   * - ``sigma_init_on_error``
+     - str
+     - "warn"
+     - IR実行で ``sigma_init``（一様グリッド）のフィット残差が 100×``ir_tol``
+       を超えた場合の挙動: ``"warn"``（使用して警告）/ ``"abort"`` /
+       ``"zero"``（ゼロ初期化に退避）。
    * - ``gpu``
      - bool
      - false

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -197,7 +197,7 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 - ``coeff_tail = 1.0``（省略可）: 松原和の高振動数テール加速係数。``coeff_tail = 1``
   は :math:`G` の厳密な :math:`1/(i\omega_n)` 係数（ユニタリ性）に一致するため、
   結果を歪めずに ``Nmat`` に対する収束を加速します。RPAソルバーでもサポートされて
-  います。
+  います。``matsubara_basis = "ir"`` の場合は不要のため無視されます。
 - ``IterationMax = 100``: SCF反復の最大回数
 - ``Mix = 0.2``: 自己エネルギー更新の混合パラメータ
   (:math:`\Sigma_{\mathrm{new}} = (1 - \alpha)\Sigma_{\mathrm{old}} + \alpha\Sigma_{\mathrm{calc}}`)
@@ -589,9 +589,9 @@ FLEXソルバーは ``[mode.param]`` セクションで以下のパラメータ�
    * - ``sigma_init_on_error``
      - str
      - "warn"
-     - IR実行で ``sigma_init``（一様グリッド）のフィット残差が 100×``ir_tol``
-       を超えた場合の挙動: ``"warn"``（使用して警告）/ ``"abort"`` /
-       ``"zero"``（ゼロ初期化に退避）。
+     - IR実行で一様グリッドの ``sigma_init`` のフィット残差が ``ir_tol``
+       の100倍を超えた場合の挙動: ``"warn"`` は使用して警告、``"abort"``
+       はエラー停止、``"zero"`` はゼロ初期化に退避します。
    * - ``gpu``
      - bool
      - false
@@ -611,6 +611,32 @@ FLEXソルバーは ``[mode.param]`` セクションで以下のパラメータ�
 
 その他のパラメータ (``T``, ``CellShape``, ``Nmat``, ``filling`` 等)
 はRPAソルバーと共通です。詳細は :ref:`Ch:Config_rpa` を参照してください。
+
+.. note::
+
+   **IR基底でFLEXを実行するには。** オプションの依存パッケージを一度
+   インストールし（``pip install sparse-ir``）、既存のFLEX入力の
+   ``[mode.param]`` に1行追加するだけです。``Nmat`` を含め他の行は
+   そのままで動作します:
+
+   .. code-block:: toml
+
+      [mode]
+      mode = "FLEX"
+      calc_scheme = "reduced"     # または "squashed"（"general" は一様グリッドのみ）
+      [mode.param]
+      CellShape = [64, 64, 1]
+      T = 0.05
+      Nmat = 4096                 # 従来どおり必要（出力グリッド）
+      matsubara_basis = "ir"      # sparse-IR 軸へのオプトイン
+      # ir_tol = 1e-8             # 省略可: 基底の打ち切り精度
+      # ir_wmax = 30.0            # 省略可: バンド幅（自動推定あり）
+
+   SCF は ``Nmat`` 個の振動数の代わりに数十個のスパースノード上で走り
+   （例: :math:`T=0.05` で 4096 → 42）、出力ファイルはすべて ``Nmat``
+   グリッドへ密評価して書き出されるため、下流のツール（動的 Eliashberg
+   ソルバーを含む）は無変更で動作します。``coeff_tail`` はこのパスでは
+   無視されます（IR基底が :math:`1/(i\omega)` テールを厳密に保持するため）。
 
 .. note::
 

--- a/docs/ja/source/howtouse/ho-index.rst
+++ b/docs/ja/source/howtouse/ho-index.rst
@@ -19,7 +19,8 @@
       を参照してください。CuPyが無い場合、``gpu = true`` は警告を出して
       CPU実行にフォールバックします。）
     - sparse-ir モジュール（任意。動的 Eliashberg ソルバーの IR 基底松原軸
-      ``[eliashberg] matsubara_basis = "ir"`` にのみ必要です。
+      ``[eliashberg] matsubara_basis = "ir"`` および FLEX ソルバーの
+      ``[mode.param] matsubara_basis = "ir"`` にのみ必要です。
       ``pip install sparse-ir`` でインストールできます。未導入で ``"ir"``
       を指定した場合はインストール手順つきの明示エラーになります。）
 

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -263,6 +263,33 @@ class FLEX(RPA):
                 .format(self.mixing_scheme))
         self.anderson_depth = int(self.param_mod.get("anderson_depth", 5))
 
+        # Matsubara-axis representation (design: docs/design/ir-matsubara.md,
+        # Stage 2): the default uniform grid, or the sparse-ir intermediate
+        # representation. IR computes chi0/Sigma natively on sparse nodes (no
+        # uniform-FFT tau products), so the coeff_tail machinery is bypassed.
+        self.matsubara_basis = str(
+            self.param_mod.get("matsubara_basis", "uniform")).lower()
+        if self.matsubara_basis not in ("uniform", "ir"):
+            raise ValueError(
+                "matsubara_basis must be 'uniform' or 'ir', got '{}'."
+                .format(self.matsubara_basis))
+        self.use_ir = (self.matsubara_basis == "ir")
+        if self.use_ir and self._flex_general:
+            raise ValueError(
+                "matsubara_basis='ir' supports calc_scheme='reduced'/"
+                "'squashed' only (v1); the general full-vertex path stays on "
+                "the uniform grid.")
+        self.ir_tol = float(self.param_mod.get("ir_tol", 1.0e-8))
+        self.ir_wmax = self.param_mod.get("ir_wmax")
+        self.sigma_init_on_error = str(
+            self.param_mod.get("sigma_init_on_error", "warn")).lower()
+        if self.sigma_init_on_error not in ("warn", "abort", "zero"):
+            raise ValueError(
+                "sigma_init_on_error must be 'warn', 'abort' or 'zero', "
+                "got '{}'.".format(self.sigma_init_on_error))
+        self._ir_axF = None
+        self._ir_axB = None
+
         eps_exp = self.param_mod.get("EPS", 6)
         if isinstance(eps_exp, float) and eps_exp < 1.0:
             self.eps = eps_exp
@@ -368,6 +395,9 @@ class FLEX(RPA):
                 "only, got '{}'. spin-diag/spinful are deferred to the "
                 "generalized FLEX solver.".format(self.spin_mode))
 
+        if self.use_ir:
+            self._ir_setup(beta)
+
         if self.calc_mu:
             # spin-free counts one spin, so the target is halved (as in
             # RPA._find_mu / RPA.solve).  Ncond_target is reused every SCF
@@ -400,12 +430,16 @@ class FLEX(RPA):
             self.H0_eigenvector = xp.asarray(self.H0_eigenvector)
 
         # Step 2: Compute bare Green's function G0(k, iwn)
-        green0, green0_tail = self._calc_green(beta, mu)
+        if self.use_ir:
+            green0, green0_tail = self._calc_green_ir(beta, mu)
+        else:
+            green0, green0_tail = self._calc_green(beta, mu)
 
         # Store for reference (as host arrays; the loop below keeps using the
         # backend-local green0_tail)
         self.green0 = _bk.to_host(green0)
-        self.green0_tail = _bk.to_host(green0_tail)
+        self.green0_tail = (None if green0_tail is None
+                            else _bk.to_host(green0_tail))
 
         # High-frequency tail contract (coeff_tail): RPA's tail acceleration
         # is a two-step pair -- _calc_green subtracts aa/(i w_n) in FREQUENCY
@@ -422,7 +456,7 @@ class FLEX(RPA):
         # convolution and needs no tau-space tail reconstruction -- measured
         # on the 8x8 Hubbard fixture, reconstructing the "true" G(tau) there
         # does not improve the Nmat convergence of Sigma.
-        aa = self.coeff_tail
+        aa = 0.0 if self.use_ir else self.coeff_tail
         if aa != 0.0:
             iomega = (xp.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
             ev = self.H0_eigenvector
@@ -439,20 +473,28 @@ class FLEX(RPA):
         # k-mesh and Matsubara grid.
         nblock = green0.shape[0]
         nd_block = green0.shape[-1]
-        expected = (nblock, nmat, nvol, nd_block, nd_block)
+        nfreq_axis = self._ir_axF.n_freq if self.use_ir else nmat
+        expected_uniform = (nblock, nmat, nvol, nd_block, nd_block)
+        expected = (nblock, nfreq_axis, nvol, nd_block, nd_block)
         sigma_init = green_info.get("sigma_init")
         if sigma_init is not None:
-            if sigma_init.shape != expected:
+            if sigma_init.shape != expected_uniform:
                 raise ValueError(
                     "sigma_init shape {} does not match this run's {} "
                     "(nblock, Nmat, Nvol, nd, nd); warm-start requires the same "
                     "k-mesh and Matsubara grid. Regenerate sigma_init at this "
-                    "Nmat/CellShape.".format(sigma_init.shape, expected))
+                    "Nmat/CellShape.".format(sigma_init.shape,
+                                             expected_uniform))
+            seed = np.array(sigma_init, dtype=np.complex128, copy=True)
+            if self.use_ir:
+                seed = self._ir_sigma_init(seed)
             # xp.asarray moves the (host-loaded) seed to the device under GPU
             # execution; on numpy it is a plain cast.
-            sigma = xp.asarray(np.array(sigma_init, dtype=np.complex128,
-                                        copy=True))
-            logger.info("FLEX: warm-starting the SCF loop from sigma_init")
+            if seed is None:
+                sigma = xp.zeros(expected, dtype=np.complex128)
+            else:
+                sigma = xp.asarray(seed)
+                logger.info("FLEX: warm-starting the SCF loop from sigma_init")
         else:
             sigma = xp.zeros(expected, dtype=np.complex128)
 
@@ -494,7 +536,10 @@ class FLEX(RPA):
                 green_scf = green_kw
 
             # Step 4: Compute chi0(q, ivn) from dressed G
-            chi0q_raw = self._calc_chi0q(green_scf, green0_tail, beta)
+            if self.use_ir:
+                chi0q_raw = self._calc_chi0q_ir(green_scf, beta)
+            else:
+                chi0q_raw = self._calc_chi0q(green_scf, green0_tail, beta)
 
             # Remove spin block dimension
             if self.spin_mode in ["spin-free", "spinful"]:
@@ -515,7 +560,14 @@ class FLEX(RPA):
             else:
                 chi0q_out, v_eff, chi_s, chi_c = self._flex_compute_veff(
                     chi0q_raw, ham_orig)
-                sigma_new = self._calc_self_energy(green_kw, v_eff, beta)
+                if self.use_ir:
+                    sigma_new = self._calc_self_energy_ir(green_kw, v_eff,
+                                                          beta)
+                else:
+                    sigma_new = self._calc_self_energy(green_kw, v_eff, beta)
+
+            if self.use_ir:
+                self._ir_coeff_decay_check(sigma_new)
 
             # Step 7: Mix and check convergence
             diff = self._calc_convergence(sigma, sigma_new)
@@ -580,12 +632,23 @@ class FLEX(RPA):
             self.H0_eigenvector = _bk.to_host(self.H0_eigenvector)
 
         # Store results (as host arrays: everything downstream -- writers,
-        # green_info consumers -- is numpy)
-        sigma = _bk.to_host(sigma)
-        green_kw = _bk.to_host(green_kw)
-        chi_s = _bk.to_host(chi_s)
-        chi_c = _bk.to_host(chi_c)
-        chi0q_out = _bk.to_host(chi0q_out)
+        # green_info consumers -- is numpy). On the IR path every stored
+        # frequency axis is densified back onto the run's uniform Nmat grid
+        # so the output files keep their exact format (design OQ-1) and the
+        # Stage-1 dynamic Eliashberg loader works unchanged.
+        if self.use_ir:
+            axF, axB = self._ir_axF, self._ir_axB
+            sigma = self._ir_densify(sigma, axF, 1)
+            green_kw = self._ir_densify(green_kw, axF, 1)
+            chi_s = self._ir_densify(chi_s, axB, 0)
+            chi_c = self._ir_densify(chi_c, axB, 0)
+            chi0q_out = self._ir_densify(chi0q_out, axB, 0)
+        else:
+            sigma = _bk.to_host(sigma)
+            green_kw = _bk.to_host(green_kw)
+            chi_s = _bk.to_host(chi_s)
+            chi_c = _bk.to_host(chi_c)
+            chi0q_out = _bk.to_host(chi0q_out)
         self.sigma = sigma
         self.green_kw = green_kw
         self.chi_s = chi_s
@@ -600,6 +663,268 @@ class FLEX(RPA):
         green_info["physics"] = physics
 
         logger.info("End FLEX calculations")
+
+    # ------------------------------------------------------------------
+    # IR-basis Matsubara axis (Stage 2, docs/design/ir-matsubara.md 3.3/3.4)
+    # ------------------------------------------------------------------
+
+    def _ir_setup(self, beta):
+        """Build the fermionic/bosonic IR axes once per solve."""
+        if self._ir_axF is not None:
+            return
+        from hwave.solver.ir_axis import IRAxis
+        wmax = self.ir_wmax
+        if wmax is None:
+            ew = _bk.to_host(self.H0_eigenvalue)
+            band = 2.0 * float(np.abs(ew).max())
+            u = float(np.abs(_bk.to_host(
+                self.ham_info.ham_inter_q)).max())
+            wmax = 3.0 * (band + u)
+            if not np.isfinite(wmax) or wmax <= 0.0:
+                raise ValueError(
+                    "ir_wmax auto-estimate is not a positive finite number "
+                    "(band bound {} + interaction scale {}); set "
+                    "[mode.param] ir_wmax explicitly (a real-frequency "
+                    "bandwidth in the same energy units as the "
+                    "Hamiltonian).".format(band, u))
+            logger.info("IR: auto ir_wmax = %.6g (override with "
+                        "[mode.param] ir_wmax)", wmax)
+        wmax = float(wmax)
+        self._ir_axF = IRAxis(beta=beta, wmax=wmax, eps=self.ir_tol,
+                              statistics="F")
+        self._ir_axB = IRAxis(beta=beta, wmax=wmax, eps=self.ir_tol,
+                              statistics="B")
+        logger.info("IR: Lambda=%.3g eps=%.1e -> L_F=%d (nodes %d), "
+                    "L_B=%d (nodes %d)", beta * wmax, self.ir_tol,
+                    self._ir_axF.L, self._ir_axF.n_freq,
+                    self._ir_axB.L, self._ir_axB.n_freq)
+        if self.coeff_tail != 0.0:
+            logger.info("IR: coeff_tail is not used on the IR path (the "
+                        "fermionic basis carries the 1/(i w) tail exactly); "
+                        "the option is ignored.")
+
+    def _freq_omegas(self, beta, xp):
+        """Matsubara frequencies of the working axis (uniform or IR nodes)."""
+        if self._ir_axF is not None:
+            return xp.asarray(self._ir_axF.freq_n) * (np.pi / beta)
+        nmat = self.nmat
+        return (xp.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+
+    @do_profile
+    def _calc_green_ir(self, beta, mu):
+        """Bare Green's function on the fermionic IR nodes (no tail terms:
+        the basis represents the 1/(i w) asymptotics within ir_tol)."""
+        ew = self.H0_eigenvalue
+        ev = self.H0_eigenvector
+        xp = _bk.array_module_of(ew)
+        iomega = xp.asarray(self._ir_axF.freq_n) * (np.pi / beta)
+        wn = 1j * iomega[np.newaxis, :, np.newaxis, np.newaxis]
+        ek = (ew - mu)[:, np.newaxis, :, :]
+        g = 1.0 / (wn - ek)
+        ev_conj_t = xp.conj(ev).swapaxes(-2, -1)
+        Vg = ev[:, np.newaxis, :, :, :] * g[:, :, :, np.newaxis, :]
+        green = Vg @ ev_conj_t[:, np.newaxis, :, :, :]
+        return green, None
+
+    @do_profile
+    def _calc_chi0q_ir(self, green_kw, beta):
+        r"""chi0 on the bosonic IR nodes, computed natively from G on the
+        fermionic nodes (reduced scheme).
+
+        chi0_{ab}(r,tau) = -G_{ab}(r,tau) * G_{ba}(-r,-tau) with the
+        fermionic anti-periodicity G(-tau) = -G(beta - tau) realized as a
+        pure tau-node index reversal (symmetric node sets); the spatial
+        r -> -r is the same reverse+roll map as the uniform path. The
+        product lives on the BOSONIC tau nodes (chi0 is periodic), where G
+        is evaluated exactly from its fermionic coefficients. All IR
+        transforms are physical (the tau -> i nu step is the integral over
+        tau), so no 1/beta factors appear -- pinned against the uniform
+        chi0 by test_chi0_gate_ir_matches_uniform_large_nmat.
+        """
+        axF, axB = self._ir_axF, self._ir_axB
+        nx, ny, nz = self.lattice.shape
+        nblock, nw, nvol, nd, _ = green_kw.shape
+        if not self.enable_reduced:
+            raise ValueError(
+                "matsubara_basis='ir' chi0 supports the reduced scheme only")
+        xp = _bk.array_module_of(green_kw)
+        workers = getattr(self, "fft_workers", 1)
+
+        # G(k, tau_B): fermionic coefficients evaluated at the bosonic nodes
+        g = xp.moveaxis(green_kw.reshape(nblock, nw, nvol * nd * nd), 1, -1)
+        g_tau = axF.freq_to_tau_points(g, axB.tau)      # (nblock, ., n_tauB)
+        ntB = axB.n_tau
+        g_tau = xp.moveaxis(g_tau, -1, 1).reshape(
+            nblock, ntB, nx, ny, nz, nd * nd)
+
+        g_rt = _bk.spatial_ifftn(g_tau, axes=(2, 3, 4), workers=workers)
+
+        # G(-r, -tau) = -G(-r, beta - tau): interior symmetric tau nodes ->
+        # plain tau reversal (with the global fermionic -1); r -> -r is
+        # reverse+roll on the k grid (identical to the uniform path).
+        g_rev = -xp.flip(
+            xp.roll(g_rt, -1, axis=(2, 3, 4)), axis=(1, 2, 3, 4))
+        g_rt = g_rt.reshape(nblock, ntB, nvol, nd, nd)
+        g_rev = g_rev.reshape(nblock, ntB, nvol, nd, nd)
+
+        # chi0[a,b] = -G[a,b](r,tau) * G[b,a](-r,-tau)
+        chi0_rt = -g_rt * g_rev.swapaxes(-2, -1)
+
+        chi0_qt = _bk.spatial_fftn(
+            chi0_rt.reshape(nblock, ntB, nx, ny, nz, nd * nd),
+            axes=(2, 3, 4), workers=workers)
+        chi0_q = axB.tau_to_freq(
+            xp.moveaxis(chi0_qt.reshape(nblock, ntB, nvol * nd * nd), 1, -1))
+        chi0_q = xp.moveaxis(chi0_q, -1, 1).reshape(
+            nblock, axB.n_freq, nvol, nd, nd)
+        return chi0_q
+
+    @do_profile
+    def _calc_self_energy_ir(self, green_kw, v_eff, beta):
+        """Sigma on the fermionic IR nodes: V (bosonic nodes) and G
+        (fermionic nodes) are both evaluated on the FERMIONIC tau nodes
+        (the product V*G is anti-periodic), multiplied there, and fitted
+        back. Physical transforms -> no explicit 1/beta (pinned by
+        test_sigma_gate_one_iteration)."""
+        axF, axB = self._ir_axF, self._ir_axB
+        nx, ny, nz = self.lattice.shape
+        nvol = self.lattice.nvol
+        nblock = green_kw.shape[0]
+        nd_block = green_kw.shape[-1]
+        nd_v = v_eff.shape[-1]
+        xp = _bk.array_module_of(green_kw)
+        workers = getattr(self, "fft_workers", 1)
+        ntF = axF.n_tau
+
+        # G -> (r, tau_F)
+        g = xp.moveaxis(
+            green_kw.reshape(nblock, axF.n_freq, nvol * nd_block ** 2),
+            1, -1)
+        g_tau = xp.moveaxis(axF.freq_to_tau(g), -1, 1).reshape(
+            nblock, ntF, nx, ny, nz, nd_block ** 2)
+        green_rt = _bk.spatial_ifftn(g_tau, axes=(2, 3, 4), workers=workers
+                                     ).reshape(nblock, ntF, nvol,
+                                               nd_block, nd_block)
+
+        # V_eff -> (r, tau_F) via the bosonic basis evaluated on tau_F
+        v = xp.moveaxis(
+            v_eff.reshape(axB.n_freq, nvol * nd_v * nd_v), 0, -1)
+        v_tau = xp.moveaxis(
+            axB.freq_to_tau_points(v, axF.tau), -1, 0).reshape(
+            ntF, nx, ny, nz, nd_v * nd_v)
+        v_rt = _bk.spatial_ifftn(v_tau, axes=(1, 2, 3), workers=workers
+                                 ).reshape(ntF, nvol, nd_v, nd_v)
+
+        # Sigma(r,tau) = V(r,tau) * G(r,tau), spin-slot sliced as uniform
+        if nd_block != nd_v:
+            norb = self.norb
+            sigma_rt = xp.zeros((nblock, ntF, nvol, nd_block, nd_block),
+                                dtype=np.complex128)
+            for gblk in range(nblock):
+                s = gblk if nblock == self.ns else 0
+                sl = slice(s * norb, (s + 1) * norb)
+                sigma_rt[gblk] = v_rt[:, :, sl, sl] * green_rt[gblk]
+        else:
+            sigma_rt = v_rt[np.newaxis] * green_rt
+
+        nd_sig = sigma_rt.shape[-1]
+        sigma_kt = _bk.spatial_fftn(
+            sigma_rt.reshape(nblock, ntF, nx, ny, nz, nd_sig ** 2),
+            axes=(2, 3, 4), workers=workers)
+        sigma_kw = axF.tau_to_freq(xp.moveaxis(
+            sigma_kt.reshape(nblock, ntF, nvol * nd_sig ** 2), 1, -1))
+        return xp.moveaxis(sigma_kw, -1, 1).reshape(
+            nblock, axF.n_freq, nvol, nd_sig, nd_sig)
+
+    def _number_from_eigs_ir(self, lam, mu):
+        """N(mu) (and dN/dmu) on the IR path: the k-summed trace of G at the
+        fermionic nodes has closed form through the eigenvalues lam of M,
+        and the particle number is the beta^- evaluation of its fermionic
+        fit (n_total = -Re Tr G(beta^-)); the derivative passes through the
+        same LINEAR fit (d/dmu of 1/(lam+mu) per node)."""
+        axF = self._ir_axF
+        denom = lam + mu
+        g = _bk.to_host((1.0 / denom).sum(axis=(0, 2, 3)))
+        dg = _bk.to_host((-1.0 / denom ** 2).sum(axis=(0, 2, 3)))
+        n = -float(np.real(axF.fit_from_freq(g) @ axF.u_beta_minus))
+        dn = -float(np.real(axF.fit_from_freq(dg) @ axF.u_beta_minus))
+        return n, dn
+
+    @do_profile
+    def _ir_densify(self, arr, ax, freq_axis, max_chunk_bytes=1 << 28):
+        """Evaluate a node-resolved array back onto the run's uniform grid
+        (output compatibility; the frequency axis is ``freq_axis``).
+
+        The uniform-grid OUTPUT is Nmat/L times larger than the node array
+        (GB-scale at production sizes), so only the small coefficient array
+        crosses the device boundary; the expansion to the uniform grid runs
+        as chunked host GEMMs straight into the output buffer (design R-4:
+        memory-aware densification)."""
+        xp = _bk.array_module_of(arr)
+        a = xp.ascontiguousarray(xp.moveaxis(arr, freq_axis, -1))
+        coeffs = _bk.to_host(ax.fit_from_freq(a))       # (..., L): small
+        _, ev = ax.uniform_matrices(self.nmat)          # (L, nmat)
+        evT = np.ascontiguousarray(ev.T)                # (nmat, L)
+        out = np.empty(arr.shape[:freq_axis] + (self.nmat,)
+                       + arr.shape[freq_axis + 1:], dtype=np.complex128)
+        # Write DIRECTLY in the output layout: for each leading index before
+        # the frequency axis, out[idx] viewed as (nmat, trailing) is a
+        # contiguous matrix filled by one GEMM (the transposed coefficient
+        # operand is handled natively by BLAS) -- no GB-scale axis-move copy.
+        lead_shape = arr.shape[:freq_axis]
+        c = coeffs.reshape(lead_shape + (-1, ax.L))     # (lead..., trail, L)
+        for idx in np.ndindex(lead_shape):
+            np.matmul(evT, c[idx].T, out=out[idx].reshape(self.nmat, -1))
+        return out
+
+    def _ir_coeff_decay_check(self, sigma, label="sigma"):
+        """Always-on layer-1 diagnostic (design Sec. 5): warn when the tail
+        of the fitted coefficients stops decaying (out-of-basis content)."""
+        axF = self._ir_axF
+        c = _bk.to_host(axF.fit_from_freq(
+            np.moveaxis(_bk.to_host(sigma), 1, -1)))
+        mag = np.abs(c).max(axis=tuple(range(c.ndim - 1)))
+        tail = float(mag[-max(1, axF.L // 10):].max())
+        peak = float(mag.max()) or 1.0
+        if tail > 10.0 * axF.eps * peak:
+            logger.warning(
+                "IR coefficient tail of %s is not decaying (ratio %.2e > "
+                "10*ir_tol): the object exceeds the basis bandwidth -- "
+                "raise ir_wmax or tighten ir_tol.", label, tail / peak)
+
+    def _ir_sigma_init(self, seed):
+        """Uniform-grid sigma_init -> fermionic nodes (uniform -> IR
+        migration). The fit residual over the full uniform grid is checked
+        against 100*ir_tol (relative); above it, behavior follows
+        [mode.param] sigma_init_on_error ('warn' default / 'abort' /
+        'zero'). Returns None to request the zero start."""
+        axF = self._ir_axF
+        a = np.moveaxis(seed, 1, -1)
+        coeffs = axF.fit_from_uniform(a, self.nmat)
+        resid = float(np.abs(axF.eval_to_uniform(coeffs, self.nmat)
+                             - a).max())
+        scale = float(np.abs(a).max()) or 1.0
+        rel = resid / scale
+        logger.info("IR sigma_init fit: max uniform residual %.3e (rel "
+                    "%.3e)", resid, rel)
+        if rel > 100.0 * axF.eps:
+            msg = ("sigma_init IR fit residual (rel {:.3e}) exceeds "
+                   "100*ir_tol; the seed may exceed the basis "
+                   "bandwidth.".format(rel))
+            if self.sigma_init_on_error == "abort":
+                raise ValueError(
+                    msg + " Raise ir_wmax, or set sigma_init_on_error="
+                    "'warn'/'zero'.")
+            if self.sigma_init_on_error == "zero":
+                logger.warning(
+                    "%s Falling back to the zero start "
+                    "(sigma_init_on_error='zero').", msg)
+                return None
+            logger.warning(
+                "%s Using the fitted seed anyway "
+                "(sigma_init_on_error='warn').", msg)
+        return np.ascontiguousarray(
+            np.moveaxis(axF.eval_to_freq(coeffs), -1, 1))
 
     @do_profile
     def _calc_dressed_green(self, beta, mu, sigma):
@@ -626,10 +951,9 @@ class FLEX(RPA):
         xp = _bk.array_module_of(sigma)
 
         nblock, nvol, nd = ew.shape
-        nmat = self.nmat
 
-        # Matsubara frequencies
-        iomega = (xp.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        # Matsubara frequencies of the working axis (uniform or IR nodes)
+        iomega = self._freq_omegas(beta, xp)
 
         # Reconstruct H0 in orbital basis from eigendecomposition
         # H0 = ev @ diag(ew) @ ev†, using matmul for BLAS efficiency
@@ -747,10 +1071,19 @@ class FLEX(RPA):
         ndarray
             Occupation summed over k, shape (nblock, nd_block).
         """
+        xp = _bk.array_module_of(green_kw)
+        if self._ir_axF is not None:
+            # IR path: n_a = -Re G_aa(tau = beta^-) directly through the
+            # fermionic basis (tail-free by construction).
+            axF = self._ir_axF
+            g_aa = xp.einsum('bnkaa->bnka', green_kw)   # (nb, nw, nvol, a)
+            g_aa = _bk.to_host(xp.moveaxis(g_aa, 1, -1))  # (nb, nvol, a, nw)
+            n_k = -np.real(axF.fit_from_freq(g_aa) @ axF.u_beta_minus)
+            return n_k.sum(axis=1)                       # (nblock, nd_block)
+
         nmat = self.nmat
         ew = self.H0_eigenvalue                       # (nblock, nvol, nd_block)
         ev = self.H0_eigenvector                      # (nblock, nvol, a, j)
-        xp = _bk.array_module_of(green_kw)
         vsq = xp.abs(ev) ** 2                          # |V_aj|^2
 
         # bare per-orbital reference: n0_a = sum_j |V_aj|^2 f(eps_j - mu)
@@ -856,9 +1189,8 @@ class FLEX(RPA):
         ev = self.H0_eigenvector
         xp = _bk.array_module_of(sigma)
         nblock, nvol, nd = ew.shape
-        nmat = self.nmat
 
-        iomega = (xp.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        iomega = self._freq_omegas(beta, xp)
         H0_k = xp.matmul(ev * ew[:, :, np.newaxis, :],
                          xp.conj(ev).swapaxes(-2, -1))       # (nb, nvol, nd, nd)
         eye = xp.eye(nd, dtype=np.complex128)
@@ -989,6 +1321,11 @@ class FLEX(RPA):
         w = ew
 
         def _delta_n(mu, with_deriv=False):
+            if self._ir_axF is not None:
+                n, dn = self._number_from_eigs_ir(lam, mu)
+                if with_deriv:
+                    return n - Ncond, dn
+                return n - Ncond
             r = self._number_from_eigs(lam, ew, mu, beta, with_deriv=with_deriv)
             if with_deriv:
                 return r[0] - Ncond, r[1]

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -271,22 +271,22 @@ class FLEX(RPA):
             self.param_mod.get("matsubara_basis", "uniform")).lower()
         if self.matsubara_basis not in ("uniform", "ir"):
             raise ValueError(
-                "matsubara_basis must be 'uniform' or 'ir', got '{}'."
-                .format(self.matsubara_basis))
+                "[mode.param] matsubara_basis must be 'uniform' or 'ir', "
+                "got '{}'.".format(self.matsubara_basis))
         self.use_ir = (self.matsubara_basis == "ir")
         if self.use_ir and self._flex_general:
             raise ValueError(
-                "matsubara_basis='ir' supports calc_scheme='reduced'/"
-                "'squashed' only (v1); the general full-vertex path stays on "
-                "the uniform grid.")
+                "[mode.param] matsubara_basis='ir' supports [mode] "
+                "calc_scheme='reduced'/'squashed' only (v1); the general "
+                "full-vertex path stays on the uniform grid.")
         self.ir_tol = float(self.param_mod.get("ir_tol", 1.0e-8))
         self.ir_wmax = self.param_mod.get("ir_wmax")
         self.sigma_init_on_error = str(
             self.param_mod.get("sigma_init_on_error", "warn")).lower()
         if self.sigma_init_on_error not in ("warn", "abort", "zero"):
             raise ValueError(
-                "sigma_init_on_error must be 'warn', 'abort' or 'zero', "
-                "got '{}'.".format(self.sigma_init_on_error))
+                "[mode.param] sigma_init_on_error must be 'warn', 'abort' "
+                "or 'zero', got '{}'.".format(self.sigma_init_on_error))
         self._ir_axF = None
         self._ir_axB = None
 
@@ -851,15 +851,16 @@ class FLEX(RPA):
         return n, dn
 
     @do_profile
-    def _ir_densify(self, arr, ax, freq_axis, max_chunk_bytes=1 << 28):
+    def _ir_densify(self, arr, ax, freq_axis):
         """Evaluate a node-resolved array back onto the run's uniform grid
         (output compatibility; the frequency axis is ``freq_axis``).
 
         The uniform-grid OUTPUT is Nmat/L times larger than the node array
         (GB-scale at production sizes), so only the small coefficient array
-        crosses the device boundary; the expansion to the uniform grid runs
-        as chunked host GEMMs straight into the output buffer (design R-4:
-        memory-aware densification)."""
+        crosses the device boundary; the expansion runs as one host GEMM per
+        leading index, written straight into the preallocated output buffer,
+        so peak extra memory beyond that buffer is the coefficient array
+        (design R-4: memory-aware densification)."""
         xp = _bk.array_module_of(arr)
         a = xp.ascontiguousarray(xp.moveaxis(arr, freq_axis, -1))
         coeffs = _bk.to_host(ax.fit_from_freq(a))       # (..., L): small
@@ -890,7 +891,8 @@ class FLEX(RPA):
             logger.warning(
                 "IR coefficient tail of %s is not decaying (ratio %.2e > "
                 "10*ir_tol): the object exceeds the basis bandwidth -- "
-                "raise ir_wmax or tighten ir_tol.", label, tail / peak)
+                "raise [mode.param] ir_wmax or tighten [mode.param] ir_tol.",
+                label, tail / peak)
 
     def _ir_sigma_init(self, seed):
         """Uniform-grid sigma_init -> fermionic nodes (uniform -> IR
@@ -913,8 +915,8 @@ class FLEX(RPA):
                    "bandwidth.".format(rel))
             if self.sigma_init_on_error == "abort":
                 raise ValueError(
-                    msg + " Raise ir_wmax, or set sigma_init_on_error="
-                    "'warn'/'zero'.")
+                    msg + " Raise [mode.param] ir_wmax, or set [mode.param] "
+                    "sigma_init_on_error='warn'/'zero'.")
             if self.sigma_init_on_error == "zero":
                 logger.warning(
                     "%s Falling back to the zero start "

--- a/src/hwave/solver/ir_axis.py
+++ b/src/hwave/solver/ir_axis.py
@@ -11,9 +11,12 @@ Wraps the optional ``sparse-ir`` package behind explicit H-wave conventions:
   (asserted at construction; tau nodes are snapped to symmetric pair means).
   Frequency-axis reversals in existing solver code therefore keep their
   meaning on IR node arrays.
-- Transforms are pure basis changes contracting the LAST axis, with no
-  temperature factors inside (the 1/beta factors stay at product exits, as in
-  ``solver/matsubara.py``).
+- Transforms contract the LAST axis and are PHYSICAL: ``tau_to_freq`` is the
+  integral over tau (u_l(tau) fits carry the measure) and ``freq_to_tau``
+  contains the 1/beta Matsubara sum through the basis. Consumers therefore
+  apply NO extra 1/beta at product exits on the IR path -- unlike the
+  uniform-FFT path of ``solver/matsubara.py``, whose bare FFTs need explicit
+  1/beta factors there.
 - Transform matrices are built once on the host; applications are plain
   matmuls, so they work unchanged on numpy or cupy arrays (the caller moves
   matrices to the device via :func:`hwave.solver.backend.array_module_of`

--- a/src/hwave/solver/ir_axis.py
+++ b/src/hwave/solver/ir_axis.py
@@ -165,12 +165,27 @@ class IRAxis:
 
     def eval_to_tau_points(self, coeffs, tau_points):
         """Evaluate coefficients on ARBITRARY tau points (e.g. this axis is
-        bosonic and ``tau_points`` are the fermionic product nodes)."""
-        m = np.ascontiguousarray(self._basis.u(np.asarray(tau_points)))  # (L, npts)
+        bosonic and ``tau_points`` are the fermionic product nodes). The
+        evaluation matrix is cached per tau-point set (and per backend), so
+        repeated SCF-loop calls with the same node array are matmuls only."""
+        tau_points = np.asarray(tau_points, dtype=np.float64)
+        key = ("taupts", hash(tau_points.tobytes()))
+        if key not in self._device_m:
+            self._device_m[key] = np.ascontiguousarray(
+                self._basis.u(tau_points))              # (L, npts)
+        m = self._device_m[key]
         xp = _bk.array_module_of(coeffs)
         if xp is not np:
-            m = xp.asarray(m)
+            dkey = key + ("dev",)
+            if dkey not in self._device_m:
+                self._device_m[dkey] = xp.asarray(m)
+            m = self._device_m[dkey]
         return coeffs @ m
+
+    def freq_to_tau_points(self, arr, tau_points):
+        """(..., n_freq) node values -> values on ARBITRARY tau points
+        (fused fit + evaluate, cached like :meth:`eval_to_tau_points`)."""
+        return self.eval_to_tau_points(self.fit_from_freq(arr), tau_points)
 
     # -- uniform-grid (centered H-wave) interface ----------------------------
 

--- a/tests/test_flex_ir.py
+++ b/tests/test_flex_ir.py
@@ -1,0 +1,241 @@
+"""IR-basis (sparse-ir) FLEX SCF (Stage 2 of docs/design/ir-matsubara.md).
+
+Unlike Stage 1 (which consumes finite-Nmat uniform-FFT FLEX outputs), the IR
+FLEX computes chi0 and Sigma natively on sparse nodes, so its agreement with
+the uniform path is limited by the UNIFORM path's own O(beta/Nmat)
+discretization artifacts: the equivalence tests therefore assert convergence
+of the uniform result TOWARD the IR result as Nmat grows.
+
+Import-safe under both pytest and unittest discovery (CI lesson from #54).
+Tests must run from the repository root.
+"""
+import os
+
+import numpy as np
+import pytest
+
+try:
+    import sparse_ir  # noqa: F401
+    _HAVE_SPARSE_IR = True
+except ImportError:
+    _HAVE_SPARSE_IR = False
+
+pytestmark = pytest.mark.skipif(not _HAVE_SPARSE_IR,
+                                reason="sparse-ir not installed")
+
+
+def _make_solver(nmat, extra_param=None, U=2.5, T=0.5, Lx=4, Ly=4,
+                 iteration_max=60, mix=0.3):
+    info_mode = {'mode': 'FLEX', 'param': {
+        'T': T, 'mu': 0.0, 'CellShape': [Lx, Ly, 1], 'SubShape': [1, 1, 1],
+        'Nmat': nmat, 'IterationMax': iteration_max, 'Mix': mix, 'EPS': 8}}
+    info_mode['calc_scheme'] = 'reduced'
+    if extra_param:
+        info_mode['param'].update(extra_param)
+    info_input = {'path_to_input': 'tests/rpa/input', 'interaction': {
+        'path_to_input': 'tests/rpa/input', 'Geometry': 'geom.dat',
+        'Transfer': 'transfer.dat', 'CoulombIntra': 'coulombintra.dat'}}
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as solver_flex
+    rio = read_input_k.QLMSkInput(info_input)
+    ham = rio.get_param("ham")
+    gi = rio.get_param("green")
+    if "CoulombIntra" in ham:
+        ham["CoulombIntra"] = {k: complex(U) for k in ham["CoulombIntra"]}
+    solver = solver_flex.FLEX(ham, {}, info_mode)
+    return solver, gi
+
+
+def _run(nmat, extra_param=None, **kw):
+    solver, gi = _make_solver(nmat, extra_param, **kw)
+    os.makedirs('tests/flex/output', exist_ok=True)
+    solver.solve(gi, 'tests/flex/output')
+    return solver, gi
+
+
+def test_chi0_gate_ir_matches_uniform_large_nmat():
+    """GATE (design Sec. 2 analogue): the IR-native chi0 on bosonic nodes
+    must agree with the uniform-FFT chi0 computed at LARGE Nmat and
+    compressed (constant dropped) onto the same nodes -- the uniform result
+    converges to the IR one as its Nmat artifacts vanish."""
+    from hwave.solver import eliashberg_dynamic as ed
+    T = 0.5
+    beta = 1.0 / T
+
+    diffs = []
+    for nmat in (256, 1024):
+        solver, gi = _make_solver(nmat, {'matsubara_basis': 'ir'})
+        solver._calc_epsilon_k(gi)
+        solver._ir_setup(beta)
+        axF, axB = solver._ir_axF, solver._ir_axB
+
+        # IR-native chi0 from the bare G on nodes
+        g_nodes, _ = solver._calc_green_ir(beta, 0.0)
+        chi0_ir = solver._calc_chi0q_ir(g_nodes, beta)[0]   # strip block
+
+        # uniform chi0 from the same solver machinery at this Nmat
+        solver_u, gi_u = _make_solver(nmat)
+        solver_u._calc_epsilon_k(gi_u)
+        g_u, gtail_u = solver_u._calc_green(beta, 0.0)
+        chi0_u = solver_u._calc_chi0q(g_u, gtail_u, beta)[0]
+        # (nmat, nvol, nd, nd) -> nodes, dropping the delta(tau) constant
+        chi0_u_nodes = ed._ir_compress(
+            np.moveaxis(chi0_u, 0, -1), axB, nmat, "chi0_u",
+            drop_constant=True)
+        chi0_u_nodes = np.moveaxis(chi0_u_nodes, -1, 0)
+
+        scale = np.abs(chi0_u_nodes).max()
+        diffs.append(np.abs(chi0_ir - chi0_u_nodes).max() / scale)
+
+    # measured: 1.89e-2 (Nmat=256) -> 3.1e-3 (1024) -> 1.5e-3 (2048),
+    # i.e. ~1/Nmat -- the uniform path's own artifact scale beyond the
+    # removed delta(tau) constant (aliasing images).
+    assert diffs[-1] < 5e-3, "chi0 gate failed: {}".format(diffs)
+    assert diffs[-1] < 0.5 * diffs[0], \
+        "no Nmat convergence toward IR chi0: {}".format(diffs)
+
+
+def test_sigma_gate_one_iteration():
+    """GATE: one SCF step (sigma=0 -> sigma_new) on the IR path must match
+    the uniform step at large Nmat, compressed onto the fermionic nodes."""
+    from hwave.solver import eliashberg_dynamic as ed
+    T = 0.5
+    beta = 1.0 / T
+
+    diffs = []
+    for nmat in (256, 1024):
+        s_ir, gi_ir = _run(nmat, {'matsubara_basis': 'ir'}, iteration_max=1,
+                           mix=1.0)
+        s_u, gi_u = _run(nmat, None, iteration_max=1, mix=1.0)
+        axF = s_ir._ir_axF
+        sig_u = np.moveaxis(gi_u["sigma"], 1, -1)       # freq axis last
+        sig_u_nodes = np.moveaxis(
+            ed._ir_compress(sig_u, axF, nmat, "sigma_u"), -1, 1)
+        # IR run stores the DENSIFIED sigma; re-compress to nodes for the
+        # node-space comparison (round trip is eps-exact)
+        sig_ir = np.moveaxis(gi_ir["sigma"], 1, -1)
+        sig_ir_nodes = np.moveaxis(
+            ed._ir_compress(sig_ir, axF, nmat, "sigma_ir"), -1, 1)
+        scale = np.abs(sig_u_nodes).max()
+        diffs.append(np.abs(sig_ir_nodes - sig_u_nodes).max() / scale)
+
+    assert diffs[-1] < 1e-2, "sigma gate failed: {}".format(diffs)
+    assert diffs[-1] < 0.5 * diffs[0], \
+        "no Nmat convergence toward IR sigma: {}".format(diffs)
+
+
+def test_e2e_converged_flex_ir_vs_uniform():
+    """Full SCF: the uniform observables converge toward the IR ones as
+    Nmat grows (chi_s peak, sigma, and the fixed-mu particle number)."""
+    s_ir, gi_ir = _run(1024, {'matsubara_basis': 'ir'})
+    assert s_ir.scf_converged
+
+    gaps = []
+    for nmat in (256, 1024):
+        s_u, gi_u = _run(nmat)
+        assert s_u.scf_converged
+        # chi_s static (nu=0 slice at the bosonic center) peak value
+        chis_u = gi_u["chiq_s"][nmat // 2].real.max()
+        chis_ir = gi_ir["chiq_s"][1024 // 2].real.max()
+        n_u = gi_u["physics"]["NCond"]
+        n_ir = gi_ir["physics"]["NCond"]
+        gaps.append((abs(chis_u - chis_ir) / abs(chis_ir),
+                     abs(n_u - n_ir) / max(abs(n_ir), 1e-30)))
+
+    assert gaps[-1][0] < 2e-3, "chi_s peak mismatch: {}".format(gaps)
+    assert gaps[-1][1] < 2e-3, "NCond mismatch: {}".format(gaps)
+    assert gaps[-1][0] <= gaps[0][0] * 1.05, \
+        "chi_s not converging toward IR: {}".format(gaps)
+
+
+def test_ir_filling_driven_mu_conserves_ncond():
+    """The IR dressed mu search (n from G(beta^-) through the basis) must
+    deliver the requested particle number after the SCF."""
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as solver_flex
+    Ncond = 8.0     # Nstate = 4*4*2 = 32 -> doped
+    info_mode = {'mode': 'FLEX', 'param': {
+        'T': 0.5, 'Ncond': Ncond, 'CellShape': [4, 4, 1],
+        'SubShape': [1, 1, 1], 'Nmat': 256, 'IterationMax': 60,
+        'Mix': 0.3, 'EPS': 8, 'matsubara_basis': 'ir'},
+        'calc_scheme': 'reduced'}
+    info_input = {'path_to_input': 'tests/rpa/input', 'interaction': {
+        'path_to_input': 'tests/rpa/input', 'Geometry': 'geom.dat',
+        'Transfer': 'transfer.dat', 'CoulombIntra': 'coulombintra.dat'}}
+    rio = read_input_k.QLMSkInput(info_input)
+    ham = rio.get_param("ham")
+    gi = rio.get_param("green")
+    ham["CoulombIntra"] = {k: complex(2.5) for k in ham["CoulombIntra"]}
+    s = solver_flex.FLEX(ham, {}, info_mode)
+    os.makedirs('tests/flex/output', exist_ok=True)
+    s.solve(gi, 'tests/flex/output')
+    assert s.scf_converged
+    assert abs(gi["physics"]["NCond"] - Ncond) < 1e-6
+
+
+def test_ir_outputs_are_densified_uniform_grid():
+    """IR FLEX outputs must land on the run's uniform Nmat grid so
+    downstream consumers (incl. the Stage-1 dynamic Eliashberg loader)
+    work unchanged."""
+    nmat = 256
+    s, gi = _run(nmat, {'matsubara_basis': 'ir'}, iteration_max=5)
+    assert gi["sigma"].shape[1] == nmat
+    assert gi["green"].shape[1] == nmat
+    assert gi["chiq_s"].shape[0] == nmat
+    assert gi["chi0q"].shape[0] == nmat
+    for key in ("sigma", "green", "chiq_s", "chiq_c", "chi0q"):
+        assert isinstance(gi[key], np.ndarray)
+
+
+def test_ir_rejects_general_scheme():
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as solver_flex
+    info_mode = {'mode': 'FLEX', 'param': {
+        'T': 0.5, 'mu': 0.0, 'CellShape': [4, 4, 1], 'SubShape': [1, 1, 1],
+        'Nmat': 64, 'matsubara_basis': 'ir'}, 'calc_scheme': 'general'}
+    info_input = {'path_to_input': 'tests/rpa/input', 'interaction': {
+        'path_to_input': 'tests/rpa/input', 'Geometry': 'geom.dat',
+        'Transfer': 'transfer.dat', 'CoulombIntra': 'coulombintra.dat'}}
+    rio = read_input_k.QLMSkInput(info_input)
+    with pytest.raises(ValueError, match="matsubara_basis"):
+        solver_flex.FLEX(rio.get_param("ham"), {}, info_mode)
+
+
+def test_ir_rejects_unknown_basis():
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as solver_flex
+    info_mode = {'mode': 'FLEX', 'param': {
+        'T': 0.5, 'mu': 0.0, 'CellShape': [4, 4, 1], 'SubShape': [1, 1, 1],
+        'Nmat': 64, 'matsubara_basis': 'nonsense'}, 'calc_scheme': 'reduced'}
+    info_input = {'path_to_input': 'tests/rpa/input', 'interaction': {
+        'path_to_input': 'tests/rpa/input', 'Geometry': 'geom.dat',
+        'Transfer': 'transfer.dat', 'CoulombIntra': 'coulombintra.dat'}}
+    rio = read_input_k.QLMSkInput(info_input)
+    with pytest.raises(ValueError, match="matsubara_basis"):
+        solver_flex.FLEX(rio.get_param("ham"), {}, info_mode)
+
+
+def test_ir_with_anderson_mixing():
+    """IR path composes with Anderson acceleration and reaches the same
+    fixed point as IR + linear mixing."""
+    s_lin, gi_lin = _run(256, {'matsubara_basis': 'ir'})
+    s_and, gi_and = _run(256, {'matsubara_basis': 'ir',
+                               'mixing_scheme': 'anderson'})
+    assert s_and.scf_converged
+    ref = gi_lin["sigma"]
+    np.testing.assert_allclose(gi_and["sigma"], ref,
+                               atol=1e-5 * np.abs(ref).max())
+    assert s_and.scf_iterations < s_lin.scf_iterations
+
+
+def test_ir_gpu_matches_cpu():
+    cupy = pytest.importorskip("cupy")
+    try:
+        cupy.zeros(1)
+    except Exception:
+        pytest.skip("cupy installed but no usable CUDA device")
+    s_c, gi_c = _run(256, {'matsubara_basis': 'ir'}, iteration_max=10)
+    s_g, gi_g = _run(256, {'matsubara_basis': 'ir', 'gpu': True},
+                     iteration_max=10)
+    np.testing.assert_allclose(gi_g["sigma"], gi_c["sigma"], atol=1e-9)
+    assert isinstance(gi_g["sigma"], np.ndarray)

--- a/tests/test_flex_ir.py
+++ b/tests/test_flex_ir.py
@@ -239,3 +239,67 @@ def test_ir_gpu_matches_cpu():
                      iteration_max=10)
     np.testing.assert_allclose(gi_g["sigma"], gi_c["sigma"], atol=1e-9)
     assert isinstance(gi_g["sigma"], np.ndarray)
+
+
+def test_ir_subshape_folded_matches_uniform():
+    """Sublattice folding (SubShape != [1,1,1]) composes with the IR path:
+    on the folded lattice (norb=2 after fold) the uniform chi_s static peak
+    at large Nmat matches the IR one."""
+    sub = {'SubShape': [2, 1, 1]}
+    s_ir, gi_ir = _run(256, dict(sub, matsubara_basis='ir'))
+    assert s_ir.scf_converged
+    s_u, gi_u = _run(1024, dict(sub))
+    assert s_u.scf_converged
+    chis_ir = gi_ir["chiq_s"][256 // 2].real.max()
+    chis_u = gi_u["chiq_s"][1024 // 2].real.max()
+    assert abs(chis_u - chis_ir) / abs(chis_ir) < 2e-3
+    n_ir = gi_ir["physics"]["NCond"]
+    n_u = gi_u["physics"]["NCond"]
+    assert abs(n_u - n_ir) / abs(n_ir) < 2e-3
+
+
+def test_ir_wmax_explicit_override_and_decay_warning(caplog):
+    """An explicit ir_wmax is honored verbatim, and an insufficient
+    bandwidth must trip the always-on coefficient-decay diagnostic."""
+    import logging
+    with caplog.at_level(logging.WARNING, logger="hwave.solver.flex"):
+        s, gi = _run(256, {'matsubara_basis': 'ir', 'ir_wmax': 0.5},
+                     iteration_max=2)
+    assert s._ir_axF.wmax == 0.5
+    assert any("coefficient tail" in r.getMessage() for r in caplog.records)
+
+
+def test_ir_sigma_init_policies(caplog):
+    """A white-noise sigma_init exceeds the basis bandwidth by construction:
+    'abort' raises, 'zero' falls back to the zero start (logged), 'warn'
+    (default) proceeds with the fitted seed under a warning."""
+    import logging
+    nmat = 64
+    s_u, gi_u = _run(nmat, None, iteration_max=1)
+    shape = gi_u["sigma"].shape          # (nblock, nmat, nvol, nd, nd)
+    rng = np.random.default_rng(12345)
+    noise = 0.1 * (rng.standard_normal(shape)
+                   + 1j * rng.standard_normal(shape))
+
+    def _seeded(policy):
+        solver, gi = _make_solver(nmat, {'matsubara_basis': 'ir',
+                                         'sigma_init_on_error': policy},
+                                  iteration_max=1)
+        gi["sigma_init"] = noise.copy()
+        return solver, gi
+
+    solver, gi = _seeded('abort')
+    with pytest.raises(ValueError, match="sigma_init"):
+        solver.solve(gi, 'tests/flex/output')
+
+    solver, gi = _seeded('zero')
+    with caplog.at_level(logging.WARNING, logger="hwave.solver.flex"):
+        solver.solve(gi, 'tests/flex/output')
+    assert any("zero start" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+    solver, gi = _seeded('warn')
+    with caplog.at_level(logging.WARNING, logger="hwave.solver.flex"):
+        solver.solve(gi, 'tests/flex/output')
+    assert any("fitted seed anyway" in r.getMessage()
+               for r in caplog.records)


### PR DESCRIPTION
## Summary

Stage 2 of the Phase-0-reviewed design `docs/design/ir-matsubara.md`: the **FLEX SCF loop runs its whole frequency axis on sparse-ir nodes** — `[mode.param] matsubara_basis = "ir"` (default "uniform" unchanged; reduced/squashed schemes; general+ir is a fail-fast error). Requires the optional `sparse-ir` package.

- **chi0 computed natively on bosonic nodes** (G evaluated exactly on the bosonic τ nodes; anti-periodic reflection = index reversal on symmetric node sets; τ→iν is the physical integral) — the uniform-FFT **O(β/Nmat) δ(τ) constant and aliasing artifacts do not arise by construction**. Σ = V·G on the fermionic τ nodes. chiq/V_eff reuse the per-frequency machinery unchanged.
- **μ search simplified**: n(μ) = −Re Tr G(τ=β⁻) through the fermionic fit (closed-form node eigenvalues as evaluators, analytic derivative through the linear fit); the tail-subtraction machinery and `coeff_tail` are bypassed (ignored with INFO).
- `sigma_init` (uniform grid) migrates onto the nodes via a full-grid fit with the sweep-safe residual policy **`sigma_init_on_error = warn|abort|zero`** (default warn).
- Always-on **coefficient-decay diagnostic** per iteration (design Sec. 5 layer 1) warns on insufficient `ir_wmax`.
- **Outputs densified onto the uniform Nmat grid** (exact format compatibility — the Stage-1 dynamic-Eliashberg loader consumes them unchanged); only coefficient arrays leave the device, expansion by direct-layout host GEMMs.
- Composes with `gpu = true`, Anderson mixing, `fft_workers`, and Stage 1 (#54).

## Measured (clavius RTX 6000 Ada; T=0.05, 64², Nmat=4096 → 42 nodes = 98× axis compression; 30 SCF iterations)

| | uniform | ir | speedup |
|---|---|---|---|
| CPU | 1014 s | 18.9 s | **54×** |
| GPU | 65.4 s | 12.0 s | **5.4×** |

(The IR runs are dominated by the fixed ~10 s densified-output generation — the SCF itself is ~0.1 s/iteration; Stage 3's IR-native output will remove that floor.)

## Accuracy gates (4×4 Hubbard fixture, T=0.5)

chi0 gate: rel diff vs the uniform path **1.9e-2 → 3.1e-3 → 1.5e-3 for uniform Nmat 256 → 1024 → 2048 (~1/Nmat)** — the uniform path's own artifact scale converging toward the IR result. Same-trend Σ gate and full-SCF observable tests (χs peak, NCond); filling conservation through the IR μ search to 1e-6; Anderson×IR and GPU×IR equivalence.

## Test plan

- `tests/test_flex_ir.py` (unittest-import-safe per the #54 CI lesson): both gates with Nmat-convergence assertions, e2e observables, filling-driven μ, densified-output contract, general+ir / unknown-basis errors, Anderson×IR, GPU×IR (skips without CUDA).
- 685 tests locally; 25 IR/FLEX tests on clavius GPU.
- Docs: FLEX tutorial parameter table (EN/JA) incl. the Nmat-role and coeff_tail notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)