### PR TITLE
Follow-ups for #60: honor seed overlap on tiny operators + fix tsweep docs example (#61)

### DIFF
--- a/docs/en/source/rpa/tutorial/sc-index.rst
+++ b/docs/en/source/rpa/tutorial/sc-index.rst
@@ -768,6 +768,7 @@ Example
       frequency     = "dynamic"
       chi0q_mode    = "flex"
       pairing_type  = "singlet"
+      solver_mode   = "eigenvalue"   # required by hwave_tsweep preflight
 
     [continuation]
       T_start        = 0.02

--- a/docs/en/source/rpa/tutorial/sc-index.rst
+++ b/docs/en/source/rpa/tutorial/sc-index.rst
@@ -768,7 +768,7 @@ Example
       frequency     = "dynamic"
       chi0q_mode    = "flex"
       pairing_type  = "singlet"
-      solver_mode   = "eigenvalue"   # required by hwave_tsweep preflight
+      solver_mode   = "eigenvalue"   # required by hwave_tsweep pre-flight
 
     [continuation]
       T_start        = 0.02

--- a/docs/ja/source/rpa/tutorial/sc-index.rst
+++ b/docs/ja/source/rpa/tutorial/sc-index.rst
@@ -740,6 +740,7 @@ Eliashberg ソルバー）を実行します。各段では、直前の段の収
       frequency     = "dynamic"
       chi0q_mode    = "flex"
       pairing_type  = "singlet"
