### PR TITLE
fix(flex): correct GPU VRAM preflight sizing

### DIFF
--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -468,8 +468,8 @@ class FLEX(RPA):
             # and a chi/vertex tensor, then allow for several live arrays.
             # The reduced chi/vertex is inflated to spin-orbital space, while
             # the general path carries a rank-4 orbital block. The 5x factor is
-            # still only an order-of-magnitude lower bound: transient
-            # FFT/einsum/solve workspace is not counted.
+            # a rough advisory estimate; transient FFT/einsum/solve workspace
+            # is not included, so actual peak usage may be higher.
             nblk0, _, _, nd0 = self.H0_eigenvector.shape
             nfreq_f = self._ir_axF.n_freq if self.use_ir else nmat
             nfreq_b = self._ir_axB.n_freq if self.use_ir else nmat

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -464,21 +464,23 @@ class FLEX(RPA):
         if gpu_active:
             logger.info("FLEX: GPU backend active (CuPy); moving H0 "
                         "eigenpairs and interaction to the device.")
-            # VRAM preflight: the resident device tensors (dressed G, sigma,
-            # chi_s/chi_c, v_eff, chi0q) are each ~ nblock*Nmat*Nvol*nd^2
-            # complex128 (H0_eigenvector has shape (nblock, Nvol, nd, nd)), and
-            # the SCF loop keeps several live at once. The 5x factor is a rough
-            # order-of-magnitude estimate -- transient FFT/einsum/solve
-            # workspace is not counted, so treat it as a lower bound. Advisory
-            # only; CuPy raises a clear OutOfMemoryError on the actual
-            # allocation.
+            # VRAM preflight: estimate the larger of a dressed-G/sigma tensor
+            # and a chi/vertex tensor, then allow for several live arrays.
+            # The reduced chi/vertex is inflated to spin-orbital space, while
+            # the general path carries a rank-4 orbital block. The 5x factor is
+            # still only an order-of-magnitude lower bound: transient
+            # FFT/einsum/solve workspace is not counted.
             nblk0, _, _, nd0 = self.H0_eigenvector.shape
-            # IR compresses the frequency axis to the node count; the general
-            # (full-vertex) susceptibilities carry a rank-4 orbital block
-            # (nd0**4) vs the reduced nd0**2.
-            nfreq_est = self._ir_axB.n_freq if self.use_ir else nmat
-            orb_factor = nd0 ** 4 if self._flex_general else nd0 ** 2
-            resident_bytes = nblk0 * nfreq_est * nvol * orb_factor * 16
+            nfreq_f = self._ir_axF.n_freq if self.use_ir else nmat
+            nfreq_b = self._ir_axB.n_freq if self.use_ir else nmat
+            green_elems = nblk0 * nfreq_f * nvol * nd0 ** 2
+            if self._flex_general:
+                vertex_elems = nfreq_b * nvol * nd0 ** 4
+            else:
+                inflated_nd = (nd0 if self.spin_mode == "spinful"
+                               else self.ns * self.norb)
+                vertex_elems = nfreq_b * nvol * inflated_nd ** 2
+            resident_bytes = max(green_elems, vertex_elems) * 16
             _bk.warn_if_device_memory_short(
                 5 * resident_bytes, logger, label="the FLEX SCF loop")
             self.H0_eigenvalue = xp.asarray(self.H0_eigenvalue)

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -473,13 +473,14 @@ class FLEX(RPA):
             nblk0, _, _, nd0 = self.H0_eigenvector.shape
             nfreq_f = self._ir_axF.n_freq if self.use_ir else nmat
             nfreq_b = self._ir_axB.n_freq if self.use_ir else nmat
-            green_elems = nblk0 * nfreq_f * nvol * nd0 ** 2
+            green_elems = nblk0 * nfreq_f * nvol * nd0**2
             if self._flex_general:
-                vertex_elems = nfreq_b * nvol * nd0 ** 4
+                vertex_elems = nfreq_b * nvol * nd0**4
             else:
