### PR TITLE
Add an undocumented output_chi_pm switch to cross-check the FLEX spin channel

### DIFF
--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -263,17 +263,27 @@ class FLEX(RPA):
                 .format(self.mixing_scheme))
         self.anderson_depth = int(self.param_mod.get("anderson_depth", 5))
 
-        # UNDOCUMENTED verification switch, off by default. On the paramagnetic
-        # general path it additionally solves the TRANSVERSE (spin-flip) channel
-        # and stores it as chiq_pm. For a paramagnetic system SU(2) symmetry
-        # forces chi^{+-} == chi^{zz}, and the two are built along genuinely
-        # different routes -- the longitudinal one from the Kuroki S matrix, the
-        # transverse one from the crossed (Fock-exchange) Hartree vertex -- so
-        # their agreement is a real cross-check of the vertex construction
-        # rather than a restatement. It is deliberately not in the manual: it
-        # adds a diagnostic output, not physics, and is redundant by symmetry.
-        self.output_chi_pm = _bk.as_bool(
-            self.param_mod.get("output_chi_pm", False))
+        # UNDOCUMENTED verification switch, off by default. On the general path
+        # it additionally solves the TRANSVERSE (spin-flip) channel from the
+        # crossed (Fock-exchange) Hartree vertex, which for an SU(2)-invariant
+        # interaction must reproduce the longitudinal spin channel built from
+        # the Kuroki S matrix -- a genuine cross-check, since the two come from
+        # different vertices. Deliberately not in the manual: a diagnostic, not
+        # physics.
+        #
+        # Three states, because the array is large -- at Nmat=5120 on a 48x48
+        # mesh it is about 3 GB, and the answer being sought is a single number:
+        #   false   (default) do nothing
+        #   "check"           solve it, report the comparison, discard the array
+        #   true              solve it, report, and store/save chiq_pm
+        _pm = self.param_mod.get("output_chi_pm", False)
+        if isinstance(_pm, str) and _pm.strip().lower() == "check":
+            self.chi_pm_mode = "check"
+        elif _bk.as_bool(_pm):
+            self.chi_pm_mode = "save"
+        else:
+            self.chi_pm_mode = "off"
+        self.output_chi_pm = self.chi_pm_mode != "off"
 
         # Matsubara-axis representation (design: docs/design/ir-matsubara.md,
         # Stage 2): the default uniform grid, or the sparse-ir intermediate
@@ -743,6 +753,20 @@ class FLEX(RPA):
         # of the axis, not of the vertices.
         chi_pm = (self._calc_chi_pm(chi0q_out, ham_orig)
                   if self.output_chi_pm else None)
+        if chi_pm is not None:
+            # Compare on the axis both were dressed on, before densification.
+            _pm_h, _s_h = _bk.to_host(chi_pm), _bk.to_host(chi_s)
+            _d = float(np.max(np.abs(_pm_h - _s_h)))
+            _sc = float(np.max(np.abs(_s_h)))
+            logger.info(
+                "output_chi_pm: max|chi_pm - chi_s| = %.6e (relative %.3e). "
+                "For an SU(2)-invariant interaction this should be at "
+                "round-off; a larger value with anisotropic terms (bare Hund, "
+                "bare Ising) is physical.",
+                _d, _d / max(_sc, np.finfo(float).tiny))
+            if self.chi_pm_mode == "check":
+                # The number above was the point; do not carry ~GB of array.
+                chi_pm = None
 
         if self.use_ir and self.write_densified:
             axF, axB = self._ir_axF, self._ir_axB

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -700,6 +700,9 @@ class FLEX(RPA):
                 self.H0_eigenvector = _bk.to_host(self.H0_eigenvector)
             logger.warning("FLEX IterationMax=0: no SCF step performed; "
                            "no results stored.")
+            # Reachable with a reused green_info; do not leave a chiq_pm from
+            # an earlier solve behind for save_results to publish.
+            green_info.pop("chiq_pm", None)
             return
 
         # Final-output consistency: during the loop green_kw was built from the
@@ -738,7 +741,7 @@ class FLEX(RPA):
         # the (nonlinear) RPA solve to interpolated data -- the two operations do
         # not commute, so the check would report a mismatch that is an artifact
         # of the axis, not of the vertices.
