### PR TITLE
feat(sc): GPU (CuPy) support for the static Eliashberg solver

### DIFF
--- a/docs/en/source/rpa/tutorial/sc-index.rst
+++ b/docs/en/source/rpa/tutorial/sc-index.rst
@@ -202,9 +202,15 @@ This section controls the Eliashberg solver. Key parameters:
   Recommended whenever the leading eigenvalue comes out negative or you scan
   weakly-pairing systems (low pressure, quasi-1D). Note this differs from
   ``sigma_shift`` above (a shift-invert *target*, not a spectral shift).
-- ``gpu``: Set ``true`` to run the dynamic-mode (``frequency = "dynamic"``)
-  kernel applications on a GPU via CuPy (default ``false``; see the
-  :ref:`GPU section <sc_dynamic_gpu_en>` below).
+- ``gpu``: ``true`` runs the kernel-apply (matvec/matmat, the FFT convolution)
+  on the GPU (CuPy) for **both** ``frequency = "dynamic"`` and
+  ``frequency = "static"`` (default ``false``). The eigensolver itself (ARPACK
+  Arnoldi, power iteration, subspace iteration, shift-invert) always runs on the
+  host, because CuPy has no general non-Hermitian eigensolver; only the gap
+  vector crosses to the device per iteration. Without a usable CuPy/CUDA device
+  the run falls back to CPU with a warning (see the
+  :ref:`GPU-execution section <sc_dynamic_gpu_en>` below). ``fft_workers`` is
+  ignored on the GPU path.
 - ``gpu_required``: Set ``true`` to make ``gpu = true`` strict -- the solver
   raises instead of silently falling back to CPU when CuPy/CUDA is unavailable
   (default ``false``). Honored by the dynamic Eliashberg solver (set it in

--- a/docs/ja/source/rpa/tutorial/sc-index.rst
+++ b/docs/ja/source/rpa/tutorial/sc-index.rst
@@ -197,9 +197,14 @@ Eliashberg方程式ソルバーの設定です。主なパラメータ:
   スペクトルが全て正の実部になるように）。主固有値が負になる場合や、対形成が
   弱い系（低圧・擬1次元）を走査する場合に推奨します。上記の ``sigma_shift``
   （shift-invert のターゲット）とは別物である点に注意してください。
-- ``gpu``: ``true`` で動的モード（``frequency = "dynamic"``）のカーネル適用を
-  GPU（CuPy）で実行します（デフォルト ``false``。下記の
-  :ref:`GPU実行の節 <sc_dynamic_gpu>` を参照）。
+- ``gpu``: ``true`` でカーネル適用（matvec/matmat、FFT 畳み込み）を GPU（CuPy）で
+  実行します。``frequency = "dynamic"`` と ``frequency = "static"`` の **両方** に
+  対応します（デフォルト ``false``）。固有値ソルバー本体（ARPACK Arnoldi・べき乗
+  反復・部分空間反復・shift-invert）は常にホストで実行されます（CuPy に一般の
+  非エルミート固有値ソルバーが無いため）。反復ごとにデバイスへ渡るのはギャップ
+  ベクトルのみです。使用可能な CuPy/CUDA デバイスが無い場合は警告を出して CPU に
+  フォールバックします（下記の :ref:`GPU実行の節 <sc_dynamic_gpu>` を参照）。GPU
+  実行時は ``fft_workers`` は無視されます。
 - ``gpu_required``: ``true`` にすると ``gpu = true`` を厳格化し、CuPy/CUDA が
   使えない場合に静かに CPU へフォールバックせずエラーで停止します
   （デフォルト ``false``）。動的 Eliashberg ソルバー（``[eliashberg]`` に設定）

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -25,6 +25,7 @@ import hwave
 import hwave.qlmsio.wan90 as wan90
 from hwave.solver.rpa import validate_chi0q_index_convention
 from hwave.solver.ir_axis import is_ir_native, ir_native_meta
+from hwave.solver import backend
 
 logger = logging.getLogger("hwave_sc")
 
@@ -1918,9 +1919,18 @@ def _make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz):
     vec_size = norb * norb * Nx * Ny * Nz
     nvol = Nx * Ny * Nz
 
+    # Backend of the resident invariants (numpy on CPU, cupy when calc_eliashberg
+    # parked them on the device). Everything the kernel builds/derives must live
+    # on this same backend; assert Vs_q and G2 agree.
+    xp = backend.array_module_of(Vs_q)
+    if backend.array_module_of(G2) is not xp:
+        raise ValueError(
+            "_make_kernel_operator: Vs_q and G2 must be on the same backend "
+            "(both host or both device).")
+
     # Precompute invariants that don't change per matvec call:
-    # 1. V_r = IFFT(Vs_q) — used every matvec
-    V_r = ifftn(Vs_q, axes=(-3, -2, -1))
+    # 1. V_r = IFFT(Vs_q) -- used every matvec
+    V_r = backend.spatial_ifftn(Vs_q, axes=(-3, -2, -1))
 
     # 2. Precompute G2 reshaped for contraction
     G2_r = G2.reshape(norb, norb, norb, norb, nvol)
