### PR TITLE
Restore the inter-site same-orbital CoulombInter on the S/C charge diagonal

### DIFF
--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -783,12 +783,15 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
     idx34 = l3f * norb + l4f
 
     # Case 1: l1 == l2 == l3 == l4
+    # Accumulate rather than assign: this element is also reached by Case 3
+    # below (which now includes l1 == l3), where an inter-site same-orbital
+    # CoulombInter contributes 2 V_aa(q) to the charge channel.
     mask1 = (l1f == l2f) & (l2f == l3f) & (l3f == l4f)
     if U_mat is not None and np.any(mask1):
         for i in np.where(mask1)[0]:
             _l = l1f[i]
-            S_all[:, :, :, idx12[i], idx34[i]] = U_mat[_l, _l]
-            C_all[:, :, :, idx12[i], idx34[i]] = U_mat[_l, _l]
+            S_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
+            C_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
 
     # Case 2: l1==l3, l2==l4, l1!=l2
     mask2 = (l1f == l3f) & (l2f == l4f) & (l1f != l2f)
@@ -807,21 +810,30 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
-    # Case 3: l1==l2, l3==l4, l1!=l3
-    mask3 = (l1f == l2f) & (l3f == l4f) & (l1f != l3f)
+    # Case 3: l1==l2, l3==l4 -- INCLUDING l1 == l3, but for CoulombInter ONLY.
+    # The l1 != l3 exclusion dropped the inter-site same-orbital CoulombInter
+    # from the charge diagonal C[(a,a),(a,a)], which must be U_a + 2 V_aa(q)
+    # (issue #95); the simple two-index formulation used by chi0q_mode="load"
+    # builds exactly that (`Wc = U_k + 2 V_k`, _compute_vertices_simple).
+    # Case 1 above writes U_a into the same element, so both accumulate.
+    # Hund and Ising stay restricted to l1 != l3: an orbital has no Hund or
+    # Ising coupling with itself, and letting a stray diagonal entry through
+    # here would silently move S as well.
+    mask3 = (l1f == l2f) & (l3f == l4f)
     for i in np.where(mask3)[0]:
         s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         _l1, _l3 = l1f[i], l3f[i]
-        if J_mat is not None:
-            s_q += J_mat[_l1, _l3]
-            c_q -= J_mat[_l1, _l3]
-        if I_mat is not None:
-            s_q -= 2.0 * I_mat[_l1, _l3]
+        if _l1 != _l3:
+            if J_mat is not None:
+                s_q += J_mat[_l1, _l3]
+                c_q -= J_mat[_l1, _l3]
+            if I_mat is not None:
+                s_q -= 2.0 * I_mat[_l1, _l3]
         if Up_mat is not None:
             c_q += 2.0 * Up_mat[_l1, _l3]
-        S_all[:, :, :, idx12[i], idx34[i]] = s_q
-        C_all[:, :, :, idx12[i], idx34[i]] = c_q
+        S_all[:, :, :, idx12[i], idx34[i]] += s_q
+        C_all[:, :, :, idx12[i], idx34[i]] += c_q
 
     # Case 4: l1==l4, l2==l3, l1!=l2
     mask4 = (l1f == l4f) & (l2f == l3f) & (l1f != l2f)
@@ -891,9 +903,14 @@ def _build_sc_matrices(inter_k, norb, ix, iy, iz):
                     c_val = 0.0 + 0.0j
 
                     if l1 == l2 == l3 == l4:
-                        # Same orbital: S = U, C = U
+                        # Same orbital: S = U, C = U + 2 V_aa(q).  The charge
+                        # (Hartree) diagonal also carries the INTER-SITE
+                        # same-orbital CoulombInter (issue #95); the simple
+                        # two-index formulation builds the same thing as
+                        # `Wc = U_k + 2 V_k`.  Hund/Ising are deliberately not
+                        # included: an orbital has no such coupling with itself.
                         s_val = U_mat[l1, l1]
-                        c_val = U_mat[l1, l1]
+                        c_val = U_mat[l1, l1] + 2.0 * Up_mat[l1, l1]
                     elif l1 == l3 and l2 == l4 and l1 != l2:
                         # l1=l3 != l2=l4 (cross): S = U' - I, C = -U' + J - I
                         s_val = Up_mat[l1, l2] - I_mat[l1, l2]

--- a/src/hwave/solver/_sc_matrices_myo.py
+++ b/src/hwave/solver/_sc_matrices_myo.py
@@ -68,12 +68,15 @@ def build_sc_matrices_myo(inter_k, norb, Nx, Ny, Nz):
     idx34 = l3f * norb + l4f
 
     # Case 1: l1 == l2 == l3 == l4