-        chi_pm = (self._calc_chi_pm_check(chi0q_out, ham_orig)
+        chi_pm = (self._calc_chi_pm(chi0q_out, ham_orig)
                   if self.output_chi_pm else None)
 
         if self.use_ir and self.write_densified:
@@ -1850,56 +1853,48 @@ class FLEX(RPA):
 
         return chi0q, ham
 
-    def _calc_chi_pm_check(self, chi0q_out, ham_orig):
-        """Transverse (spin-flip) susceptibility, as a verification output.
+    def _calc_chi_pm(self, chi0q_out, ham_orig):
+        """Transverse (spin-flip) susceptibility chi^{+-}, as an extra output.
 
         Enabled by the undocumented ``output_chi_pm`` switch. Solves the
         transverse RPA channel with the crossed (Fock-exchange) Hartree vertex
         -- ``RPA._build_transverse_channel`` -- from the final-iteration FLEX
-        chi0q (the same one the stored chi_s was dressed from; note FLEX still
-        produces it when the SCF stops at IterationMax without converging), and
-        returns chi^{+-}.
+        chi0q, the same one the stored chi_s was dressed from. (FLEX still
+        produces that chi0q when the SCF stops at IterationMax without
+        converging.)
 
-        For a paramagnetic system SU(2) symmetry forces chi^{+-} == chi^{zz},
-        so this must reproduce the longitudinal spin channel. Because the two
-        are assembled from different vertices, agreement is a genuine check on
-        the vertex construction rather than a tautology.
+        This deliberately makes NO claim about what the result should equal, and
+        applies no interaction-dependent filter. Whether chi^{+-} coincides with
+        the longitudinal spin channel depends on the rotational invariance of
+        the interaction, which is a property of the user's model rather than
+        something this function should adjudicate:
 
-        Returns ``None`` (with a warning) when the check is not applicable:
-        it needs the rank-4 orbital chi0q that only ``calc_scheme="general"``
-        produces, and the identity it verifies only holds for a paramagnetic
-        run.
+        - For an SU(2)-invariant interaction (density-density terms such as
+          CoulombIntra/CoulombInter, or a coefficient-matched full Kanamori set)
+          it must equal the longitudinal spin susceptibility, and a mismatch
+          points at the vertex construction.
+        - Bare Hund gives W_+- = -J and bare Ising W_+- = 2J, neither equal to
+          the longitudinal vertex, so there the two differ legitimately -- and
+          that difference is itself the interesting quantity.
+
+        An earlier version tried to decide applicability from the configured
+        interaction names. That was wrong in both directions: it skipped a valid
+        rotationally invariant Kanamori set and accepted bare Exchange, and it
+        would have needed the parameter relations between the anisotropic terms
+        encoded in the loader. Emitting the number and leaving the comparison to
+        the reader is both simpler and more useful.
+
+        Returns ``None`` (with a warning) only for a genuine technical
+        obstruction: the transverse channel needs the rank-4 orbital chi0q that
+        only ``calc_scheme="general"`` produces.
         """
         if not self._flex_general:
             logger.warning(
                 "output_chi_pm: skipped -- the transverse channel needs the "
                 "full rank-4 orbital chi0q, which only calc_scheme='general' "
-                "produces (got '%s'). On the reduced/squashed path the "
-                "transverse channel is not separately defined: chi_s already "
-                "IS the isotropic spin susceptibility.", self.calc_scheme)
-            return None
-        if self.spin_mode != "spin-free":
-            logger.warning(
-                "output_chi_pm: skipped -- chi^{+-} == chi^{zz} only for a "
-                "paramagnetic run, and this one is spin_mode='%s'.",
-                self.spin_mode)
-            return None
-        # spin-free is about the ONE-BODY Hamiltonian; the identity also needs
-        # SU(2)-invariant interactions. Per the transverse builder's own table,
-        # Hund alone gives W_+- = -J and Ising alone W_+- = 2J, neither equal to
-        # the longitudinal vertex, so chi^{+-} != chi^{zz} legitimately and a
-        # mismatch would say nothing about the vertex construction. Only run the
-        # check on interaction sets where the identity actually holds.
-        not_su2 = [k for k in ("Hund", "Ising")
-                   if k in getattr(self.ham_info, "param_ham", {})]
-        if not_su2:
-            logger.warning(
-                "output_chi_pm: skipped -- %s present. spin-free constrains the "
-                "one-body Hamiltonian, not the interaction: these terms are not "
-                "SU(2)-invariant on their own (W_+- differs from the "
-                "longitudinal vertex), so chi^{+-} != chi^{zz} is expected and "
-                "the comparison would not test the vertex construction.",
-                ", ".join(not_su2))
+                "produces (got '%s'). On the reduced/squashed path there is "
+                "also nothing separate to output: chi_s already IS the "
+                "isotropic spin susceptibility.", self.calc_scheme)
             return None
         # Both operands on the host: ham_orig may still be the device copy the
         # SCF loop used, and mixing it with a host chi0q inside _solve_rpa would
@@ -1907,9 +1902,12 @@ class FLEX(RPA):
         chi0q_pm, ham_pm = self._build_transverse_channel(
             _bk.to_host(chi0q_out), _bk.to_host(ham_orig))
         chi_pm = _bk.to_host(self._solve_rpa(chi0q_pm, ham_pm))
-        logger.info("output_chi_pm: transverse channel solved "
-                    "(shape %s); for a paramagnetic run it should equal the "
-                    "longitudinal spin susceptibility.", chi_pm.shape)
+        logger.info(
+            "output_chi_pm: transverse channel solved (shape %s). For an "
+            "SU(2)-invariant interaction it should equal the longitudinal spin "
+            "susceptibility chiq_s; with anisotropic terms (bare Hund, bare "
+            "Ising, unmatched combinations) a difference is physical.",
+            chi_pm.shape)
         return chi_pm
 
     @do_profile

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -263,6 +263,18 @@ class FLEX(RPA):
                 .format(self.mixing_scheme))
         self.anderson_depth = int(self.param_mod.get("anderson_depth", 5))
 
+        # UNDOCUMENTED verification switch, off by default. On the paramagnetic
+        # general path it additionally solves the TRANSVERSE (spin-flip) channel
+        # and stores it as chiq_pm. For a paramagnetic system SU(2) symmetry
+        # forces chi^{+-} == chi^{zz}, and the two are built along genuinely
+        # different routes -- the longitudinal one from the Kuroki S matrix, the
+        # transverse one from the crossed (Fock-exchange) Hartree vertex -- so
+        # their agreement is a real cross-check of the vertex construction
+        # rather than a restatement. It is deliberately not in the manual: it
+        # adds a diagnostic output, not physics, and is redundant by symmetry.
+        self.output_chi_pm = _bk.as_bool(
+            self.param_mod.get("output_chi_pm", False))
+
         # Matsubara-axis representation (design: docs/design/ir-matsubara.md,
         # Stage 2): the default uniform grid, or the sparse-ir intermediate
         # representation. IR computes chi0/Sigma natively on sparse nodes (no
@@ -746,6 +758,10 @@ class FLEX(RPA):
         green_info["chi0q"] = chi0q_out
         green_info["chiq_s"] = chi_s
         green_info["chiq_c"] = chi_c
+        if self.output_chi_pm:
+            chi_pm = self._calc_chi_pm_check(chi0q_out, ham_orig)
+            if chi_pm is not None:
+                green_info["chiq_pm"] = chi_pm
         green_info["sigma"] = sigma
         green_info["green"] = green_kw
         green_info["physics"] = physics
@@ -1823,6 +1839,46 @@ class FLEX(RPA):
 
         return chi0q, ham
 
+    def _calc_chi_pm_check(self, chi0q_out, ham_orig):
+        """Transverse (spin-flip) susceptibility, as a verification output.
+
+        Enabled by the undocumented ``output_chi_pm`` switch. Solves the
+        transverse RPA channel with the crossed (Fock-exchange) Hartree vertex
+        -- ``RPA._build_transverse_channel`` -- from the converged FLEX chi0q,
+        and returns chi^{+-}.
+
+        For a paramagnetic system SU(2) symmetry forces chi^{+-} == chi^{zz},
+        so this must reproduce the longitudinal spin channel. Because the two
+        are assembled from different vertices, agreement is a genuine check on
+        the vertex construction rather than a tautology.
+
+        Returns ``None`` (with a warning) when the check is not applicable:
+        it needs the rank-4 orbital chi0q that only ``calc_scheme="general"``
+        produces, and the identity it verifies only holds for a paramagnetic
+        run.
+        """
+        if not self._flex_general:
+            logger.warning(
+                "output_chi_pm: skipped -- the transverse channel needs the "
+                "full rank-4 orbital chi0q, which only calc_scheme='general' "
+                "produces (got '%s'). On the reduced/squashed path the "
+                "transverse channel is not separately defined: chi_s already "
+                "IS the isotropic spin susceptibility.", self.calc_scheme)
+            return None
+        if self.spin_mode != "spin-free":
+            logger.warning(
+                "output_chi_pm: skipped -- chi^{+-} == chi^{zz} only for a "
+                "paramagnetic run, and this one is spin_mode='%s'.",
+                self.spin_mode)
+            return None
+        chi0q_pm, ham_pm = self._build_transverse_channel(
+            _bk.to_host(chi0q_out), ham_orig)
+        chi_pm = _bk.to_host(self._solve_rpa(chi0q_pm, ham_pm))
+        logger.info("output_chi_pm: transverse channel solved "
+                    "(shape %s); for a paramagnetic run it should equal the "
+                    "longitudinal spin susceptibility.", chi_pm.shape)
+        return chi_pm
+
     @do_profile
     def _inflate_chi0q_and_ham_general(self, chi0q_raw, ham_orig):
         """Convert chi0q to MYO convention; build full MYO S/C interaction matrices.
@@ -2612,6 +2668,15 @@ class FLEX(RPA):
                                      info_outputfile.get("chiq_c", "chiq_c"))
             np.savez(file_name, chiq_c=green_info["chiq_c"], **common_meta)
             logger.info("save_results: save chiq_c in file {}".format(file_name))