-                inflated_nd = (nd0 if self.spin_mode == "spinful"
-                               else self.ns * self.norb)
-                vertex_elems = nfreq_b * nvol * inflated_nd ** 2
+                inflated_nd = (
+                    nd0 if self.spin_mode == "spinful" else self.ns * self.norb
+                )
+                vertex_elems = nfreq_b * nvol * inflated_nd**2
             resident_bytes = max(green_elems, vertex_elems) * 16
             _bk.warn_if_device_memory_short(
                 5 * resident_bytes, logger, label="the FLEX SCF loop")

--- a/tests/test_flex_ir.py
+++ b/tests/test_flex_ir.py
@@ -244,18 +244,16 @@ def test_ir_gpu_matches_cpu():
 
 
 def test_ir_reduced_vram_preflight_uses_inflated_spin_orbital_shape(
-        monkeypatch, tmp_path):
+    monkeypatch, tmp_path
+):
     """The resident reduced chi/V tensors are (2*norb)^2, not norb^2."""
     from hwave.solver import backend
 
-    solver, gi = _make_solver(
-        64, {"matsubara_basis": "ir"}, iteration_max=1)
+    solver, gi = _make_solver(64, {"matsubara_basis": "ir"}, iteration_max=1)
     solver.use_gpu = True
     captured = {}
 
-    monkeypatch.setattr(
-        backend, "get_backend",
-        lambda *a, **k: (np, True))
+    monkeypatch.setattr(backend, "get_backend", lambda *a, **k: (np, True))
 
     def capture(required_bytes, *args, **kwargs):
         captured["required_bytes"] = required_bytes