@@ -1934,9 +1944,9 @@ def _make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz):
     # are, per spatial point s, a small dense matvec over j (size norb*norb).
     # numpy.einsum does NOT lower these to batched BLAS GEMM, so we precompute
     # the operator tensors ONCE in GEMM-friendly (nvol, M=il, K=j) layout and
-    # apply them with np.matmul (s, and the column axis z for matmat, as
-    # leading batch axes). This is NOT bit-identical to the einsum (GEMM
-    # changes the reduction order) but matches it to ~1e-13.
+    # apply them with matmul (s, and the column axis z for matmat, as leading
+    # batch axes). This is NOT bit-identical to the einsum (GEMM changes the
+    # reduction order) but matches it to ~1e-13.
     if not is_simple:
         # G2_pre is (i, l, j, s); we need (s, (i,l), j).
         G2_gemm = G2_pre.transpose(3, 0, 1, 2).reshape(
@@ -1948,74 +1958,72 @@ def _make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz):
             nvol, norb * norb, norb * norb)
 
     def matvec(v):
+        # scipy hands us a HOST numpy vector; move it onto the invariants'
+        # backend before any device op (mixed numpy/cupy operands raise on real
+        # CuPy). On the numpy backend this is a no-op.
+        v = xp.asarray(v)
         sigma = v.reshape(norb, norb, Nx, Ny, Nz)
         sigma_flat = sigma.reshape(norb * norb, nvol)
 
         if is_simple:
-            G2Sigma = np.einsum('iljs,js->ils', G2_pre, sigma_flat).reshape(
+            G2Sigma = xp.einsum('iljs,js->ils', G2_pre, sigma_flat).reshape(
                 norb, norb, Nx, Ny, Nz)
-            G2Sigma_r = ifftn(G2Sigma, axes=(-3, -2, -1))
+            G2Sigma_r = backend.spatial_ifftn(G2Sigma, axes=(-3, -2, -1))
             Sigma_r = V_r * G2Sigma_r
-            sigma_new = fftn(Sigma_r, axes=(-3, -2, -1))
+            sigma_new = backend.spatial_fftn(Sigma_r, axes=(-3, -2, -1))
         else:
-            # G2Sigma[i,l,s] = sum_j G2_gemm[s,(i,l),j] * sigma_flat[j,s]
-            # sigma_flat (j, s) -> (s, j, 1); matmul -> (s, (i,l), 1).
-            sig = np.moveaxis(sigma_flat, 1, 0)[..., np.newaxis]
+            sig = xp.moveaxis(sigma_flat, 1, 0)[..., np.newaxis]
             G2Sigma = (G2_gemm @ sig)[..., 0]            # (s, (i,l))
-            # Back to the einsum's (i, l, s) order, then to spatial grid.
             G2Sigma = G2Sigma.reshape(nvol, norb, norb).transpose(
                 1, 2, 0).reshape(norb, norb, Nx, Ny, Nz)
 
-            F_r = ifftn(G2Sigma, axes=(-3, -2, -1))
+            F_r = backend.spatial_ifftn(G2Sigma, axes=(-3, -2, -1))
             F_r_flat = F_r.reshape(norb * norb, nvol)
-            f = np.moveaxis(F_r_flat, 1, 0)[..., np.newaxis]
+            f = xp.moveaxis(F_r_flat, 1, 0)[..., np.newaxis]
             sigma_r = (V_r_gemm @ f)[..., 0]             # (s, (i,l))
             sigma_r = sigma_r.reshape(nvol, norb, norb).transpose(
                 1, 2, 0).reshape(norb, norb, Nx, Ny, Nz)
-            sigma_new = fftn(sigma_r, axes=(-3, -2, -1))
+            sigma_new = backend.spatial_fftn(sigma_r, axes=(-3, -2, -1))
 
         # Keep complex: for complex hopping (e.g. spin-orbit coupling),
         # non-centrosymmetric models, or chiral gaps the kernel is genuinely
-        # complex; projecting to real would discard physical components.
-        return (-sigma_new).ravel()
+        # complex; projecting to real would discard physical components. Return
+        # a HOST array so scipy's ARPACK/power/subspace driver stays on numpy.
+        return backend.to_host(-sigma_new).ravel()
 
     def matmat(B):
         # Batched form of matvec: apply the SAME kernel to every column of the
-        # (vec_size, k) block B in a single FFT, instead of column-by-column.
-        # The batch/column axis is appended as the LAST axis so the spatial FFT
-        # axes keep their absolute positions (2, 3, 4) and the precomputed
-        # V_r / G2_pre (which have no column axis) broadcast over it.
-        B = np.asarray(B)
+        # (vec_size, k) block B in a single FFT. The batch/column axis is the
+        # LAST axis so the spatial FFT axes keep absolute positions (2, 3, 4)
+        # and V_r / G2_pre (no column axis) broadcast over it.
+        B = xp.asarray(B)
         if B.ndim == 1:
             return matvec(B)
         k = B.shape[1]
-        # (norb, norb, Nx, Ny, Nz, k)
         sigma = B.reshape(norb, norb, Nx, Ny, Nz, k)
         sigma_flat = sigma.reshape(norb * norb, nvol, k)
 
         if is_simple:
-            G2Sigma = np.einsum('iljs,jsz->ilsz', G2_pre, sigma_flat).reshape(
+            G2Sigma = xp.einsum('iljs,jsz->ilsz', G2_pre, sigma_flat).reshape(
                 norb, norb, Nx, Ny, Nz, k)
-            G2Sigma_r = ifftn(G2Sigma, axes=(2, 3, 4))
+            G2Sigma_r = backend.spatial_ifftn(G2Sigma, axes=(2, 3, 4))
             Sigma_r = V_r[..., np.newaxis] * G2Sigma_r
-            sigma_new = fftn(Sigma_r, axes=(2, 3, 4))
+            sigma_new = backend.spatial_fftn(Sigma_r, axes=(2, 3, 4))
         else:
-            # The column axis z is an extra trailing dim carried through the
-            # GEMM: sigma_flat (j, s, k) -> (s, j, k); matmul -> (s, (i,l), k).
-            sig = np.moveaxis(sigma_flat, 1, 0)          # (nvol, norb*norb, k)
+            sig = xp.moveaxis(sigma_flat, 1, 0)          # (nvol, norb*norb, k)
             G2Sigma = G2_gemm @ sig                      # (s, (i,l), k)
             G2Sigma = G2Sigma.reshape(nvol, norb, norb, k).transpose(
                 1, 2, 0, 3).reshape(norb, norb, Nx, Ny, Nz, k)
 
-            F_r = ifftn(G2Sigma, axes=(2, 3, 4))
+            F_r = backend.spatial_ifftn(G2Sigma, axes=(2, 3, 4))
             F_r_flat = F_r.reshape(norb * norb, nvol, k)
-            f = np.moveaxis(F_r_flat, 1, 0)              # (nvol, norb*norb, k)
+            f = xp.moveaxis(F_r_flat, 1, 0)              # (nvol, norb*norb, k)
             sigma_r = V_r_gemm @ f                       # (s, (i,l), k)
             sigma_r = sigma_r.reshape(nvol, norb, norb, k).transpose(
                 1, 2, 0, 3).reshape(norb, norb, Nx, Ny, Nz, k)
-            sigma_new = fftn(sigma_r, axes=(2, 3, 4))
+            sigma_new = backend.spatial_fftn(sigma_r, axes=(2, 3, 4))
 
-        return (-sigma_new).reshape(vec_size, k)
+        return backend.to_host(-sigma_new).reshape(vec_size, k)
 
     A = LinearOperator((vec_size, vec_size), matvec=matvec, matmat=matmat,
                        dtype=complex)

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -3032,6 +3032,12 @@ def _convert_chi0q_to_ref_format(chi0q, norb, Nx, Ny, Nz):
 def calc_eliashberg(input_dict):
     """Main calculation orchestration for linearized Eliashberg equation.
 
+    Supports ``[eliashberg] gpu = true`` for both ``frequency = "static"`` and
+    ``"dynamic"``: the kernel matvec/matmat runs on the GPU (CuPy) while the
+    host eigensolvers (ARPACK/power/subspace/shift-invert) consume host arrays.
+    Falls back to CPU with a warning when CuPy/CUDA is unusable, unless
+    ``gpu_required = true`` (then it fails fast).
+
     Parameters
     ----------
     input_dict : dict

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -3212,7 +3212,13 @@ def calc_eliashberg(input_dict):
     # solver entry points below pass Vs_q/G2 straight to _make_kernel_operator,
     # which derives its backend from them, so no other change is needed here.
     if gpu_active:
-        est_bytes = 2 * (Vs_q.nbytes + G2.nbytes)  # invariants + ~one workspace
+        # Resident device tensors are more than the two inputs: the operator
+        # also holds V_r (~Vs_q) and G2_pre (~G2), and in general mode
+        # G2_gemm (~G2) + V_r_gemm (~Vs_q) -- i.e. up to ~3x the inputs. The
+        # per-matmat block workspace (gap-sized x num columns) adds on top; a
+        # subspace/eigenvalue run with a wide block can still exceed this. It is
+        # only a pre-warning -- CuPy raises a clear OutOfMemoryError regardless.
+        est_bytes = 3 * (Vs_q.nbytes + G2.nbytes)
         backend.warn_if_device_memory_short(
             est_bytes, logger, label="the static Eliashberg kernel")
         logger.info("GPU backend active (CuPy): moving the pairing vertex and "

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -3037,17 +3037,6 @@ def calc_eliashberg(input_dict):
     input_dict : dict
         Parsed TOML configuration dictionary.
     """
-    # --- Config guards (fail fast before any file I/O) ---
-    # GPU acceleration is only wired into the dynamic solver; on the static
-    # (CPU-only) path refuse gpu=true rather than silently ignoring the flag.
-    from hwave.solver import eliashberg_dynamic as _ed
-    if (_eliashberg_frequency(input_dict) != "dynamic"
-            and _ed._gpu_requested(input_dict.get("eliashberg", {}))):
-        raise ValueError(
-            "[eliashberg] gpu=true is only supported for frequency='dynamic'; "
-            "the static Eliashberg solver is CPU-only. Set frequency='dynamic' "
-            "or remove gpu.")
-
     # --- Parse parameters ---
     mode_param = input_dict["mode"]["param"]
     T = mode_param["T"]
@@ -3084,6 +3073,13 @@ def calc_eliashberg(input_dict):
         _validate_dynamic_prereqs(input_dict)
         from hwave.solver import eliashberg_dynamic
         return eliashberg_dynamic.solve_dynamic(input_dict)
+
+    # GPU backend for the static kernel (the dynamic branch returned above and
+    # handles its own gpu flag). get_backend falls back to numpy with a warning
+    # when CuPy/CUDA is unusable, unless gpu_required=true (then it raises).
+    use_gpu = backend.as_bool(eli_param.get("gpu", False))
+    gpu_required = backend.as_bool(eli_param.get("gpu_required", False))
+    xp, gpu_active = backend.get_backend(use_gpu, logger, required=gpu_required)
 
     solver_mode = eli_param.get("solver_mode", "iteration")
     max_iter = eli_param.get("max_iter", 1000)
@@ -3204,6 +3200,20 @@ def calc_eliashberg(input_dict):
 
     # --- Step 11: Initialize gap function ---
     sigma_init = _initialize_gap(init_gap_mode, norb, kx_array, ky_array, kz_array)
+
+    # GPU: park the two large invariants (pairing vertex and pair bubble) on the
+    # device once; each matvec then only moves the gap vector across PCIe. The
+    # solver entry points below pass Vs_q/G2 straight to _make_kernel_operator,
+    # which derives its backend from them, so no other change is needed here.
+    if gpu_active:
+        est_bytes = 2 * (Vs_q.nbytes + G2.nbytes)  # invariants + ~one workspace
+        backend.warn_if_device_memory_short(
+            est_bytes, logger, label="the static Eliashberg kernel")
+        logger.info("GPU backend active (CuPy): moving the pairing vertex and "
+                    "G2 to the device (%.2f GB).",
+                    (Vs_q.nbytes + G2.nbytes) / 1e9)
+        Vs_q = xp.asarray(Vs_q)
+        G2 = xp.asarray(G2)
 
     # --- Step 12: Solve ---
     sigma_result = None

--- a/tests/test_eliashberg_dynamic.py
+++ b/tests/test_eliashberg_dynamic.py
@@ -50,15 +50,6 @@ def test_gpu_requested_parses_bool_and_string():
     assert ed._gpu_requested({"gpu": "0"}) is False
 
 
-def test_gpu_true_with_static_frequency_raises():
-    """gpu=true is only wired into the dynamic solver; on the static (CPU-only)
-    path it must fail loudly rather than silently ignore the flag."""
-    import hwave.sc as sc
-    inp = _min_input(gpu=True)          # frequency omitted -> static
-    with pytest.raises(ValueError, match="gpu"):
-        sc.calc_eliashberg(inp)
-
-
 def _write_flex_fixture(tmp_path, nmat=8, norb=1, Nx=2, Ny=2, Nz=1):
     nvol = Nx*Ny*Nz; nd = norb*norb
     rng = np.random.default_rng(3)

--- a/tests/test_sc_gpu.py
+++ b/tests/test_sc_gpu.py
@@ -164,3 +164,82 @@ def test_static_gpu_false_default_unchanged(flex_outdir, tmp_path):
     sc.calc_eliashberg(inp)
     assert os.path.exists(os.path.join(inp["file"]["output"]["path_to_output"],
                                        "eigenvalue.dat"))
+
+
+# --- real-CuPy parity (skips without a usable CUDA device) ----------------
+
+def _usable_cuda():
+    try:
+        import cupy
+        return cupy.cuda.runtime.getDeviceCount() >= 1
+    except Exception:
+        return False
+
+
+requires_cuda = pytest.mark.skipif(
+    not _usable_cuda(), reason="no usable CUDA device / CuPy")
+
+
+def _phase_align(g_gpu, g_cpu):
+    """Remove the arbitrary global complex phase between two eigenvectors."""
+    g_gpu = np.asarray(g_gpu).ravel()
+    g_cpu = np.asarray(g_cpu).ravel()
+    ov = np.vdot(g_cpu, g_gpu)
+    if abs(ov) > 0:
+        g_gpu = g_gpu * np.exp(-1j * np.angle(ov))
+    g_gpu = g_gpu / (np.linalg.norm(g_gpu) + 1e-300)
+    g_cpu = g_cpu / (np.linalg.norm(g_cpu) + 1e-300)
+    return g_gpu, g_cpu
+
+
+@requires_cuda
+@pytest.mark.parametrize("method", ["arnoldi", "subspace",
+                                    "shift-invert-gmres"])
+def test_static_kernel_gpu_matches_cpu_eigenvalue(method):
+    """Real CuPy: the static kernel's leading eigenvalue matches CPU for
+    matvec (arnoldi), matmat (subspace), and the inner-host-solver
+    (shift-invert) paths. The device path validates the host->device input
+    transfer that a numpy spy would tolerate."""
+    import cupy
+    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs(seed=3)
+    # a slightly larger, well-separated grid so the leading eigenvalue is
+    # non-degenerate
+    norb, Nx, Ny, Nz = 1, 4, 4, 1
+    rng = np.random.default_rng(7)
+    Vs_q = (rng.standard_normal((norb, norb, Nx, Ny, Nz))
+            + 1j * rng.standard_normal((norb, norb, Nx, Ny, Nz)))
+    G2 = (rng.standard_normal((norb, norb, norb, norb, Nx, Ny, Nz))
+          + 1j * rng.standard_normal((norb, norb, norb, norb, Nx, Ny, Nz)))
+
+    kw = dict(num_eigenvalues=4, method=method, sigma_shift=None,
+              spectral_shift=None)
+    vals_cpu, vecs_cpu = sc._solve_eigenvalue(Vs_q, G2, norb, Nx, Ny, Nz, **kw)
+    vals_gpu, vecs_gpu = sc._solve_eigenvalue(
+        cupy.asarray(Vs_q), cupy.asarray(G2), norb, Nx, Ny, Nz, **kw)
+
+    lam_cpu, lam_gpu = vals_cpu[0], vals_gpu[0]
+    assert abs(lam_gpu - lam_cpu) <= 1e-8 * max(1.0, abs(lam_cpu))
+    # outputs are host arrays
+    assert isinstance(vals_gpu, np.ndarray) and isinstance(vecs_gpu, np.ndarray)
+    # gap parity only when the leading eigenvalue is well separated
+    if abs(vals_cpu[0] - vals_cpu[1]) > 1e-3 * max(1.0, abs(vals_cpu[0])):
+        g_gpu, g_cpu = _phase_align(vecs_gpu[0], vecs_cpu[0])
+        assert np.linalg.norm(g_gpu - g_cpu) <= 1e-6
+
+
+@requires_cuda
+def test_static_kernel_gpu_matmat_is_host():
+    """The subspace/matmat path returns host arrays on the device backend."""
+    import cupy
+    norb, Nx, Ny, Nz = 1, 4, 4, 1
+    n = norb * norb * Nx * Ny * Nz
+    rng = np.random.default_rng(1)
+    Vs_q = (rng.standard_normal((norb, norb, Nx, Ny, Nz))
+            + 1j * rng.standard_normal((norb, norb, Nx, Ny, Nz)))
+    G2 = (rng.standard_normal((norb, norb, norb, norb, Nx, Ny, Nz))
+          + 1j * rng.standard_normal((norb, norb, norb, norb, Nx, Ny, Nz)))
+    A, _ = sc._make_kernel_operator(cupy.asarray(Vs_q), cupy.asarray(G2),
+                                    norb, Nx, Ny, Nz)
+    out = A.matmat(np.ones((n, 3), dtype=complex))
+    assert isinstance(out, np.ndarray) and out.shape == (n, 3)
+    assert out.dtype == np.complex128

--- a/tests/test_sc_gpu.py
+++ b/tests/test_sc_gpu.py
@@ -130,7 +130,7 @@ def _no_cupy(*args, **kwargs):
     raise ImportError("No module named 'cupy'")
 
 
-def test_static_gpu_true_no_longer_raises_and_falls_back(flex_outdir, tmp_path,
+def test_static_gpu_true_no_longer_raises_and_falls_back(flex_outdir,
                                                          monkeypatch, caplog):
     """gpu=true on the static path no longer raises; without CuPy it warns and
     completes on numpy."""
@@ -145,7 +145,7 @@ def test_static_gpu_true_no_longer_raises_and_falls_back(flex_outdir, tmp_path,
                                        "eigenvalue.dat"))
 
 
-def test_static_gpu_required_fails_fast_without_cupy(flex_outdir, tmp_path,
+def test_static_gpu_required_fails_fast_without_cupy(flex_outdir,
                                                      monkeypatch):
     """gpu_required=true must raise (not silently fall back) when CuPy is
     missing, on the static path too (issue #63 contract)."""
@@ -157,7 +157,7 @@ def test_static_gpu_required_fails_fast_without_cupy(flex_outdir, tmp_path,
         sc.calc_eliashberg(inp)
 
 
-def test_static_gpu_false_default_unchanged(flex_outdir, tmp_path):
+def test_static_gpu_false_default_unchanged(flex_outdir):
     """The default (gpu=false) static solve still runs and writes results."""
     import os
     inp = _static_flex_input(flex_outdir)
@@ -201,9 +201,7 @@ def test_static_kernel_gpu_matches_cpu_eigenvalue(method):
     (shift-invert) paths. The device path validates the host->device input
     transfer that a numpy spy would tolerate."""
     import cupy
-    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs(seed=3)
-    # a slightly larger, well-separated grid so the leading eigenvalue is
-    # non-degenerate
+    # a well-separated grid so the leading eigenvalue is non-degenerate
     norb, Nx, Ny, Nz = 1, 4, 4, 1
     rng = np.random.default_rng(7)
     Vs_q = (rng.standard_normal((norb, norb, Nx, Ny, Nz))

--- a/tests/test_sc_gpu.py
+++ b/tests/test_sc_gpu.py
@@ -1,0 +1,103 @@
+"""GPU (CuPy) support for the static Eliashberg solver.
+
+The real-CuPy parity tests skip on machines without a usable CUDA device; the
+routing, fallback, and orchestration tests run everywhere (they use a numpy-
+delegating spy backend or a monkeypatched missing-CuPy import). Tests must run
+from the repository root.
+"""
+import logging
+import types
+
+import numpy as np
+import pytest
+
+import hwave.sc as sc
+from hwave.solver import backend
+
+
+def _spy_backend(record):
+    """A numpy-delegating stand-in for a device backend module. Every op runs on
+    numpy (results stay correct), but asarray/asnumpy calls are recorded so a
+    test can assert the operator moved its inputs onto the backend and its
+    outputs back to the host. `array_module_of` is monkeypatched to return this,
+    so backend.to_host/spatial_* route through it too."""
+    def asarray(a, *args, **kwargs):
+        record.setdefault("asarray_shapes", []).append(np.asarray(a).shape)
+        return np.asarray(a, *args, **kwargs)
+
+    def asnumpy(a):
+        record.setdefault("asnumpy_calls", 0)
+        record["asnumpy_calls"] += 1
+        return np.asarray(a)
+
+    fft = types.SimpleNamespace(ifftn=np.fft.ifftn, fftn=np.fft.fftn)
+    return types.SimpleNamespace(
+        asarray=asarray, asnumpy=asnumpy, einsum=np.einsum,
+        moveaxis=np.moveaxis, fft=fft, newaxis=np.newaxis)
+
+
+def _small_simple_operator_inputs(seed=0):
+    """Tiny simple-mode (5-D vertex) inputs for the kernel operator."""
+    norb, Nx, Ny, Nz = 1, 2, 2, 1
+    rng = np.random.default_rng(seed)
+    def cplx(shape):
+        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape))
+    Vs_q = cplx((norb, norb, Nx, Ny, Nz))
+    G2 = cplx((norb, norb, norb, norb, Nx, Ny, Nz))
+    return Vs_q, G2, norb, Nx, Ny, Nz
+
+
+def test_kernel_operator_cpu_returns_host_complex128():
+    """On the plain CPU path matvec/matmat return real numpy complex128 arrays
+    of the documented shapes (guards against silent CuPy leakage)."""
+    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs()
+    A, n = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
+    out = A.matvec(np.ones(n, dtype=complex))
+    assert isinstance(out, np.ndarray) and out.shape == (n,)
+    assert out.dtype == np.complex128
+    B = np.ones((n, 3), dtype=complex)
+    outm = A.matmat(B)
+    assert isinstance(outm, np.ndarray) and outm.shape == (n, 3)
+    assert outm.dtype == np.complex128
+
+
+def test_kernel_operator_routes_input_and_output_through_backend(monkeypatch):
+    """matvec/matmat must (a) move their host input onto the invariants'
+    backend (xp.asarray) BEFORE any kernel op, and (b) return host arrays via
+    backend.to_host. Catches the review must-fix: a missing host->device input
+    transfer would break real CuPy but not a spy that returns numpy."""
+    record = {}
+    spy = _spy_backend(record)
+    monkeypatch.setattr(backend, "array_module_of", lambda a: spy)
+
+    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs()
+    # reference (unpatched) result for correctness
+    A_ref, n = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
+    ref = A_ref.matvec(np.ones(n, dtype=complex))
+
+    A, n = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
+    v = np.ones(n, dtype=complex)
+    out = A.matvec(v)
+
+    # (a) the input vector (shape (n,)) was passed through xp.asarray
+    assert (n,) in record["asarray_shapes"]
+    # (b) an output was host-ized
+    assert record.get("asnumpy_calls", 0) >= 1
+    # correctness preserved
+    assert isinstance(out, np.ndarray)
+    np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
+
+
+def test_kernel_operator_asserts_matched_backends(monkeypatch):
+    """Vs_q and G2 must live on the same backend."""
+    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs()
+    calls = {"n": 0}
+    real = backend.array_module_of
+
+    def alternating(a):
+        calls["n"] += 1
+        return np if calls["n"] == 1 else types.SimpleNamespace()
+
+    monkeypatch.setattr(backend, "array_module_of", alternating)
+    with pytest.raises(ValueError, match="same backend"):
+        sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)

--- a/tests/test_sc_gpu.py
+++ b/tests/test_sc_gpu.py
@@ -254,6 +254,37 @@ def test_static_kernel_gpu_matches_cpu_general_multiorbital(method):
 
 
 @requires_cuda
+@pytest.mark.parametrize("pairing_type", ["singlet", "triplet"])
+def test_static_kernel_gpu_iteration_matches_cpu(pairing_type):
+    """Real CuPy: the _solve_iteration path -- the parity-leakage probe (several
+    A.matvec calls) plus the power loop and parity handling -- runs on
+    device-resident invariants and matches CPU. The _solve_eigenvalue tests
+    above never exercise this path; here the device operator is driven by the
+    iteration/probe machinery instead. green_kw is unused by the body, so None."""
+    import cupy
+    norb, Nx, Ny, Nz = 1, 4, 4, 1
+    rng = np.random.default_rng(5)
+
+    def cplx(shape):
+        return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+    Vs_q = cplx((norb, norb, Nx, Ny, Nz))
+    G2 = cplx((norb, norb, norb, norb, Nx, Ny, Nz))
+    sigma_init = cplx((norb, norb, Nx, Ny, Nz))
+    kw = dict(max_iter=300, alpha=0.5, tol=1e-10, pairing_type=pairing_type)
+
+    sig_cpu, lam_cpu, _, _ = sc._solve_iteration(
+        None, Vs_q, G2, sigma_init.copy(), norb, **kw)
+    sig_gpu, lam_gpu, _, _ = sc._solve_iteration(
+        None, cupy.asarray(Vs_q), cupy.asarray(G2), sigma_init.copy(), norb, **kw)
+
+    assert abs(lam_gpu - lam_cpu) <= 1e-8 * max(1.0, abs(lam_cpu))
+    assert isinstance(sig_gpu, np.ndarray)   # returned gap is host
+    g_gpu, g_cpu = _phase_align(sig_gpu, sig_cpu)
+    assert np.linalg.norm(g_gpu - g_cpu) <= 1e-6
+
+
+@requires_cuda
 def test_static_kernel_gpu_matmat_is_host():
     """The subspace/matmat path returns host arrays on the device backend."""
     import cupy

--- a/tests/test_sc_gpu.py
+++ b/tests/test_sc_gpu.py
@@ -101,3 +101,66 @@ def test_kernel_operator_asserts_matched_backends(monkeypatch):
     monkeypatch.setattr(backend, "array_module_of", alternating)
     with pytest.raises(ValueError, match="same backend"):
         sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
+
+
+# --- calc_eliashberg static-path GPU orchestration ------------------------
+
+from tests.test_eliashberg_ir import flex_outdir  # noqa: E402  (module fixture)
+
+
+def _static_flex_input(outdir):
+    """A small static (frequency omitted -> 'static') Eliashberg input that
+    reads the FLEX fixture's susceptibilities. Nmat matches the fixture."""
+    from tests.test_eliashberg_ir import BETA_T, LX, LY, NMAT
+    return {
+        "mode": {"param": {"T": BETA_T, "CellShape": [LX, LY, 1],
+                           "SubShape": [1, 1, 1], "Nmat": NMAT,
+                           "filling": 0.5}},
+        "file": {"input": {"interaction": {
+                    "path_to_input": "tests/rpa/input",
+                    "Geometry": "geom.dat", "Transfer": "transfer.dat",
+                    "CoulombIntra": "coulombintra.dat"}},
+                 "output": {"path_to_output": outdir}},
+        "eliashberg": {"chi0q_mode": "flex", "solver_mode": "iteration",
+                       "max_iter": 50, "convergence_tol": 1e-7},
+    }
+
+
+def _no_cupy(*args, **kwargs):
+    raise ImportError("No module named 'cupy'")
+
+
+def test_static_gpu_true_no_longer_raises_and_falls_back(flex_outdir, tmp_path,
+                                                         monkeypatch, caplog):
+    """gpu=true on the static path no longer raises; without CuPy it warns and
+    completes on numpy."""
+    monkeypatch.setattr(backend, "_import_cupy", _no_cupy)
+    inp = _static_flex_input(flex_outdir)
+    inp["eliashberg"]["gpu"] = True
+    with caplog.at_level(logging.WARNING):
+        sc.calc_eliashberg(inp)   # must not raise
+    assert any("cupy" in r.getMessage().lower() for r in caplog.records)
+    import os
+    assert os.path.exists(os.path.join(inp["file"]["output"]["path_to_output"],
+                                       "eigenvalue.dat"))
+
+
+def test_static_gpu_required_fails_fast_without_cupy(flex_outdir, tmp_path,
+                                                     monkeypatch):
+    """gpu_required=true must raise (not silently fall back) when CuPy is
+    missing, on the static path too (issue #63 contract)."""
+    monkeypatch.setattr(backend, "_import_cupy", _no_cupy)
+    inp = _static_flex_input(flex_outdir)
+    inp["eliashberg"]["gpu"] = True
+    inp["eliashberg"]["gpu_required"] = True
+    with pytest.raises(RuntimeError, match="gpu_required"):
+        sc.calc_eliashberg(inp)
+
+
+def test_static_gpu_false_default_unchanged(flex_outdir, tmp_path):
+    """The default (gpu=false) static solve still runs and writes results."""
+    import os
+    inp = _static_flex_input(flex_outdir)
+    sc.calc_eliashberg(inp)
+    assert os.path.exists(os.path.join(inp["file"]["output"]["path_to_output"],
+                                       "eigenvalue.dat"))

--- a/tests/test_sc_gpu.py
+++ b/tests/test_sc_gpu.py
@@ -66,17 +66,20 @@ def test_kernel_operator_routes_input_and_output_through_backend(monkeypatch):
     backend (xp.asarray) BEFORE any kernel op, and (b) return host arrays via
     backend.to_host. Catches the review must-fix: a missing host->device input
     transfer would break real CuPy but not a spy that returns numpy."""
+    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs()
+    n = norb * norb * Nx * Ny * Nz
+    v = np.ones(n, dtype=complex)
+
+    # true numpy reference computed BEFORE any monkeypatch, so the allclose
+    # below can actually detect a numerical change introduced by the routing
+    # (an unpatched-vs-patched compare, not spy-vs-spy).
+    A_ref, _ = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
+    ref = A_ref.matvec(v)
+
     record = {}
     spy = _spy_backend(record)
     monkeypatch.setattr(backend, "array_module_of", lambda a: spy)
-
-    Vs_q, G2, norb, Nx, Ny, Nz = _small_simple_operator_inputs()
-    # reference (unpatched) result for correctness
-    A_ref, n = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
-    ref = A_ref.matvec(np.ones(n, dtype=complex))
-
-    A, n = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
-    v = np.ones(n, dtype=complex)
+    A, _ = sc._make_kernel_operator(Vs_q, G2, norb, Nx, Ny, Nz)
     out = A.matvec(v)
 
     # (a) the input vector (shape (n,)) was passed through xp.asarray
@@ -223,6 +226,31 @@ def test_static_kernel_gpu_matches_cpu_eigenvalue(method):
     if abs(vals_cpu[0] - vals_cpu[1]) > 1e-3 * max(1.0, abs(vals_cpu[0])):
         g_gpu, g_cpu = _phase_align(vecs_gpu[0], vecs_cpu[0])
         assert np.linalg.norm(g_gpu - g_cpu) <= 1e-6
+
+
+@requires_cuda
+@pytest.mark.parametrize("method", ["arnoldi", "subspace"])
+def test_static_kernel_gpu_matches_cpu_general_multiorbital(method):
+    """Real CuPy: the GENERAL 4-index vertex path -- norb=2, a 7-D Vs_q, and
+    distinct non-unit spatial dims (2x3x2) -- exercising the else-branch GEMM /
+    xp.moveaxis and all three FFT axes, where a backend/axis mistake is most
+    likely and which the simple-mode (5-D, norb=1) tests above do not cover."""
+    import cupy
+    norb, Nx, Ny, Nz = 2, 2, 3, 2
+    rng = np.random.default_rng(11)
+
+    def cplx(shape):
+        return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+    Vs_q = cplx((norb, norb, norb, norb, Nx, Ny, Nz))   # 7-D -> general branch
+    G2 = cplx((norb, norb, norb, norb, Nx, Ny, Nz))
+    kw = dict(num_eigenvalues=4, method=method, sigma_shift=None,
+              spectral_shift=None)
+    vals_cpu, _ = sc._solve_eigenvalue(Vs_q, G2, norb, Nx, Ny, Nz, **kw)
+    vals_gpu, vecs_gpu = sc._solve_eigenvalue(
+        cupy.asarray(Vs_q), cupy.asarray(G2), norb, Nx, Ny, Nz, **kw)
+    assert abs(vals_gpu[0] - vals_cpu[0]) <= 1e-8 * max(1.0, abs(vals_cpu[0]))
+    assert isinstance(vals_gpu, np.ndarray) and isinstance(vecs_gpu, np.ndarray)
 
 
 @requires_cuda


### PR DESCRIPTION
## Summary

Adds `[eliashberg] gpu = true` support to the **static** linearized-Eliashberg solver, which was previously CPU-only (it explicitly refused `gpu=true`). This mirrors the existing dynamic-Eliashberg GPU path exactly.

**Architecture — the GPU boundary is the kernel operator.** The iterative eigensolve calls the kernel `matvec`/`matmat` hundreds of times; that is the whole speedup target.
- `_make_kernel_operator` is made backend-parametric: it derives its backend from `Vs_q`/`G2`, converts each host `matvec`/`matmat` input onto that backend (`xp.asarray`) before any device op, runs the FFT convolution via `backend.spatial_fftn`/`spatial_ifftn`, and returns **host** arrays via `backend.to_host`.
- `calc_eliashberg` resolves the backend once (`backend.get_backend`, CPU fallback with warning / `gpu_required` fail-fast) and parks the two invariants (`Vs_q`, `G2`) on the device before the solve.
- **The eigensolvers stay on the host, unchanged** — ARPACK `eigs`, power iteration, subspace iteration, shift-invert all keep consuming numpy, because CuPy has no general non-Hermitian eigensolver. Only the gap vector crosses PCIe per matvec.

The three solver entry points (`_solve_iteration`, `_solve_eigenvalue`, `_solve_subspace_iteration`) are unchanged pass-throughs — they touch `Vs_q`/`G2` only via `_make_kernel_operator`.

## Scope
- In scope: the kernel-apply (matvec/matmat). The one-time builders (`_calc_green`/`_calc_g2`/vertices), `_determine_mu`, and the RPA chi0q internal path stay on CPU (deferred).
- CPU path (`gpu=false`, default) is behavior-preserving for every `solver_mode`/`eigenvalue_method`.

## Tests
- CI-runnable: guard-removed, fallback + warning, `gpu_required` fail-fast, backend-routing (spy backend proves host→device input conversion + host output), CPU return-type/dtype. Existing `tests/test_sc.py` kernel-equivalence suite guards CPU numerics.
- GPU-gated (`@requires_cuda`, skips on CI): real-CuPy λ parity for arnoldi (matvec) / subspace (matmat) / shift-invert-gmres (inner host solver), phase-aligned gap parity, host-output assertions.
- Full repo suite: 875 passed, 16 skipped.

## Real-GPU validation (clavius, RTX 6000 Ada)
- All 10 `test_sc_gpu.py` tests pass on real CuPy 13.6 (including the 4 GPU-gated parity tests).
- Full `calc_eliashberg` static solve, gpu=false vs gpu=true: the `gpu_active` device-move block fires (confirmed via log) and **λ is bitwise identical (0.706269657, abs diff = 0.0)**.

## Process
Designed via brainstorming + AI design review (Codex + Antigravity — caught the host→device input-transfer must-fix and an over-engineered state-restoration that were folded in), implemented task-by-task with per-task + final whole-branch review (READY TO MERGE, no Critical/Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)