+
+        if "chiq_pm" in green_info:
+            # Verification output only (undocumented output_chi_pm switch); the
+            # Eliashberg loader never reads it.
+            file_name = os.path.join(path_to_output,
+                                     info_outputfile.get("chiq_pm", "chiq_pm"))
+            np.savez(file_name, chiq_pm=green_info["chiq_pm"], **common_meta)
+            logger.info(
+                "save_results: save chiq_pm in file {}".format(file_name))
 
         if "chiq" in info_outputfile:
             file_name = os.path.join(path_to_output, info_outputfile["chiq"])

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -733,8 +733,18 @@ class FLEX(RPA):
         # frequency axis is densified back onto the run's uniform Nmat grid
         # so the output files keep their exact format (design OQ-1) and the
         # Stage-1 dynamic Eliashberg loader works unchanged.
+        # Solve the transverse channel BEFORE densification, on the same axis
+        # chi_s was dressed on. Densifying first and dressing after would apply
+        # the (nonlinear) RPA solve to interpolated data -- the two operations do
+        # not commute, so the check would report a mismatch that is an artifact
+        # of the axis, not of the vertices.
+        chi_pm = (self._calc_chi_pm_check(chi0q_out, ham_orig)
+                  if self.output_chi_pm else None)
+
         if self.use_ir and self.write_densified:
             axF, axB = self._ir_axF, self._ir_axB