@@ -267,7 +265,7 @@ def test_ir_reduced_vram_preflight_uses_inflated_spin_orbital_shape(
 
     nfreq = solver._ir_axB.n_freq
     inflated_nd = solver.ns * solver.norb
-    expected = 5 * nfreq * solver.lattice.nvol * inflated_nd ** 2 * 16
+    expected = 5 * nfreq * solver.lattice.nvol * inflated_nd**2 * 16
     assert captured["required_bytes"] == expected
 
 

--- a/tests/test_flex_ir.py
+++ b/tests/test_flex_ir.py
@@ -10,6 +10,7 @@ Import-safe under both pytest and unittest discovery (CI lesson from #54).
 Tests must run from the repository root.
 """
 import os
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -263,9 +264,44 @@ def test_ir_reduced_vram_preflight_uses_inflated_spin_orbital_shape(
     with pytest.raises(RuntimeError, match="stop after VRAM preflight"):
         solver.solve(gi, str(tmp_path))
 
-    nfreq = solver._ir_axB.n_freq
+    nfreq_f = solver._ir_axF.n_freq
+    nfreq_b = solver._ir_axB.n_freq
+    nblk, _, _, nd = solver.H0_eigenvector.shape
     inflated_nd = solver.ns * solver.norb
-    expected = 5 * nfreq * solver.lattice.nvol * inflated_nd**2 * 16
+    green_elems = nblk * nfreq_f * solver.lattice.nvol * nd**2
+    vertex_elems = nfreq_b * solver.lattice.nvol * inflated_nd**2
+    expected = 5 * max(green_elems, vertex_elems) * 16
+    assert captured["required_bytes"] == expected
+
+
+def test_ir_vram_preflight_uses_larger_fermionic_tensor(monkeypatch, tmp_path):
+    """The fermionic node count controls sizing when dressed G is larger."""
+    from hwave.solver import backend
+
+    solver, gi = _make_solver(64, {"matsubara_basis": "ir"}, iteration_max=1)
+    solver.use_gpu = True
+    captured = {}
+    original_ir_setup = solver._ir_setup
+
+    def setup_with_more_fermionic_nodes(beta):
+        original_ir_setup(beta)
+        nfreq = 10 * solver._ir_axB.n_freq
+        solver._ir_axF = SimpleNamespace(n_freq=nfreq)
+
+    monkeypatch.setattr(solver, "_ir_setup", setup_with_more_fermionic_nodes)
+    monkeypatch.setattr(backend, "get_backend", lambda *a, **k: (np, True))
+
+    def capture(required_bytes, *args, **kwargs):
+        captured["required_bytes"] = required_bytes
+        raise RuntimeError("stop after VRAM preflight")
+
+    monkeypatch.setattr(backend, "warn_if_device_memory_short", capture)
+    with pytest.raises(RuntimeError, match="stop after VRAM preflight"):
+        solver.solve(gi, str(tmp_path))
+
+    nblk, _, _, nd = solver.H0_eigenvector.shape
+    green_elems = nblk * solver._ir_axF.n_freq * solver.lattice.nvol * nd**2
+    expected = 5 * green_elems * 16
     assert captured["required_bytes"] == expected
 
 

--- a/tests/test_flex_ir.py
+++ b/tests/test_flex_ir.py
@@ -243,6 +243,34 @@ def test_ir_gpu_matches_cpu():
     assert isinstance(gi_g["sigma"], np.ndarray)
 
 
+def test_ir_reduced_vram_preflight_uses_inflated_spin_orbital_shape(
+        monkeypatch, tmp_path):
+    """The resident reduced chi/V tensors are (2*norb)^2, not norb^2."""
+    from hwave.solver import backend
+
+    solver, gi = _make_solver(
+        64, {"matsubara_basis": "ir"}, iteration_max=1)
+    solver.use_gpu = True
+    captured = {}
+
+    monkeypatch.setattr(
+        backend, "get_backend",
+        lambda *a, **k: (np, True))
+
+    def capture(required_bytes, *args, **kwargs):
+        captured["required_bytes"] = required_bytes
+        raise RuntimeError("stop after VRAM preflight")
+
+    monkeypatch.setattr(backend, "warn_if_device_memory_short", capture)
+    with pytest.raises(RuntimeError, match="stop after VRAM preflight"):
+        solver.solve(gi, str(tmp_path))
+
+    nfreq = solver._ir_axB.n_freq
+    inflated_nd = solver.ns * solver.norb
+    expected = 5 * nfreq * solver.lattice.nvol * inflated_nd ** 2 * 16
+    assert captured["required_bytes"] == expected
+
+
 def test_ir_subshape_folded_matches_uniform():
     """Sublattice folding (SubShape != [1,1,1]) composes with the IR path:
     on the folded lattice (norb=2 after fold) the uniform chi_s static peak


### PR DESCRIPTION
## Summary

- size the FLEX GPU VRAM preflight from the largest resident tensor shape
- use separate fermionic and bosonic IR node counts
- account for reduced spin-free/spin-diag susceptibility and vertex inflation to spin-orbital space
- retain rank-4 orbital scaling for the general scheme
- add regression coverage for both a bosonic vertex maximum and a fermionic Green maximum

## Root cause

The previous reduced-scheme estimate used `nblock * nfreq * nvol * nd0**2` for every resident tensor. In spin-free and spin-diag FLEX, susceptibility and vertex tensors are inflated to `(ns * norb)**2`, so the advisory preflight could underestimate their resident size by up to 4x.

The estimate remains advisory: the 5x multiplier approximates several live arrays, while transient FFT/einsum/solve workspace is intentionally not included.

## Validation

- ai-review-cycle Phase 1: converged, no must/should-fix findings
- ai-review-cycle Phase 2: converged, no documentation/workflow findings
- regression RED/GREEN: both tests fail against `origin/develop` and pass with this fix
- full suite: `851 passed, 16 skipped`
- GPU-related: `24 passed, 3 skipped`
- IR FLEX: `16 passed, 1 skipped`
- flake8: 0 findings
- mypy: success on 22 source files
- darker/isort diff check: clean

All local pytest runs explicitly set `PYTHONPATH` to this worktree's `src` directory.