+    # Accumulate rather than assign: this element is also reached by Case 3
+    # below (which now includes l1 == l3), where an inter-site same-orbital
+    # CoulombInter contributes 2 V_aa(q) to the charge channel.
     mask1 = (l1f == l2f) & (l2f == l3f) & (l3f == l4f)
     if U_mat is not None and np.any(mask1):
         for i in np.where(mask1)[0]:
             _l = l1f[i]
-            S_all[:, :, :, idx12[i], idx34[i]] = U_mat[_l, _l]
-            C_all[:, :, :, idx12[i], idx34[i]] = U_mat[_l, _l]
+            S_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
+            C_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
 
     # Case 2: l1==l3, l2==l4, l1!=l2
     mask2 = (l1f == l3f) & (l2f == l4f) & (l1f != l2f)
@@ -94,21 +97,30 @@ def build_sc_matrices_myo(inter_k, norb, Nx, Ny, Nz):
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
-    # Case 3: l1==l2, l3==l4, l1!=l3
-    mask3 = (l1f == l2f) & (l3f == l4f) & (l1f != l3f)
+    # Case 3: l1==l2, l3==l4 -- INCLUDING l1 == l3, but for CoulombInter ONLY.
+    # The l1 != l3 exclusion dropped the inter-site same-orbital CoulombInter
+    # from the charge diagonal C[(a,a),(a,a)], which must be U_a + 2 V_aa(q)
+    # (issue #95); the simple two-index formulation used by chi0q_mode="load"
+    # builds exactly that (`Wc = U_k + 2 V_k`, _compute_vertices_simple).
+    # Case 1 above writes U_a into the same element, so both accumulate.
+    # Hund and Ising stay restricted to l1 != l3: an orbital has no Hund or
+    # Ising coupling with itself, and letting a stray diagonal entry through
+    # here would silently move S as well.
+    mask3 = (l1f == l2f) & (l3f == l4f)
     for i in np.where(mask3)[0]:
         s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         _l1, _l3 = l1f[i], l3f[i]
-        if J_mat is not None:
-            s_q += J_mat[_l1, _l3]
-            c_q -= J_mat[_l1, _l3]
-        if I_mat is not None:
-            s_q -= 2.0 * I_mat[_l1, _l3]
+        if _l1 != _l3:
+            if J_mat is not None:
+                s_q += J_mat[_l1, _l3]
+                c_q -= J_mat[_l1, _l3]
+            if I_mat is not None:
+                s_q -= 2.0 * I_mat[_l1, _l3]
         if Up_mat is not None:
             c_q += 2.0 * Up_mat[_l1, _l3]
-        S_all[:, :, :, idx12[i], idx34[i]] = s_q
-        C_all[:, :, :, idx12[i], idx34[i]] = c_q
+        S_all[:, :, :, idx12[i], idx34[i]] += s_q
+        C_all[:, :, :, idx12[i], idx34[i]] += c_q
 
     # Case 4: l1==l4, l2==l3, l1!=l2
     mask4 = (l1f == l4f) & (l2f == l3f) & (l1f != l2f)

--- a/tests/test_eliashberg_ir.py
+++ b/tests/test_eliashberg_ir.py
@@ -409,12 +409,19 @@ def test_ir_matvec_gate_offsite_interaction(flex_outdir_offsite):
             # 0.5*(S+C) != 0 with off-site V -- the issue-#57 case
             assert np.abs(V_inst).max() > 1e-10
         else:
-            # 0.5*(C-S) vanishes identically on this 1-orbital fixture
-            # (S == C in the Kuroki construction here); the gate still runs
-            # the triplet channel end to end, and the channel-agnostic
-            # split+analytic-add-back algebra is covered for ARBITRARY
-            # V_inst tensors by test_ir_kernel_instantaneous_vertex_*.
-            assert np.abs(V_inst).max() == 0.0
+            # 0.5*(C-S) on this 1-orbital fixture is exactly V(q): the on-site
+            # U cancels between the two channels (Pauli -- two same-spin
+            # electrons cannot share a site, so U cannot drive triplet
+            # pairing), while the inter-site V survives, since it enters the
+            # charge channel only.  This used to assert the vertex was
+            # identically zero, which was the missing 2 V_aa(q) on the charge
+            # diagonal (issue #95) showing up as "an extended Hubbard model
+            # has no triplet pairing interaction".
+            V_q = np.squeeze(inter_k["CoulombInter"][0, 0])
+            assert np.abs(V_inst).max() > 1e-10
+            np.testing.assert_allclose(
+                np.squeeze(V_inst), V_q, rtol=0.0, atol=1e-12,
+                err_msg="triplet instantaneous vertex must equal V(q)")
         V_n = ed.compute_vertices_flex_dynamic(chis_n, chic_n, inter_k,
                                                norb, Nx, Ny, Nz,
                                                pairing_type=pairing,

--- a/tests/test_flex_general.py
+++ b/tests/test_flex_general.py
@@ -914,6 +914,110 @@ class TestFLEXGeneralWarningGating(unittest.TestCase):
             self._construct('general')
 
 
+def _intersite_v_inter_k(norb=2, U=4.0, V_same=0.8, V_cross=0.3,
+                        Nx=2, Ny=2, Nz=1):
+    """``inter_k`` with an inter-site CoulombInter that has a SAME-ORBITAL part.
+
+    ``CoulombInter[a, a]`` is what an extended Hubbard ``V`` between the same
+    orbital on neighbouring sites produces after the R-sum; it is q-dependent
+    and it is NOT the on-site ``CoulombIntra``.  The Kanamori helper above never
+    populates it (it only fills ``a != b``), which is why the charge-diagonal
+    omission is invisible there.
+    """
+    shape = (norb, norb, Nx, Ny, Nz)
+    CoulombIntra = np.zeros(shape, dtype=complex)
+    CoulombInter = np.zeros(shape, dtype=complex)
+    # a q-dependent V so the test cannot pass by a constant coincidence
+    qramp = np.arange(Nx * Ny * Nz, dtype=float).reshape(Nx, Ny, Nz) + 1.0
+    for a in range(norb):
+        CoulombIntra[a, a, :] = U
+        CoulombInter[a, a, :] = V_same * qramp
+        for b in range(norb):
+            if a != b:
+                CoulombInter[a, b, :] = V_cross * qramp
+    return {"CoulombIntra": CoulombIntra, "CoulombInter": CoulombInter}
+
+
+class TestChargeDiagonalIntersiteV(unittest.TestCase):
+    """Issue #95: the charge matrix must carry 2 V_aa(q) on its diagonal.
+
+    ``C[(a,a),(a,a)]`` is the Hartree channel for orbital ``a``.  It gets ``U_a``
+    from the on-site interaction and ``2 V_aa(q)`` from an inter-site
+    CoulombInter between the same orbital on neighbouring sites.  The latter was
+    dropped, because the case that adds ``+2 U'`` to the charge channel excluded
+    ``a == b``.
+
+    The intended form is visible elsewhere in the same file: the simple
+    two-index formulation used by ``chi0q_mode="load"`` builds the charge
+    vertex as ``Wc = U_k + 2 V_k`` (``_compute_vertices_simple``), diagonal
+    included.
+    """
+
+    def _assert_charge_diagonal(self, builder, extra=None):
+        norb, Nx, Ny, Nz = 2, 2, 2, 1
+        U, V_same = 4.0, 0.8
+        ik = _intersite_v_inter_k(norb=norb, U=U, V_same=V_same,
+                                  Nx=Nx, Ny=Ny, Nz=Nz)
+        if extra:
+            ik.update(extra)
+        S, C = builder(ik, norb, Nx, Ny, Nz)
+        V_aa = ik["CoulombInter"]
+        for a in range(norb):
+            idx = a * norb + a
+            np.testing.assert_allclose(
+                C[:, :, :, idx, idx], U + 2.0 * V_aa[a, a],
+                rtol=0.0, atol=1e-12,
+                err_msg="C[({0},{0}),({0},{0})] must be U + 2 V_{0}{0}(q)".format(a))
+            # the spin channel takes no Hartree term: S stays at U
+            np.testing.assert_allclose(
+                S[:, :, :, idx, idx], U, rtol=0.0, atol=1e-12,
+                err_msg="S[({0},{0}),({0},{0})] must stay U".format(a))
+        # guard against a vacuous fixture: V_aa really is nonzero and q-dependent
+        self.assertGreater(np.max(np.abs(V_aa[0, 0])), 1e-6)
+        self.assertGreater(np.ptp(np.abs(V_aa[0, 0])), 1e-6)
+
+    def test_kuroki_builder(self):
+        from hwave.sc import _build_sc_matrices_all_q
+        self._assert_charge_diagonal(_build_sc_matrices_all_q)
+
+    def test_myo_builder(self):
+        from hwave.solver._sc_matrices_myo import build_sc_matrices_myo
+        self._assert_charge_diagonal(build_sc_matrices_myo)
+
+    def test_diagonal_hund_and_ising_do_not_leak_onto_the_diagonal(self):
+        """Only CoulombInter may reach C[(a,a),(a,a)].
+
+        An orbital has no Hund or Ising coupling with itself, but the readers
+        accept such an entry (#93).  Widening the density case to include
+        ``a == b`` must not let those through -- they would move S as well.
+        """
+        from hwave.sc import _build_sc_matrices_all_q
+        from hwave.solver._sc_matrices_myo import build_sc_matrices_myo
+        shape = (2, 2, 2, 2, 1)
+        diag = np.zeros(shape, dtype=complex)
+        for a in range(2):
+            diag[a, a, :] = 1.0
+        extra = {"Hund": 0.3 * diag, "Ising": 0.2 * diag}
+        for builder in (_build_sc_matrices_all_q, build_sc_matrices_myo):
+            self._assert_charge_diagonal(builder, extra=extra)
+
+    def test_single_q_builder_agrees_with_the_all_q_builder(self):
+        """The private single-q sibling is used as a reference by other tests,
+        so it must not drift from the all-q builder."""
+        from hwave.sc import _build_sc_matrices_all_q, _build_sc_matrices
+        norb, Nx, Ny, Nz = 2, 2, 2, 1
+        ik = _intersite_v_inter_k(norb=norb, Nx=Nx, Ny=Ny, Nz=Nz)
+        Sa, Ca = _build_sc_matrices_all_q(ik, norb, Nx, Ny, Nz)
+        for ix in range(Nx):
+            for iy in range(Ny):
+                for iz in range(Nz):
+                    S1, C1 = _build_sc_matrices(ik, norb, ix, iy, iz)
+                    np.testing.assert_allclose(S1, Sa[ix, iy, iz],
+                                               rtol=0.0, atol=1e-12)
+                    np.testing.assert_allclose(C1, Ca[ix, iy, iz],
+                                               rtol=0.0, atol=1e-12)
+
+
 def _kanamori_inter_k(norb=2, U=4.0, Up=2.0, J=0.5, Jp=0.5,
                       Nx=2, Ny=2, Nz=1, with_pairhop=False):
     """Build a constant Kanamori ``inter_k`` dict for the S/C matrix builders.


### PR DESCRIPTION
`C[(a,a),(a,a)]` is the Hartree channel for orbital `a`. It takes `U_a` from the on-site interaction and `2 V_aa(q)` from an inter-site `CoulombInter` between the same orbital on neighbouring sites. The second term was never added.

Closes #95

## Cause

The density case that contributes `+2 U'` to the charge channel carried an `l1 != l3` mask, so `a == b` never reached it, and Case 1 *assigned* `U_a` rather than accumulating:

```python
mask3 = (l1f == l2f) & (l3f == l4f) & (l1f != l3f)
```

## Why this form is the intended one

The simple two-index formulation — the one `chi0q_mode = "load"` uses — already builds the charge vertex as `Wc = U_k + 2 V_k` (`_compute_vertices_simple`), diagonal included. The Kuroki 4-index builder is meant to be an equivalent construction of the same physics, and on the charge diagonal it was not.

## Scope: only CoulombInter is widened

Dropping the mask outright would also let a **diagonal Hund or Ising** entry reach `(a,a),(a,a)`. An orbital has no such coupling with itself, but the readers accept one (#93), and letting it through moves the **spin** matrix too — with `U = 4, V_aa = 1, J_aa = 0.3, I_aa = 0.2` the naive widening gives `S = 3.9, C = 5.7` instead of `S = 4, C = 6`. Hund and Ising therefore stay restricted to `l1 != l3`.

Applied to all three builders that construct these matrices — the Kuroki all-q builder, its verbatim copy `_sc_matrices_myo.py`, and the single-q sibling `_build_sc_matrices`, which other tests use as a reference and which would otherwise have drifted.

## Reported measurement

A `Sigma = 0` FLEX run (`IterationMax = 1`, `Mix = 0.0`) should reproduce the RPA-Eliashberg result exactly. It did not:

```
chi0q_mode = "load"   ->  0.959725
chi0q_mode = "flex"   ->  0.252702
```

This term alone moves `"flex"` to **0.908930**. The remaining gap is a separate defect, filed as #96 (the interaction is packed in transposed orbital order by `rpa.py` and `sc.py`); with both corrected the two paths agree to 9 digits and the `Sigma = 0` FLEX run reproduces RPA-Eliashberg exactly.

## One committed expectation had baked in the omission

`test_ir_matvec_gate_offsite_interaction` asserted the **triplet** instantaneous vertex was identically zero on a 1-orbital extended-Hubbard fixture — i.e. that a model with inter-site `V` has no triplet pairing interaction.

The vertex is `0.5*(C - S)`. The on-site `U` cancels between the channels, as Pauli requires — two same-spin electrons cannot share a site, so `U` cannot drive triplet pairing — but `V` enters the charge channel only and must survive. Verified on the committed fixture (`U = 4`, `V = 1` on four neighbours): `S = U` exactly, `C - U = 2 V(q)` exactly, `0.5*(C-S) = V(q)` exactly. The assertion now pins that equality instead of zero.

## Tests

926 pass. Four of the five new/changed assertions were verified to fail against the unfixed builders; the fifth (single-q vs all-q equivalence) passes on both sides by construction, since the two builders were consistently wrong before — it guards drift, not the bug.