+            if chi_pm is not None:
+                chi_pm = self._ir_densify(chi_pm, axB, 0)
             sigma = self._ir_densify(sigma, axF, 1)
             green_kw = self._ir_densify(green_kw, axF, 1)
             chi_s = self._ir_densify(chi_s, axB, 0)
@@ -749,6 +759,8 @@ class FLEX(RPA):
             chi_s = _bk.to_host(chi_s)
             chi_c = _bk.to_host(chi_c)
             chi0q_out = _bk.to_host(chi0q_out)
+            if chi_pm is not None:
+                chi_pm = _bk.to_host(chi_pm)
         self.sigma = sigma
         self.green_kw = green_kw
         self.chi_s = chi_s
@@ -758,10 +770,9 @@ class FLEX(RPA):
         green_info["chi0q"] = chi0q_out
         green_info["chiq_s"] = chi_s
         green_info["chiq_c"] = chi_c
-        if self.output_chi_pm:
-            chi_pm = self._calc_chi_pm_check(chi0q_out, ham_orig)
-            if chi_pm is not None:
-                green_info["chiq_pm"] = chi_pm
+        green_info.pop("chiq_pm", None)   # never inherit one from a prior solve
+        if chi_pm is not None:
+            green_info["chiq_pm"] = chi_pm
         green_info["sigma"] = sigma
         green_info["green"] = green_kw
         green_info["physics"] = physics
@@ -1844,8 +1855,10 @@ class FLEX(RPA):
 
         Enabled by the undocumented ``output_chi_pm`` switch. Solves the
         transverse RPA channel with the crossed (Fock-exchange) Hartree vertex
-        -- ``RPA._build_transverse_channel`` -- from the converged FLEX chi0q,
-        and returns chi^{+-}.
+        -- ``RPA._build_transverse_channel`` -- from the final-iteration FLEX
+        chi0q (the same one the stored chi_s was dressed from; note FLEX still
+        produces it when the SCF stops at IterationMax without converging), and
+        returns chi^{+-}.
 
         For a paramagnetic system SU(2) symmetry forces chi^{+-} == chi^{zz},
         so this must reproduce the longitudinal spin channel. Because the two
@@ -1871,8 +1884,28 @@ class FLEX(RPA):
                 "paramagnetic run, and this one is spin_mode='%s'.",
                 self.spin_mode)
             return None