+      solver_mode   = "eigenvalue"   # hwave_tsweep の pre-flight で必須
 
     [continuation]
       T_start        = 0.02

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -2293,7 +2293,13 @@ def _solve_leading(make_operator, vec_size, solver_mode, num_eigenvalues=10,
         for j in range(vec_size):
             dense[:, j] = A.matvec(basis[:, j])
         vals, vecs = np.linalg.eig(dense)
-        vals, vecs = _order_eigenpairs(vals, vecs)
+        # Match the ARPACK path below: with a seed eigenvector, track the branch
+        # that overlaps it (eigenvector continuation); otherwise order by
+        # largest real part (the physical SC eigenvalue), not magnitude.
+        if seed_vec is not None:
+            vals, vecs = _order_by_seed_overlap(vals, vecs, seed_vec)
+        else:
+            vals, vecs = _order_eigenpairs(vals, vecs)
         n_keep = min(max(1, num_eigenvalues), vec_size)
         vals = vals[:n_keep]
         vecs = vecs[:, :n_keep]

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -1984,7 +1984,12 @@ def _order_by_seed_overlap(vals, vecs, seed_vec):
     s = s / ns
     ov = np.abs(vecs.conj().T @ s) / (
         np.linalg.norm(vecs, axis=0) + 1.0e-300)
-    idx = np.argsort(-ov)
+    # Primary key: descending overlap. Secondary key: descending real part, so
+    # an exact overlap TIE deterministically falls back to the physical
+    # real-part ordering (as the docstring promises) instead of the arbitrary
+    # order np.linalg.eig / ARPACK happened to return. np.lexsort takes the
+    # primary key last.
+    idx = np.lexsort((-vals.real, -ov))
     return vals[idx], vecs[:, idx]
 
 

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -686,10 +686,22 @@ class TestSeedOverlapSelection(unittest.TestCase):
         self.assertAlmostEqual(info["eigenvalues"][0].real, 1.0)
 
     def test_dense_fallback_without_seed_uses_largest_real(self):
-        make_op = self._diag_operator([2.0, 1.0])
+        # eigenvalues [2.0, -5.0]: largest real (2.0) != largest magnitude (5.0),
+        # so this catches a regression back to magnitude ordering.
+        make_op = self._diag_operator([2.0, -5.0])
         val, vec, info = _solve_leading(make_op, 2, "arnoldi")
         # No seed -> physical SC eigenvalue is the algebraically largest.
         self.assertAlmostEqual(val.real, 2.0)
+
+    def test_dense_fallback_equal_overlap_breaks_tie_by_real_part(self):
+        # A seed equally overlapping both basis eigenvectors must fall back to
+        # the physical (largest-real) ordering, not the eigensolver's arbitrary
+        # order (issue #61 tie-break contract).
+        make_op = self._diag_operator([1.0, 3.0])       # e1 has the larger real
+        seed = np.array([1.0, 1.0], dtype=complex) / np.sqrt(2.0)
+        val, vec, info = _solve_leading(make_op, 2, "arnoldi", seed_vec=seed)
+        self.assertAlmostEqual(val.real, 3.0)
+        self.assertAlmostEqual(info["eigenvalues"][0].real, 3.0)
 
 
 class TestParitySelection(unittest.TestCase):

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -37,6 +37,7 @@ from hwave.sc import (
     _initialize_gap,
     _is_gap_parity,
     _make_kernel_operator,
+    _order_by_seed_overlap,
     _order_eigenpairs,
     _project_gap_parity,
     _reorder_eigenpairs_by_parity,
@@ -46,9 +47,11 @@ from hwave.sc import (
     _shift_from_eigenvalues,
     _solve_eigenvalue,
     _solve_iteration,
+    _solve_leading,
     _solve_subspace_iteration,
     _solve_shifted_bicg,
 )
+from scipy.sparse.linalg import LinearOperator
 
 
 class TestGreenFunction(unittest.TestCase):
@@ -650,6 +653,43 @@ class TestEigenpairOrdering(unittest.TestCase):
         self.assertAlmostEqual(ovals[0].real, 2.0)
         npt.assert_allclose(ovecs[:, 0], vecs[:, 1])
         npt.assert_allclose([v.real for v in ovals], [2.0, 0.5, -5.0])
+
+
+class TestSeedOverlapSelection(unittest.TestCase):
+    """When a seed eigenvector is supplied (eigenvector continuation), the
+    leading eigenpair must be the one that maximally overlaps the seed, not
+    the algebraically largest one. This must hold in the ``vec_size <= 2``
+    dense fallback (smallest dynamic grids, e.g. norb=1/Nk=1/Nmat=2) just as
+    it does in the ARPACK path -- see issue #61."""
+
+    @staticmethod
+    def _diag_operator(diag):
+        """A LinearOperator for a real diagonal matrix, standard-basis
+        eigenvectors. ``make_operator`` returns ``(A, vec_size)``."""
+        diag = np.asarray(diag, dtype=complex)
+        n = diag.size
+        A = LinearOperator(
+            (n, n), matvec=lambda x: diag * np.asarray(x).ravel(),
+            dtype=complex)
+        return lambda: (A, n)
+
+    def test_dense_fallback_selects_seeded_branch(self):
+        # eigenvalues 2.0 (basis vec e0) and 1.0 (basis vec e1); the largest
+        # real part is 2.0, but the seed points at the 1.0-branch.
+        make_op = self._diag_operator([2.0, 1.0])
+        seed = np.array([0.0, 1.0], dtype=complex)
+        val, vec, info = _solve_leading(
+            make_op, 2, "arnoldi", seed_vec=seed)
+        # Without seed handling the dense fallback would return 2.0/e0.
+        self.assertAlmostEqual(val.real, 1.0)
+        self.assertAlmostEqual(abs(np.vdot(vec, seed)), 1.0, places=10)
+        self.assertAlmostEqual(info["eigenvalues"][0].real, 1.0)
+
+    def test_dense_fallback_without_seed_uses_largest_real(self):
+        make_op = self._diag_operator([2.0, 1.0])
+        val, vec, info = _solve_leading(make_op, 2, "arnoldi")
+        # No seed -> physical SC eigenvalue is the algebraically largest.
+        self.assertAlmostEqual(val.real, 2.0)
 
 
 class TestParitySelection(unittest.TestCase):

--- a/tests/test_tsweep.py
+++ b/tests/test_tsweep.py
@@ -87,6 +87,23 @@ def test_preflight_requires_eigenvalue_solver_mode():
     ts.preflight(base, {"run_eliashberg": False})
 
 
+def test_documented_example_passes_preflight():
+    # Mirror the complete [eliashberg]/[continuation] example in
+    # docs/{en,ja}/source/rpa/tutorial/sc-index.rst so a copy-paste of the
+    # tutorial does not fail hwave_tsweep preflight (issue #61).
+    base = {
+        "mode": {"param": {"T": 0.02, "CellShape": [32, 32, 1],
+                           "Nmat": 512, "filling": 0.75}},
+        "file": {"input": {}, "output": {"path_to_output": "output"}},
+        "eliashberg": {"frequency": "dynamic", "chi0q_mode": "flex",
+                       "pairing_type": "singlet",
+                       "solver_mode": "eigenvalue"},
+    }
+    cont = {"T_start": 0.02, "T_stop": 0.005, "num": 6, "spacing": "log",
+            "run_eliashberg": True, "warm_start": True, "seed_gap": True}
+    ts.preflight(base, cont)
+
+
 @pytest.mark.parametrize("drop", ["CellShape", "Nmat"])
 def test_preflight_missing_shape_field(drop):
     base = _valid_base()


### PR DESCRIPTION
Closes #61.

Two follow-ups from the review of #60. Targets the #60 branch
(`feature/eliashberg-seed-eigenvector`) so #60 merges in a correct state.

## 1. Dense fallback ignored `seed_vec`
`_solve_leading`'s `vec_size <= 2` dense fallback (smallest dynamic grids, e.g.
`norb=1/Nk=1/Nmat=2`) always ordered by largest real part, ignoring a supplied
seed eigenvector. This broke the documented `seed_eigenvector` continuation
contract on tiny operators.

- Apply `_order_by_seed_overlap(vals, vecs, seed_vec)` in the dense fallback
  when a seed is present; preserve real-part ordering when none is supplied
  (matching the ARPACK path).
- Regression test: a 2-dim diagonal operator whose seeded branch (λ=1.0) is
  **not** the largest-real eigenpair (λ=2.0) — with a seed it selects 1.0,
  without a seed it selects 2.0.

## 2. Documented `hwave_tsweep` example failed preflight
The complete example in `docs/en` and `docs/ja` `rpa/tutorial/sc-index.rst`
omitted `[eliashberg] solver_mode`. The default `"iteration"` is rejected by
`hwave_tsweep.preflight()` (which needs `"eigenvalue"`/`"both"`), so copying
the tutorial failed before the sweep started.

- Added `solver_mode = "eigenvalue"` to both the EN and JA examples.
- Added a preflight regression test mirroring the documented config.

## Acceptance criteria
- [x] Seed overlap selection applied consistently in ARPACK and dense fallback paths.
- [x] Regression test covers seeded selection for `vec_size <= 2`.
- [x] The documented EN `hwave_tsweep` example passes preflight.
- [x] The JA example is updated consistently.

Tests: `tests/test_sc.py` + `tests/test_tsweep.py` = 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)