### PR TITLE
Fix orbital-index consistency of FLEX chiq_s/chiq_c output and hwave_sc k-space builders

### DIFF
--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -530,11 +530,17 @@ def _build_hamiltonian_k(kx_array, ky_array, kz_array, hr, norb):
     kx_mesh, ky_mesh, kz_mesh = np.meshgrid(
         kx_array, ky_array, kz_array, indexing='ij'
     )
+    # Solver-core convention (rpa.py _make_ham_trans: tab_r[R,orb1,orb2] +
+    # fftn == e^{-ikR}): epsilon[a,b](k) = sum_R t_R[a,b] e^{-ikR}. This keeps
+    # sc-built quantities element-wise consistent with arrays loaded from
+    # FLEX/RPA output files. (The previous [orb2,orb1] + e^{+ikR} form is the
+    # orbital transpose at -k; identical for real hoppings, different for
+    # complex Hermitian ones.)
     for (irvec, orbvec), value in hr.items():
         orb1, orb2 = orbvec
         Rx, Ry, Rz = irvec
-        epsilon_k[orb2, orb1, :, :, :] += value * np.exp(
-            1j * (kx_mesh * Rx + ky_mesh * Ry + kz_mesh * Rz)
+        epsilon_k[orb1, orb2, :, :, :] += value * np.exp(
+            -1j * (kx_mesh * Rx + ky_mesh * Ry + kz_mesh * Rz)
         )
     return epsilon_k
 
@@ -566,12 +572,14 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
     )
 
     def _to_k(value_r):
+        # same solver-core convention as _build_hamiltonian_k:
+        # V[a,b](q) = sum_R V_R[a,b] e^{-iqR}
         val_k = np.zeros((norb, norb, Nx, Ny, Nz), dtype=complex)
         for (irvec, orbvec), value in value_r.items():
             orb1, orb2 = orbvec
             Rx, Ry, Rz = irvec