+        # spin-free is about the ONE-BODY Hamiltonian; the identity also needs
+        # SU(2)-invariant interactions. Per the transverse builder's own table,
+        # Hund alone gives W_+- = -J and Ising alone W_+- = 2J, neither equal to
+        # the longitudinal vertex, so chi^{+-} != chi^{zz} legitimately and a
+        # mismatch would say nothing about the vertex construction. Only run the
+        # check on interaction sets where the identity actually holds.
+        not_su2 = [k for k in ("Hund", "Ising")
+                   if k in getattr(self.ham_info, "param_ham", {})]
+        if not_su2:
+            logger.warning(
+                "output_chi_pm: skipped -- %s present. spin-free constrains the "
+                "one-body Hamiltonian, not the interaction: these terms are not "
+                "SU(2)-invariant on their own (W_+- differs from the "
+                "longitudinal vertex), so chi^{+-} != chi^{zz} is expected and "
+                "the comparison would not test the vertex construction.",
+                ", ".join(not_su2))
+            return None
+        # Both operands on the host: ham_orig may still be the device copy the
+        # SCF loop used, and mixing it with a host chi0q inside _solve_rpa would
+        # fail after a GPU run had already completed.
         chi0q_pm, ham_pm = self._build_transverse_channel(
-            _bk.to_host(chi0q_out), ham_orig)
+            _bk.to_host(chi0q_out), _bk.to_host(ham_orig))
         chi_pm = _bk.to_host(self._solve_rpa(chi0q_pm, ham_pm))
         logger.info("output_chi_pm: transverse channel solved "
                     "(shape %s); for a paramagnetic run it should equal the "
@@ -2674,7 +2707,14 @@ class FLEX(RPA):
             # Eliashberg loader never reads it.
             file_name = os.path.join(path_to_output,
                                      info_outputfile.get("chiq_pm", "chiq_pm"))
-            np.savez(file_name, chiq_pm=green_info["chiq_pm"], **common_meta)
+            # chi_convention names which S/C matrices a LONGITUDINAL chi pairs
+            # with; it is meaningless for a transverse quantity and would let a
+            # generic reader treat this as a spin/charge channel. Drop it and
+            # tag the channel explicitly instead.
+            pm_meta = {k: v for k, v in common_meta.items()
+                       if k != "chi_convention"}
+            np.savez(file_name, chiq_pm=green_info["chiq_pm"],
+                     chi_channel="transverse_pm", **pm_meta)
             logger.info(
                 "save_results: save chiq_pm in file {}".format(file_name))
 

--- a/tests/test_flex_chi_pm_check.py
+++ b/tests/test_flex_chi_pm_check.py
@@ -78,6 +78,25 @@ def _solve(dirpath, scheme, switch, extra_param=None, green_info=None):
     return _solve_with(dirpath, scheme, switch, None, extra_param, green_info)
 
 
+def _capture_flex_log(fn, level=None):
+    """Capture hwave.solver.flex records, forcing the level so INFO lines the
+    diagnostic emits are not filtered out by the ambient configuration."""
+    import logging
+    records = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    lg = logging.getLogger("hwave.solver.flex")
+    prev = lg.level
+    lg.addHandler(handler)
+    lg.setLevel(logging.INFO if level is None else level)
+    try:
+        result = fn()
+    finally:
+        lg.removeHandler(handler)
+        lg.setLevel(prev)
+    return result, [r.getMessage() for r in records]
+
+
 class TestChiPmCheck(unittest.TestCase):
 
     def test_off_by_default_produces_nothing(self):
@@ -183,6 +202,42 @@ class TestChiPmCheck(unittest.TestCase):
             self.assertIn("chiq_pm", gi)
             gi2 = _solve(d, "general", False, green_info=gi)
         self.assertNotIn("chiq_pm", gi2)
+
+
+class TestChiPmModes(unittest.TestCase):
+    """Three states, because the array is ~GB at production scale while the
+    answer being sought is one number."""
+
+    _CMP = "max|chi_pm - chi_s|"
+
+    def _run(self, switch):
+        with tempfile.TemporaryDirectory() as d:
+            return _capture_flex_log(lambda: _solve(d, "general", switch))
+
+    def test_check_mode_reports_but_stores_nothing(self):
+        gi, msgs = self._run("check")
+        self.assertNotIn("chiq_pm", gi, "check mode must not carry the array")
+        self.assertEqual(len([m for m in msgs if self._CMP in m]), 1,
+                         "check mode must still report the comparison")
+
+    def test_save_mode_reports_and_stores(self):
+        gi, msgs = self._run(True)
+        self.assertIn("chiq_pm", gi)
+        self.assertEqual(len([m for m in msgs if self._CMP in m]), 1)
+
+    def test_off_does_nothing_at_all(self):
+        gi, msgs = self._run(False)
+        self.assertNotIn("chiq_pm", gi)
+        self.assertEqual([m for m in msgs if self._CMP in m], [])
+
+    def test_check_mode_reports_roundoff_for_su2_interaction(self):
+        """The number the mode exists to deliver."""
+        _, msgs = self._run("check")
+        line = [m for m in msgs if self._CMP in m][0]
+        rel = float(line.split("relative ")[1].split(")")[0])
+        self.assertLess(rel, 1e-12,
+                        "CoulombIntra-only is SU(2)-invariant, so the two "
+                        "channels must agree to round-off")
 
 
 if __name__ == "__main__":

--- a/tests/test_flex_chi_pm_check.py
+++ b/tests/test_flex_chi_pm_check.py
@@ -143,33 +143,38 @@ class TestChiPmCheck(unittest.TestCase):
             rtol=1e-9, atol=1e-12,
             err_msg="chi^{+-} must equal chi^{zz} on the IR axis as well")
 
-    def test_non_su2_interaction_is_skipped_with_a_reason(self):
-        """spin-free constrains the one-body Hamiltonian, not the interaction.
-        Ising is not SU(2)-invariant on its own, so the identity does not hold
-        and the comparison would not test anything."""
-        import logging
-        records = []
-        handler = logging.Handler()
-        handler.emit = records.append
-        lg = logging.getLogger("hwave.solver.flex")
-        lg.addHandler(handler)
-        try:
-            with tempfile.TemporaryDirectory() as d:
-                _fixture(d)
-                with open(os.path.join(d, "ising.dat"), "w") as f:
-                    f.write("Ising\n2\n1\n 1\n"
-                            "   0    0    0    1    2   0.500000000000   0.000000000000\n"
-                            "   0    0    0    2    1   0.500000000000   0.000000000000\n")
-                gi = _solve_with(d, "general", True, {"Ising": "ising.dat"})
-        finally:
-            lg.removeHandler(handler)
-        self.assertNotIn("chiq_pm", gi)
-        msgs = [r.getMessage() for r in records
-                if r.levelno >= logging.WARNING
-                and "output_chi_pm" in r.getMessage()]
-        self.assertEqual(len(msgs), 1)
-        self.assertIn("Ising", msgs[0])
-        self.assertIn("SU(2)", msgs[0])
+    def test_non_su2_interaction_still_produces_output(self):
+        """No interaction-dependent filter: bare Ising is not SU(2)-invariant,
+        so chi^{+-} differs from the longitudinal channel legitimately -- and
+        that difference is the interesting quantity, not a reason to withhold
+        the output. Deciding applicability in the loader would mean encoding the
+        rotational-invariance relations between the anisotropic terms, which got
+        it wrong in both directions when tried."""
+        with tempfile.TemporaryDirectory() as d:
+            _fixture(d)
+            with open(os.path.join(d, "ising.dat"), "w") as f:
+                f.write("Ising\n2\n1\n 1\n"
+                        "   0    0    0    1    2   0.500000000000   0.000000000000\n"
+                        "   0    0    0    2    1   0.500000000000   0.000000000000\n")
+            gi = _solve_with(d, "general", True, {"Ising": "ising.dat"},
+                             write_fixture=False)
+        self.assertIn("chiq_pm", gi)
+        pm = np.asarray(gi["chiq_pm"])
+        cs = np.asarray(gi["chiq_s"])
+        self.assertFalse(
+            np.allclose(pm, cs),
+            "bare Ising is not SU(2)-invariant, so the transverse and "
+            "longitudinal channels must NOT coincide -- if they do, the "
+            "transverse vertex is not being built from the crossed vertex")
+
+    def test_stale_key_cleared_on_the_iterationmax_zero_path(self):
+        """The early return must not leave a previous run's chiq_pm behind."""
+        with tempfile.TemporaryDirectory() as d:
+            gi = _solve(d, "general", True)
+            self.assertIn("chiq_pm", gi)
+            gi2 = _solve(d, "general", True, {'IterationMax': 0},
+                         green_info=gi)
+        self.assertNotIn("chiq_pm", gi2)
 
     def test_no_stale_key_when_the_switch_is_off(self):
         """A reused green_info must not keep a chiq_pm from an earlier solve."""