-            val_k[orb2, orb1, :, :, :] += value * np.exp(
-                1j * (kx_mesh * Rx + ky_mesh * Ry + kz_mesh * Rz)
+            val_k[orb1, orb2, :, :, :] += value * np.exp(
+                -1j * (kx_mesh * Rx + ky_mesh * Ry + kz_mesh * Rz)
             )
         return val_k
 

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -1105,11 +1105,14 @@ def _compute_vertices_flex(chis, chic, inter_k, norb, Nx, Ny, Nz,
     ``convention`` selects the S/C interaction matrices applied to the
     susceptibilities: "kuroki" (default, arXiv:0902.3691, used by the reduced
     FLEX path and the rest of the Eliashberg solver) or "myo"
-    (cond-mat/0407094). The two differ in the charge ``C(ab,ab) = -U'+2J`` vs
-    ``-U'+J`` element. Susceptibilities produced by the general (full-vertex)
-    FLEX path are in MYO convention and MUST be paired with ``convention='myo'``
+    (cond-mat/0407094). The two differ ONLY in the charge ``C(ab,ab) = -U'+2J``
+    vs ``-U'+J`` element; they share the native [a,c,b,d] orbital-pair index
+    layout. Susceptibilities produced by the general (full-vertex) FLEX path
+    were computed with the MYO S/C and MUST be paired with ``convention='myo'``
     so the vertex stays self-consistent (mixing them with Kuroki S/C silently
-    changes the physics in the C(ab,ab) channel).
+    changes the physics in the C(ab,ab) channel). ``convention`` is a S/C-charge
+    selector, not an index-layout flag: ``chis``/``chic`` are expected in the
+    native [a,c,b,d] orbital-pair order regardless (issue #78).
 
     Parameters
     ----------
@@ -1214,9 +1217,14 @@ def _load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz,
         Dressed Green's function if available, shape
         (norb, norb, Nx, Ny, Nz, nmat) with the full fermionic axis.
     chi_convention : str
-        Orbital convention of chis_w/chic_w: "myo" (general full-vertex FLEX)
-        or "kuroki" (reduced FLEX / legacy files). Pass this to
-        _compute_vertices_flex so the matching S/C matrices are used.
+        Provenance/S-C-convention tag of chis_w/chic_w: "myo" (general
+        full-vertex FLEX) or "kuroki" (reduced FLEX / legacy files). It selects
+        which S/C interaction matrices _compute_vertices_flex pairs the
+        susceptibilities with (they differ only in the C(ab,ab) charge value)
+        and which orbital-pair shape family the file uses (orbital-pair
+        nd=norb^2 for "myo", spin-orbital nd=norb*ns for "kuroki"). It is NOT an
+        index-layout flag: chis_w/chic_w are returned in the public RPA
+        [a,c,b,d] orbital-pair order for both (issue #78).
     ir_meta : dict or None
         Only when ``allow_ir=True``: ``None`` for uniform files, else the
         per-file IR node metadata ``{"chis":..., "chic":..., "green":...}``
@@ -1309,6 +1317,28 @@ def _read_flex_chi_raw(input_dict, allow_ir=False):
             "FLEX chi_s and chi_c have different conventions ('{}' vs '{}'); "
             "they must come from the same run. Check flex_chi_s/flex_chi_c.".format(
                 chi_convention, chi_convention_c))
+    # Self-describing index-order marker (issue #78 follow-up). Current files
+    # always store [a,c,b,d]; the marker exists so a pre-#78 dev output (the
+    # general path stored MYO-transposed arrays under the SAME "myo" tag,
+    # indistinguishable by tag alone) is rejected instead of silently building
+    # a transposed pairing vertex, and so any future layout change fails fast.
+    # Marker-less "kuroki"/untagged files stay readable: the reduced-path
+    # layout never changed.
+    for data, path in ((data_s, chi_s_path), (data_c, chi_c_path)):
+        if "chi_orbital_layout" in data:
+            layout = str(data["chi_orbital_layout"])
+            if layout != "acbd":
+                raise ValueError(
+                    "FLEX chi file '{}' declares chi_orbital_layout='{}' but "
+                    "this reader only supports 'acbd'.".format(path, layout))
+        elif chi_convention == "myo":
+            raise ValueError(
+                "FLEX chi file '{}' is tagged chi_convention='myo' but lacks "
+                "the chi_orbital_layout marker: it was produced by a pre-fix "
+                "development build that stored the arrays orbital-pair-"
+                "TRANSPOSED (issue #78) and would yield a wrong pairing "
+                "vertex. Re-run FLEX with the current build to regenerate "
+                "it.".format(path))
     if not allow_ir:
         return chi_s_raw, chi_c_raw, chi_convention
 

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -1721,21 +1721,32 @@ class FLEX(RPA):
         v_eff : ndarray
             Effective FLEX interaction ``(nmat, nvol, norb^2, norb^2)``.
         chi_s : ndarray
-            Spin susceptibility in the general-path **MYO** orbital convention
-            (rank-6 ``(nmat,nvol,m,n,mu,nu)``).
+            Spin susceptibility for public output, in the RPA ``[a,c,b,d]``
+            orbital convention (rank-6), consistent with chi0q_out and the
+            reduced path -- NOT the internal MYO layout used for the S/C math.
         chi_c : ndarray
-            Charge susceptibility in the general-path **MYO** orbital convention
-            (rank-6 ``(nmat,nvol,m,n,mu,nu)``).
+            Charge susceptibility for public output, in the RPA ``[a,c,b,d]``
+            orbital convention (rank-6), consistent with chi0q_out and the
+            reduced path -- NOT the internal MYO layout used for the S/C math.
         """
         chi0q, Us, Uc = self._inflate_chi0q_and_ham_general(chi0q_raw, ham_orig)
         chi_s, chi_c = self._solve_channels_general(chi0q, Us, Uc)
         v_eff = self._calc_veff_general(chi0q, chi_s, chi_c, Us, Uc)
-        # Expose chi0q in the RPA [a,c,b,d] convention (consistent with the
-        # reduced path) for the public output. The MYO transpose is an internal
-        # detail of the S/C math; transposing back (the transpose is an
-        # involution) recovers the input convention. chi_s/chi_c remain in the
-        # general-path MYO convention (see _solve_channels_general).
+        # Expose chi0q AND chi_s/chi_c in the RPA [a,c,b,d] convention
+        # (consistent with the reduced path) for the public output. The MYO
+        # transpose is an internal detail of the S/C math; transposing back (the
+        # transpose is an involution) recovers the input convention. chi_s/chi_c
+        # MUST be back-converted too: the Eliashberg loader (_compute_vertices_flex)
+        # builds S @ chi @ S with S/C matrices in the native [a,c,b,d] orbital-pair
+        # index layout (build_sc_matrices_myo shares that layout with the Kuroki
+        # builder; convention='myo' only changes the C(ab,ab) charge value), so
+        # leaving chi_s/chi_c in the MYO index order builds a transposed pairing
+        # vertex and a wrong static lambda (issue #78). The "myo" chi_convention
+        # tag still marks these as general-path (orbital-pair shape + MYO S/C
+        # charge convention); only the orbital-pair index order is native here.
         chi0q_out = chi0q.transpose(0, 1, 4, 5, 2, 3)
+        chi_s = chi_s.transpose(0, 1, 4, 5, 2, 3)
+        chi_c = chi_c.transpose(0, 1, 4, 5, 2, 3)
         return chi0q_out, v_eff, chi_s, chi_c
 
     @do_profile
@@ -2555,15 +2566,28 @@ class FLEX(RPA):
             logger.info("save_results: save chi0q in file {}".format(file_name))
 
         # Save susceptibilities (spin and charge channels separately for
-        # Eliashberg). Tag the orbital convention so the downstream Eliashberg
-        # consumer (_load_flex_susceptibilities / _compute_vertices_flex) pairs
-        # them with the matching S/C matrices: the general (full-vertex) path
-        # produces MYO-convention susceptibilities, the reduced path Kuroki.
+        # Eliashberg). The chi_convention tag tells the downstream consumer
+        # (_load_flex_susceptibilities / _compute_vertices_flex) which S/C
+        # matrices to pair the susceptibilities with: "myo" (general full-vertex
+        # path) selects build_sc_matrices_myo, "kuroki" (reduced path) the
+        # default builder; the two differ only in the C(ab,ab) charge value.
+        # NOTE: the arrays themselves are stored in the public RPA [a,c,b,d]
+        # orbital-pair index order for BOTH paths (see _flex_compute_veff_general,
+        # issue #78) -- the tag selects the S/C charge convention, not the index
+        # layout. It also marks the general path's orbital-pair shape
+        # (nd = norb^2) vs the reduced path's spin-orbital shape (nd = norb*ns).
         common_meta = dict(nmat=self.nmat,
                            wavevector_unit=self.kvec,
                            wavevector_index=self.wavenum_table,
                            chi_convention=("myo" if self._flex_general
                                            else "kuroki"),
+                           # Explicit self-describing index-order marker: both
+                           # paths store [a,c,b,d]. Lets the reader distinguish
+                           # these files from pre-#78 dev outputs (which stored
+                           # the general path's chi MYO-transposed under the
+                           # same "myo" tag) and fail fast on any future layout
+                           # change instead of silently misreading.
+                           chi_orbital_layout="acbd",
                            **_freq_meta("B"))
 
         if "chiq_s" in green_info:

--- a/tests/test_eliashberg_dynamic.py
+++ b/tests/test_eliashberg_dynamic.py
@@ -58,9 +58,9 @@ def _write_flex_fixture(tmp_path, nmat=8, norb=1, Nx=2, Ny=2, Nz=1):
     # "myo" convention; tag it so the loader treats it as orbital-pair (no
     # spin-orbital block extraction).
     np.savez(tmp_path/"chiq_s.npz", chiq_s=rc((nmat, nvol, nd, nd)),
-             chi_convention="myo")
+             chi_convention="myo", chi_orbital_layout="acbd")
     np.savez(tmp_path/"chiq_c.npz", chiq_c=rc((nmat, nvol, nd, nd)),
-             chi_convention="myo")
+             chi_convention="myo", chi_orbital_layout="acbd")
     np.savez(tmp_path/"green.npz",  green=rc((1, nmat, nvol, norb, norb)))
     return dict(nmat=nmat, norb=norb, Nx=Nx, Ny=Ny, Nz=Nz)
 

--- a/tests/test_flex_general.py
+++ b/tests/test_flex_general.py
@@ -294,10 +294,114 @@ class TestGeneralOutputConvention(unittest.TestCase):
         myo = chi0_raw.transpose(0, 1, 4, 5, 2, 3)
         self.assertGreater(np.linalg.norm(chi0q_out - myo), 1e-6)
 
+    def test_output_chi_s_c_are_rpa_convention(self):
+        """chi_s/chi_c must exit _flex_compute_veff_general in the same RPA
+        [a,c,b,d] orbital convention as chi0q_out, i.e. the internal MYO
+        channels transposed back with transpose(0,1,4,5,2,3).
+
+        The Eliashberg loader (sc._compute_vertices_flex) consumes chi_s/chi_c
+        with native-[a,c,b,d]-layout S/C matrices, so a residual MYO transpose
+        here builds a transposed pairing vertex and a wrong static lambda
+        (issue #78: chi0q_mode='flex' disagreed with 'load' for identical Sigma=0
+        physics)."""
+        flex = _make_general_flex(norb=2)
+        # Reproduce the exact internal MYO channels the method computes, so the
+        # assertion is anchored to a genuine cross-computation, not a self-check.
+        flex._myo_sc_cache = None
+        chi0_raw = _fake_general_chi0q(flex)
+        chi0q_myo, Us, Uc = flex._inflate_chi0q_and_ham_general(chi0_raw, None)
+        chi_s_myo, chi_c_myo = flex._solve_channels_general(chi0q_myo, Us, Uc)
+
+        flex._myo_sc_cache = None
+        _, _, chi_s_out, chi_c_out = \
+            flex._flex_compute_veff_general(chi0_raw, None)
+
+        inv = (0, 1, 4, 5, 2, 3)
+        np.testing.assert_allclose(
+            chi_s_out, chi_s_myo.transpose(inv), atol=1e-12,
+            err_msg="chi_s must be exposed in RPA [a,c,b,d] convention")
+        np.testing.assert_allclose(
+            chi_c_out, chi_c_myo.transpose(inv), atol=1e-12,
+            err_msg="chi_c must be exposed in RPA [a,c,b,d] convention")
+        # ...and genuinely differ from the raw MYO layout (norb=2 is asymmetric),
+        # so the assertion above is not vacuously satisfied by a symmetric tensor.
+        self.assertGreater(np.linalg.norm(chi_s_out - chi_s_myo), 1e-6)
+        self.assertGreater(np.linalg.norm(chi_c_out - chi_c_myo), 1e-6)
+
+    def test_flex_vertex_matches_load_vertex_sigma0(self):
+        """Physical regression for issue #78: for identical Sigma=0 physics the
+        Eliashberg pairing vertex built from general-FLEX chi_s/chi_c
+        (sc._compute_vertices_flex, convention='myo') must equal the vertex the
+        'load' path builds directly from the same chi0q
+        (sc._compute_vertices_general).
+
+        This is the end-to-end check the layout-only tests cannot make: a
+        wrong-direction or missing orbital-pair transpose of chi_s/chi_c makes
+        S @ chi @ S build a transposed pairing vertex, so the two paths disagree
+        (that was the bug). The J=0 on-site 2-orbital fixture is used so the MYO
+        and Kuroki S/C matrices coincide and the singlet/triplet vertices must
+        match exactly."""
+        import os
+        import tempfile
+        import hwave.sc as sc
+
+        flex = _make_general_flex(norb=2)   # J=0 on-site 2-orbital fixture
+        flex._myo_sc_cache = None
+        norb = flex.norb
+        Nx, Ny, Nz = flex.lattice.shape
+        nvol = flex.lattice.nvol
+        nd = norb * norb
+        nmat = flex.nmat
+        si = nmat // 2
+
+        # Same random asymmetric chi0q feeds BOTH paths. FLEX solves the RPA
+        # channels in MYO layout then transposes back (issue #78 fix); the load
+        # path solves them natively from the same chi0q.
+        chi0_raw = _fake_general_chi0q(flex)   # (nmat, nvol, a, c, b, d)
+        chi0q_out, _, chi_s, chi_c = \
+            flex._flex_compute_veff_general(chi0_raw, None)
+
+        # Build the interaction on the same grid from the same fixture files the
+        # FLEX solver read, so both S/C matrices come from identical U/U'.
+        dirpath = os.path.join(tempfile.gettempdir(),
+                               "hwave_flex_2d_2orb_onsite")
+        input_dict = {"file": {"input": {"interaction": {
+            "path_to_input": dirpath,
+            "Geometry": "geom.dat", "Transfer": "transfer.dat",
+            "CoulombIntra": "coulombintra.dat",
+            "CoulombInter": "coulombinter.dat"}}}}
+        _, _, interactions = sc._read_interaction_files(input_dict)
+        kx = np.linspace(0, 2 * np.pi, Nx, endpoint=False)
+        ky = np.linspace(0, 2 * np.pi, Ny, endpoint=False)
+        kz = np.linspace(0, 2 * np.pi, Nz, endpoint=False)
+        inter_k = sc._build_interaction_k(kx, ky, kz, interactions, norb)
+
+        # load path consumes chi0q as (a,c,b,d, Nx,Ny,Nz, nmat)
+        chi0q_load = chi0q_out.transpose(2, 3, 4, 5, 1, 0).reshape(
+            norb, norb, norb, norb, Nx, Ny, Nz, nmat)
+        # flex path consumes the static chi_s/chi_c as (Nx,Ny,Nz, nd,nd)
+        chis_stat = chi_s[si].reshape(Nx, Ny, Nz, nd, nd)
+        chic_stat = chi_c[si].reshape(Nx, Ny, Nz, nd, nd)
+
+        for pairing in ("singlet", "triplet"):
+            Vs_flex = sc._compute_vertices_flex(
+                chis_stat, chic_stat, inter_k, norb, Nx, Ny, Nz,
+                pairing_type=pairing, convention="myo")
+            Vs_load = sc._compute_vertices_general(
+                chi0q_load, inter_k, norb, Nx, Ny, Nz, nmat,
+                pairing_type=pairing, static_index=si)
+            np.testing.assert_allclose(
+                Vs_flex, Vs_load, rtol=1e-8, atol=1e-10,
+                err_msg="flex vertex ({}) must match load vertex for "
+                        "Sigma=0".format(pairing))
+
 
 class TestGeneralChiConventionRoundTrip(unittest.TestCase):
-    """General FLEX tags saved chiq_s/chiq_c as MYO; the Eliashberg loader reads
-    that tag back so the pairing vertex uses MYO (not Kuroki) S/C matrices."""
+    """General FLEX tags saved chiq_s/chiq_c with chi_convention='myo'; the
+    Eliashberg loader reads that tag back so the pairing vertex uses the MYO
+    (not Kuroki) S/C matrices. The arrays themselves are stored in the public
+    [a,c,b,d] index order (issue #78); the tag selects the S/C charge
+    convention, not the index layout."""
 
     def _save_and_reload_convention(self, flex):
         import tempfile
@@ -351,17 +455,20 @@ class TestGeneralChiConventionRoundTrip(unittest.TestCase):
         with self.assertRaises(ValueError):
             sc._load_flex_susceptibilities(input_dict, 2, 2, 2, 1)
 
-    def test_real_rank6_chi_roundtrips_to_myo_flattening(self):
-        """Save REAL general-path (rank-6 MYO) chi_s/chi_c, reload through the
-        Eliashberg loader, and confirm the static slice flattens to (nd,nd) in
-        the MYO row=(m,n)/col=(mu,nu) order that build_sc_matrices_myo expects."""
+    def test_real_rank6_chi_roundtrips_to_native_flattening(self):
+        """Save REAL general-path (rank-6) chi_s/chi_c, reload through the
+        Eliashberg loader, and confirm the static slice flattens to (nd,nd)
+        consistently. The public chi_s/chi_c are exposed in the RPA [a,c,b,d]
+        orbital convention (issue #78), so the loader passes the orbital-pair
+        arrays through unchanged and the round trip is an identity."""
         import tempfile
         import hwave.sc as sc
         flex = _make_general_flex(norb=2)
         flex._myo_sc_cache = None
         chi0 = _fake_general_chi0q(flex)
         _, _, chi_s, chi_c = flex._flex_compute_veff_general(chi0, None)
-        # real general chi is rank-6 (nmat, nvol, m, n, mu, nu)
+        # real general chi is rank-6 (nmat, nvol, a, c, b, d) after the public
+        # back-transpose (issue #78); MYO ordering is internal to the S/C math
         self.assertEqual(chi_s.ndim, 6)
         nx, ny, nz = flex.lattice.shape
         nd = flex.norb * flex.norb
@@ -376,10 +483,80 @@ class TestGeneralChiConventionRoundTrip(unittest.TestCase):
             input_dict, flex.norb, nx, ny, nz)
         self.assertEqual(conv, "myo")
         self.assertEqual(chis.shape, (nx, ny, nz, nd, nd))
-        # expected static slice flattened with row=(m,n), col=(mu,nu)
+        # expected static slice flattened in the public [a,c,b,d] convention
         center = flex.nmat // 2
         expected = chi_s[center].reshape(nx, ny, nz, nd, nd)
         np.testing.assert_allclose(chis, expected, atol=1e-12)
+
+
+class TestChiOrbitalLayoutMarker(unittest.TestCase):
+    """The chiq_s/chiq_c files carry an explicit ``chi_orbital_layout="acbd"``
+    marker so the on-disk index order is self-describing (issue #78 follow-up).
+
+    Reader contract (_read_flex_chi_raw):
+    - marker present and != "acbd"  -> ValueError (future layout changes fail fast)
+    - marker absent + tag "myo"     -> ValueError (pre-#78 dev build stored the
+      MYO-transposed arrays under the same tag; must be regenerated)
+    - marker absent + tag "kuroki" / untagged -> accepted (reduced-path layout
+      never changed; legacy files stay readable)
+    """
+
+    def _write_pair(self, d, meta_s=None, meta_c=None, nd=4, nmat=4, nvol=4):
+        arr = np.zeros((nmat, nvol, nd, nd), dtype=complex)
+        np.savez(os.path.join(d, "chiq_s.npz"), chiq_s=arr, **(meta_s or {}))
+        np.savez(os.path.join(d, "chiq_c.npz"), chiq_c=arr, **(meta_c or {}))
+        return {"file": {"output": {"path_to_output": d}}, "eliashberg": {}}
+
+    def test_writer_stamps_acbd_layout_both_paths(self):
+        import tempfile
+        flex = _make_general_flex(norb=2)
+        nd = flex.norb * flex.norb
+        shape = (flex.nmat, flex.lattice.nvol, nd, nd)
+        green_info = {"chiq_s": np.zeros(shape, dtype=complex),
+                      "chiq_c": np.zeros(shape, dtype=complex)}
+        for general, conv in ((True, "myo"), (False, "kuroki")):
+            d = tempfile.mkdtemp()
+            flex._flex_general = general
+            flex.save_results(
+                {"path_to_output": d, "chiq_s": "chiq_s", "chiq_c": "chiq_c"},
+                green_info)
+            for name in ("chiq_s.npz", "chiq_c.npz"):
+                with np.load(os.path.join(d, name)) as data:
+                    self.assertEqual(str(data["chi_convention"]), conv)
+                    self.assertEqual(str(data["chi_orbital_layout"]), "acbd")
+
+    def test_reader_rejects_myo_without_layout_marker(self):
+        import tempfile
+        import hwave.sc as sc
+        inp = self._write_pair(tempfile.mkdtemp(),
+                               meta_s={"chi_convention": "myo"},
+                               meta_c={"chi_convention": "myo"})
+        with self.assertRaisesRegex(ValueError, "chi_orbital_layout"):
+            sc._read_flex_chi_raw(inp)
+
+    def test_reader_rejects_unknown_layout_marker(self):
+        import tempfile
+        import hwave.sc as sc
+        meta = {"chi_convention": "myo", "chi_orbital_layout": "myo_pair"}
+        inp = self._write_pair(tempfile.mkdtemp(), meta_s=meta, meta_c=meta)
+        with self.assertRaisesRegex(ValueError, "acbd"):
+            sc._read_flex_chi_raw(inp)
+
+    def test_reader_accepts_kuroki_without_marker(self):
+        import tempfile
+        import hwave.sc as sc
+        meta = {"chi_convention": "kuroki"}
+        inp = self._write_pair(tempfile.mkdtemp(), meta_s=meta, meta_c=meta)
+        _, _, conv = sc._read_flex_chi_raw(inp)
+        self.assertEqual(conv, "kuroki")
+
+    def test_reader_accepts_myo_with_acbd_marker(self):
+        import tempfile
+        import hwave.sc as sc
+        meta = {"chi_convention": "myo", "chi_orbital_layout": "acbd"}
+        inp = self._write_pair(tempfile.mkdtemp(), meta_s=meta, meta_c=meta)
+        _, _, conv = sc._read_flex_chi_raw(inp)
+        self.assertEqual(conv, "myo")
 
 
 class TestVeffGeneral(unittest.TestCase):

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -54,6 +54,66 @@ from hwave.sc import (
 from scipy.sparse.linalg import LinearOperator
 
 
+class TestKSpaceBuilderConvention(unittest.TestCase):
+    """The hwave_sc k-space builders must follow the SAME Fourier/orbital
+    convention as the UHFk/RPA/FLEX solver core:
+
+        M[a, b](k) = sum_R M_R[a, b] * exp(-i k.R)
+
+    (rpa.py _make_ham_trans: tab_r[R, orb1, orb2] + numpy fftn == e^{-ikR}).
+    Historically sc.py built epsilon_k[orb2, orb1] with e^{+ikR}, i.e. the
+    orbital-transposed matrix at -k. For real (time-reversal-symmetric)
+    hoppings the two coincide element-wise, which masked the difference; for
+    complex Hermitian hoppings they differ, so quantities loaded from
+    FLEX/RPA files (green, chi0q) disagreed element-wise with sc-built ones.
+    These tests pin the solver convention with a complex Hermitian fixture."""
+
+    def setUp(self):
+        self.Nx, self.Ny, self.Nz = 4, 4, 1
+        self.norb = 2
+        # complex Hermitian hopping: t(-R, b, a) = conj(t(R, a, b))
+        self.hr = {
+            ((0, 0, 0), (0, 1)): -2.5 + 0.3j,
+            ((0, 0, 0), (1, 0)): -2.5 - 0.3j,
+            ((1, 0, 0), (0, 1)): -2.8 + 0.5j,
+            ((-1, 0, 0), (1, 0)): -2.8 - 0.5j,
+            ((0, 1, 0), (0, 0)): -0.5,
+            ((0, -1, 0), (0, 0)): -0.5,
+        }
+        self.kx = np.linspace(0, 2 * np.pi, self.Nx, endpoint=False)
+        self.ky = np.linspace(0, 2 * np.pi, self.Ny, endpoint=False)
+        self.kz = np.linspace(0, 2 * np.pi, self.Nz, endpoint=False)
+
+    def _expected(self, value_r):
+        """Direct evaluation of the solver convention sum_R M_R[a,b] e^{-ikR}."""
+        out = np.zeros((self.norb, self.norb, self.Nx, self.Ny, self.Nz),
+                       dtype=complex)
+        kxm, kym, kzm = np.meshgrid(self.kx, self.ky, self.kz, indexing='ij')
+        for (irvec, (o1, o2)), v in value_r.items():
+            out[o1, o2] += v * np.exp(
+                -1j * (kxm * irvec[0] + kym * irvec[1] + kzm * irvec[2]))
+        return out
+
+    def test_hamiltonian_k_matches_solver_convention(self):
+        eps = _build_hamiltonian_k(self.kx, self.ky, self.kz, self.hr,
+                                   self.norb)
+        npt.assert_allclose(eps, self._expected(self.hr), atol=1e-12)
+
+    def test_interaction_k_matches_solver_convention(self):
+        # complex Hermitian off-site "CoulombInter" exercises both the
+        # orbital-index order and the Fourier phase sign
+        vr = {
+            ((1, 0, 0), (0, 1)): 0.7 + 0.2j,
+            ((-1, 0, 0), (1, 0)): 0.7 - 0.2j,
+            ((0, 1, 0), (0, 0)): 0.4,
+            ((0, -1, 0), (0, 0)): 0.4,
+        }
+        inter_k = _build_interaction_k(self.kx, self.ky, self.kz,
+                                       {"CoulombInter": vr}, self.norb)
+        npt.assert_allclose(inter_k["CoulombInter"], self._expected(vr),
+                            atol=1e-12)
+
+
 class TestGreenFunction(unittest.TestCase):
     """Test Green's function construction."""
 


### PR DESCRIPTION
Fixes #78.

## Summary

Two related orbital-index consistency fixes for the Eliashberg workflow, plus a self-describing layout marker for the FLEX susceptibility files.

### 1. General-FLEX `chiq_s`/`chiq_c` stored orbital-pair-transposed (#78)

The general (full-vertex) FLEX path computes the spin/charge susceptibilities internally in the MYO orbital-pair convention — the orbital-pair transpose of the RPA `[a,c,b,d]` layout. At the output boundary `chi0q` was already transposed back, but `chi_s`/`chi_c` were written still transposed, and `hwave_sc` (`chi0q_mode="flex"`) consumed them assuming the native layout. For identical Σ=0 physics the static eigenvalue differed between `chi0q_mode="load"` (0.22698, correct — independently cross-checked by the reporter) and `"flex"` (0.22198).

**Fix**: apply the same `transpose(0,1,4,5,2,3)` involution to `chi_s`/`chi_c` that `chi0q` already received. The `chi_convention="myo"` tag keeps selecting the MYO S/C charge convention (`C(ab,ab) = -U'+2J`) and the orbital-pair shape; it no longer implies an index layout.

**Marker**: the saved files now carry `chi_orbital_layout="acbd"`. The reader rejects `"myo"`-tagged files without the marker (outputs of pre-fix development builds, indistinguishable by tag alone) with a clear regenerate message, and rejects any non-`"acbd"` declaration. Marker-less `"kuroki"`/untagged files stay readable (the reduced-path layout never changed). Since this path is unreleased, no migration layer is needed — the released format is self-describing from day one.

### 2. `hwave_sc` k-space builders aligned with the solver core

`_build_hamiltonian_k`/`_build_interaction_k` built `M[orb2,orb1]` with `e^{+ikR}` — the orbital transpose of the UHFk/RPA/FLEX convention `M[a,b](k) = Σ_R M_R[a,b] e^{-ikR}` evaluated at −k. Element-wise identical for real hoppings (which masked it), different for complex Hermitian ones: sc-built Green's functions satisfied `G_sc[a,b](k) = G_file[b,a](−k)` against FLEX/RPA-loaded arrays.

Eigenvalues were **not** affected (the relabeling commutes with the kernel on the parity-projected gap sector; verified identical λ on real and complex 2-orbital models before/after), but element-wise consistency matters for orbital-resolved gap analysis and any future code mixing sc-built and file-loaded arrays. After the change, the FLEX-saved dressed green matches sc's bare green element-wise (4e-16) at Σ=0 on a complex-hopping model (previously 16% off). FLEX solver outputs are bit-identical (its general path uses `_build_interaction_k` for on-site terms only, where the change is a no-op).

## Verification

- New unit tests: chi_s/chi_c output convention, layout-marker writer/reader contract, builder convention (complex Hermitian fixtures); plus a physical regression asserting the flex-mode pairing vertex equals the load-mode vertex (singlet and triplet) for the same Σ=0 input. Each new test was confirmed to fail on the unfixed code.
- Full test suite: 891 passed, 24 skipped, 0 failures.
- End-to-end on the reporter's 2-orbital reproduction bundle: `load` and `flex` eigenvalues now identical (rel. diff 0) for both real and complex hopping; freshly written files carry the layout marker; simulated pre-fix files are rejected with an explicit regenerate message.

## Out of scope (found during verification, will be filed separately)

`chi0q_mode="calc"` gives a different eigenvalue than `"load"` for the same physics (λ=0.343 vs 0.227 on the reproduction model). Confirmed pre-existing on `develop` @ 4b2faac, unaffected by this PR; the `load` value is the independently cross-checked one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sxixvt2jcxF66HEFHg55fa