--- a/tests/test_flex_chi_pm_check.py
+++ b/tests/test_flex_chi_pm_check.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+"""The undocumented ``output_chi_pm`` verification switch.
+
+FLEX solves the LONGITUDINAL spin channel from the Kuroki :math:`S` matrix. With
+this switch it additionally solves the TRANSVERSE (spin-flip) channel from the
+crossed (Fock-exchange) Hartree vertex. For a paramagnetic system SU(2) symmetry
+forces :math:`\\chi^{+-} = \\chi^{zz}`, so the two must agree -- and because they
+are assembled from different vertices, that agreement is a real check on the
+vertex construction rather than a restatement of one computation.
+
+The switch is deliberately absent from the manual: it produces a diagnostic
+output, not physics, and is redundant by symmetry.
+
+Tests must be run from the repository root.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+
+def _fixture(dirpath):
+    os.makedirs(dirpath, exist_ok=True)
+    geom = ("  1.000000000000   0.000000000000   0.000000000000\n"
+            "  0.000000000000   1.000000000000   0.000000000000\n"
+            "  0.000000000000   0.000000000000   1.000000000000\n"
+            "2\n"
+            "    0.000000000000000e+00     0.000000000000000e+00     0.000000000000000e+00\n"
+            "    0.500000000000000e+00     0.500000000000000e+00     0.000000000000000e+00\n")
+    transfer = ("Transfer\n2\n9\n 1 1 1 1 1 1 1 1 1\n"
+                "   0    1    0    1    1  1.0 0.0\n"
+                "   0   -1    0    1    1  1.0 0.0\n"
+                "   0    1    0    2    2  1.0 0.0\n"
+                "   0   -1    0    2    2  1.0 0.0\n"
+                "   0    0    0    1    2  0.5 0.0\n"
+                "  -1    0    0    1    2  0.5 0.0\n"
+                "   0    0    0    2    1  0.5 0.0\n"
+                "   1    0    0    2    1  0.5 0.0\n")
+    intra = ("CoulombIntra\n2\n1\n 1\n"
+             "   0    0    0    1    1   2.000000000000   0.000000000000\n"
+             "   0    0    0    2    2   2.000000000000   0.000000000000\n")
+    for name, body in (("geom.dat", geom), ("transfer.dat", transfer),
+                       ("coulombintra.dat", intra)):
+        with open(os.path.join(dirpath, name), "w") as f:
+            f.write(body)
+
+
+def _solve(dirpath, scheme, switch, extra_param=None):
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as solver_flex
+
+    _fixture(dirpath)
+    info_input = {
+        'path_to_input': dirpath,
+        'interaction': {'path_to_input': dirpath, 'Geometry': 'geom.dat',
+                        'Transfer': 'transfer.dat',
+                        'CoulombIntra': 'coulombintra.dat'},
+    }
+    ham = read_input_k.QLMSkInput(info_input).get_param("ham")
+    param = {'T': 0.05, 'CellShape': [4, 4, 1],
+             'SubShape': [1, 1, 1], 'Nmat': 16, 'filling': 0.75,
+             'IterationMax': 3, 'Mix': 0.5, 'EPS': 6,
+             'output_chi_pm': switch}
+    param.update(extra_param or {})
+    solver = solver_flex.FLEX(ham, {}, {'mode': 'FLEX', 'param': param,
+                                        'calc_scheme': scheme})
+    green_info = read_input_k.QLMSkInput(info_input).get_param("green")
+    solver.solve(green_info, dirpath)
+    return green_info
+
+
+class TestChiPmCheck(unittest.TestCase):
+
+    def test_off_by_default_produces_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            gi = _solve(d, "general", False)
+        self.assertNotIn("chiq_pm", gi)
+
+    def test_transverse_equals_longitudinal_for_paramagnetic(self):
+        """The point of the switch: two different vertex constructions must
+        give the same spin susceptibility when SU(2) holds."""
+        with tempfile.TemporaryDirectory() as d:
+            gi = _solve(d, "general", True)
+        self.assertIn("chiq_pm", gi)
+        pm = np.asarray(gi["chiq_pm"])
+        cs = np.asarray(gi["chiq_s"])
+        self.assertEqual(pm.shape, cs.shape)
+        scale = float(np.abs(cs).max())
+        self.assertGreater(scale, 0.0, "fixture produced a null chi_s")
+        np.testing.assert_allclose(
+            pm, cs, rtol=1e-9, atol=1e-12,
+            err_msg="chi^{+-} must equal chi^{zz} for a paramagnetic run; a "
+                    "mismatch means the crossed transverse vertex and the "
+                    "Kuroki S matrix disagree")
+
+    def test_reduced_scheme_is_skipped_with_a_reason(self):
+        """The transverse channel needs the rank-4 orbital chi0q that only the
+        general scheme produces; on the reduced path chi_s already IS the
+        isotropic spin susceptibility."""
+        import logging
+        records = []
+        handler = logging.Handler()
+        handler.emit = records.append
+        lg = logging.getLogger("hwave.solver.flex")
+        lg.addHandler(handler)
+        try:
+            with tempfile.TemporaryDirectory() as d:
+                gi = _solve(d, "reduced", True)
+        finally:
+            lg.removeHandler(handler)
+        self.assertNotIn("chiq_pm", gi)
+        msgs = [r.getMessage() for r in records
+                if r.levelno >= logging.WARNING
+                and "output_chi_pm" in r.getMessage()]
+        self.assertEqual(len(msgs), 1)
+        self.assertIn("calc_scheme='general'", msgs[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_chi_pm_check.py
+++ b/tests/test_flex_chi_pm_check.py
@@ -48,17 +48,18 @@ def _fixture(dirpath):
             f.write(body)
 
 
-def _solve(dirpath, scheme, switch, extra_param=None):
+def _solve_with(dirpath, scheme, switch, extra_inter=None, extra_param=None,
+                green_info=None, write_fixture=True):
     import hwave.qlmsio.read_input_k as read_input_k
     import hwave.solver.flex as solver_flex
 
-    _fixture(dirpath)
-    info_input = {
-        'path_to_input': dirpath,
-        'interaction': {'path_to_input': dirpath, 'Geometry': 'geom.dat',
-                        'Transfer': 'transfer.dat',
-                        'CoulombIntra': 'coulombintra.dat'},
-    }
+    if write_fixture:
+        _fixture(dirpath)
+    inter = {'path_to_input': dirpath, 'Geometry': 'geom.dat',
+             'Transfer': 'transfer.dat',
+             'CoulombIntra': 'coulombintra.dat'}
+    inter.update(extra_inter or {})
+    info_input = {'path_to_input': dirpath, 'interaction': inter}
     ham = read_input_k.QLMSkInput(info_input).get_param("ham")
     param = {'T': 0.05, 'CellShape': [4, 4, 1],
              'SubShape': [1, 1, 1], 'Nmat': 16, 'filling': 0.75,
@@ -67,9 +68,14 @@ def _solve(dirpath, scheme, switch, extra_param=None):
     param.update(extra_param or {})
     solver = solver_flex.FLEX(ham, {}, {'mode': 'FLEX', 'param': param,
                                         'calc_scheme': scheme})
-    green_info = read_input_k.QLMSkInput(info_input).get_param("green")
+    if green_info is None:
+        green_info = read_input_k.QLMSkInput(info_input).get_param("green")
     solver.solve(green_info, dirpath)
     return green_info
+
+
+def _solve(dirpath, scheme, switch, extra_param=None, green_info=None):
+    return _solve_with(dirpath, scheme, switch, None, extra_param, green_info)
 
 
 class TestChiPmCheck(unittest.TestCase):
@@ -117,6 +123,61 @@ class TestChiPmCheck(unittest.TestCase):
                 and "output_chi_pm" in r.getMessage()]
         self.assertEqual(len(msgs), 1)
         self.assertIn("calc_scheme='general'", msgs[0])
+
+
+
+    def test_ir_axis_agrees_too(self):
+        """The transverse solve must happen on the same frequency axis chi_s was
+        dressed on. Densifying first and dressing after would not commute, and
+        would show up here as a spurious mismatch."""
+        try:
+            import sparse_ir  # noqa: F401
+        except ImportError:
+            self.skipTest("sparse_ir not installed")
+        with tempfile.TemporaryDirectory() as d:
+            gi = _solve(d, "general", True,
+                        {'matsubara_basis': 'ir', 'ir_wmax': 20.0})
+        self.assertIn("chiq_pm", gi)
+        np.testing.assert_allclose(
+            np.asarray(gi["chiq_pm"]), np.asarray(gi["chiq_s"]),
+            rtol=1e-9, atol=1e-12,
+            err_msg="chi^{+-} must equal chi^{zz} on the IR axis as well")
+
+    def test_non_su2_interaction_is_skipped_with_a_reason(self):
+        """spin-free constrains the one-body Hamiltonian, not the interaction.
+        Ising is not SU(2)-invariant on its own, so the identity does not hold
+        and the comparison would not test anything."""
+        import logging
+        records = []
+        handler = logging.Handler()
+        handler.emit = records.append
+        lg = logging.getLogger("hwave.solver.flex")
+        lg.addHandler(handler)
+        try:
+            with tempfile.TemporaryDirectory() as d:
+                _fixture(d)
+                with open(os.path.join(d, "ising.dat"), "w") as f:
+                    f.write("Ising\n2\n1\n 1\n"
+                            "   0    0    0    1    2   0.500000000000   0.000000000000\n"
+                            "   0    0    0    2    1   0.500000000000   0.000000000000\n")
+                gi = _solve_with(d, "general", True, {"Ising": "ising.dat"})
+        finally:
+            lg.removeHandler(handler)
+        self.assertNotIn("chiq_pm", gi)
+        msgs = [r.getMessage() for r in records
+                if r.levelno >= logging.WARNING
+                and "output_chi_pm" in r.getMessage()]
+        self.assertEqual(len(msgs), 1)
+        self.assertIn("Ising", msgs[0])
+        self.assertIn("SU(2)", msgs[0])
+
+    def test_no_stale_key_when_the_switch_is_off(self):
+        """A reused green_info must not keep a chiq_pm from an earlier solve."""
+        with tempfile.TemporaryDirectory() as d:
+            gi = _solve(d, "general", True)
+            self.assertIn("chiq_pm", gi)
+            gi2 = _solve(d, "general", False, green_info=gi)
+        self.assertNotIn("chiq_pm", gi2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Small verification-only addition, independent of #87.

## What it does

FLEX solves the **longitudinal** spin channel from the Kuroki `S` matrix. With `output_chi_pm = true` in `[mode.param]` it additionally solves the **transverse** (spin-flip) channel from the crossed Fock-exchange Hartree vertex (`RPA._build_transverse_channel`) and saves it as `chiq_pm`.

For a paramagnetic system SU(2) symmetry forces `chi^{+-} == chi^{zz}`. The two are assembled from different vertices, so their agreement checks the vertex construction rather than restating one computation. On a converged two-orbital on-site-U run:

```
max|chi_s|          = 1.501079486128
max|chi_pm - chi_s| = 1.7e-16     (relative 1.1e-16)
```

## Why it is undocumented

It produces a diagnostic output, not physics, and is redundant by symmetry — for any paramagnetic run the answer is already in `chiq_s`. It is off by default, and nothing consumes `chiq_pm`; the Eliashberg loader never reads it. Adding it to the manual would invite users to turn on a redundant computation.

## Where it does not apply

Both cases warn with the reason instead of silently doing nothing:

- **reduced / squashed** — the transverse channel needs the rank-4 orbital `chi0q` that only `calc_scheme = "general"` produces. There is also nothing to check on that path: `chi_s` already *is* the isotropic spin susceptibility.
- **spin-polarized** — `chi^{+-} == chi^{zz}` does not hold, so the comparison would be meaningless. Computing `chi^{+-}` for a polarized run is a much larger change: it enters the FLEX self-consistency (`Sigma <- V_eff(chi^{+-}, ...) <- chi^{+-} <- G <- Sigma`) rather than sitting on top of a converged result. Tracked as #88.

## Tests

`tests/test_flex_chi_pm_check.py`: off by default produces nothing; the transverse and longitudinal channels agree for a paramagnetic run; the reduced path skips with an explanatory warning.

908 passed.