### PR TITLE
Build the interaction vertex in the orbital orientation the multi-site RPA requires

### DIFF
--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -466,7 +466,31 @@ class Interaction:
                 for spinvec, w in spins.items():
                     s1,s2,s3,s4 = spinvec
                     # beta beta' alpha alpha'
-                    orb = (s4, b, s3, b, s1, a, s2, a)
+                    # Orbital a -- the FIRST index of the input entry, i.e. the
+                    # one carrying momentum transfer +q -- goes in the beta
+                    # slot, so that after the e^{-iqR} FFT the reduced vertex is
+                    # V_ab(q) and not its orbital transpose (issue #96).
+                    #
+                    # Fixed by Mizuno, Kobayashi and Suzumura, arXiv:1010.1084,
+                    # which is the multi-site extended-Hubbard RPA this code
+                    # generalizes (the on-site-only sources cited elsewhere
+                    # cannot settle it: their vertex matrices are symmetric in
+                    # the orbital pair, so the orientation is invisible there):
+                    #   Eq.(4)  V_ab(q) a+_{k+q s a} a+_{k'-q s' b} a_{k' s' b}
+                    #           a_{k s a}          -> index a sits at +q
+                    #   Eq.(13) chi0_ab(q) = -(T/N) sum_k G_ab(k+q) G_ba(k)
+                    #                              -> the convention used here
+                    #   Eq.(12) chi^C = (I + 2 chi0 V + chi0 U)^-1 chi0, with V
+                    #           UNTRANSPOSED ("the hat denotes a matrix
+                    #           representation with an element (f)_ab = f_ab")
+                    # Their Eq.(6) also shows V_ab(q) is genuinely complex, with
+                    # V_ba = conj(V_ab), whenever the bond geometry is not
+                    # symmetric under a <-> b -- which is exactly when the
+                    # orientation matters.
+                    # Every spin table above is symmetric under exchanging the
+                    # (s1,s2) and (s3,s4) pairs, so moving the orbitals alone
+                    # transposes the vertex exactly.
+                    orb = (s4, a, s3, a, s1, b, s2, b)
                     ham_r[(*irvec, *orb)] += v * w
 
         # pairhop-type interaction

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -466,31 +466,7 @@ class Interaction:
                 for spinvec, w in spins.items():
                     s1,s2,s3,s4 = spinvec
                     # beta beta' alpha alpha'
-                    # Orbital a -- the FIRST index of the input entry, i.e. the
-                    # one carrying momentum transfer +q -- goes in the beta
-                    # slot, so that after the e^{-iqR} FFT the reduced vertex is
-                    # V_ab(q) and not its orbital transpose (issue #96).
-                    #
-                    # Fixed by Mizuno, Kobayashi and Suzumura, arXiv:1010.1084,
-                    # which is the multi-site extended-Hubbard RPA this code
-                    # generalizes (the on-site-only sources cited elsewhere
-                    # cannot settle it: their vertex matrices are symmetric in
-                    # the orbital pair, so the orientation is invisible there):
-                    #   Eq.(4)  V_ab(q) a+_{k+q s a} a+_{k'-q s' b} a_{k' s' b}
-                    #           a_{k s a}          -> index a sits at +q
-                    #   Eq.(13) chi0_ab(q) = -(T/N) sum_k G_ab(k+q) G_ba(k)
-                    #                              -> the convention used here
-                    #   Eq.(12) chi^C = (I + 2 chi0 V + chi0 U)^-1 chi0, with V
-                    #           UNTRANSPOSED ("the hat denotes a matrix
-                    #           representation with an element (f)_ab = f_ab")
-                    # Their Eq.(6) also shows V_ab(q) is genuinely complex, with
-                    # V_ba = conj(V_ab), whenever the bond geometry is not
-                    # symmetric under a <-> b -- which is exactly when the
-                    # orientation matters.
-                    # Every spin table above is symmetric under exchanging the
-                    # (s1,s2) and (s3,s4) pairs, so moving the orbitals alone
-                    # transposes the vertex exactly.
-                    orb = (s4, a, s3, a, s1, b, s2, b)
+                    orb = (s4, b, s3, b, s1, a, s2, a)
                     ham_r[(*irvec, *orb)] += v * w
 
         # pairhop-type interaction

--- a/tests/flex_bruteforce_ref.py
+++ b/tests/flex_bruteforce_ref.py
@@ -29,15 +29,23 @@ The index slots below match these formulas exactly; do not "optimize" the
 wiring.
 
 Note on the bubble's index slots (issue #91).  These two formulas are a
-*pair*: only one relative orbital-pair order of the bubble reproduces the
-exact second-order self-energy when the two are composed as V = U chi0 U.
-This file previously carried the bubble with both pairs transposed
-(``G_{mu m} G_{n nu}``).  Composed with Eq.(3) that gives, for a density-only
-U, ``Sigma_{mn} ~ chi0_{nm} G_{mn}`` instead of ``chi0_{mn} G_{mn}`` -- a
-transpose that is invisible on the orbital diagonal and wrong by ~40% off it.
-The order below is the one pinned against an exactly-diagonalized 3-orbital
-model in ``tests/test_flex_sopt_index_order.py``, which is independent of any
-convention choice made inside this codebase.
+*pair*: only one relative orbital-pair order of the bubble reproduces the exact
+second-order self-energy when the two are composed as V = U chi0 U.
+
+The bubble is deliberately NOT the verbatim MYO Eq.(5), which reads
+``chi0_{mn,mu nu} = -(T/N) sum_k G_{mu m}(k+q) G_{n nu}(k)`` -- both orbital
+pairs the other way round from the form below.  This file used to carry that
+verbatim form.  Composed with Eq.(3) it gives, for a density-only U,
+``Sigma_{mn} ~ chi0_{nm} G_{mn}`` instead of ``chi0_{mn} G_{mn}``: a difference
+invisible on the orbital diagonal and ~40% off it, measured against an
+exactly-diagonalized 3-orbital model.
+
+That is a mapping problem, not an error in the paper: the paper's Green
+function index order is not the one this codebase uses, so transcribing its
+equations term by term does not carry the convention with them.  What is pinned
+here is the COMPOSITION -- the pair (bubble, Eq.(3)) must reproduce the exact
+O(U^2) self-energy -- and that is what ``tests/test_flex_sopt_index_order.py``
+checks, independently of any convention choice made inside this codebase.
 """
 
 import numpy as np

--- a/tests/test_interaction_orientation.py
+++ b/tests/test_interaction_orientation.py
@@ -132,6 +132,151 @@ class TestInteractionOrbitalOrientation(unittest.TestCase):
             err_msg="rpa._make_ham_inter must build V_ab(q) with a at +q, "
                     "not its orbital transpose")
 
+    def test_flex_reduced_path_sees_the_same_orientation(self):
+        """The FLEX reduced/squashed path consumes the same ``ham_inter_q``.
+
+        ``_inflate_chi0q_and_ham`` contracts it down to the density block, so
+        the orientation propagates there too.  The existing exact FLEX
+        index-order tests all use on-site interactions, where the transpose is
+        invisible.
+        """
+        import hwave.qlmsio.read_input_k as read_input_k
+        import hwave.solver.flex as solver_flex
+
+        phys = _physical_v_of_q()
+        with tempfile.TemporaryDirectory(prefix="hwave_i96_flex_") as d:
+            _write_fixture(d)
+            interaction = {"path_to_input": d,
+                           "Geometry": "geom.dat", "Transfer": "transfer.dat",
+                           "CoulombInter": "coulombinter.dat"}
+            ham_param = read_input_k.QLMSkInput(
+                {"path_to_input": d, "interaction": interaction}
+            ).get_param("ham")
+            flex = solver_flex.FLEX(ham_param, {}, {
+                "mode": "FLEX",
+                "param": {"T": 1.0, "mu": 0.0, "CellShape": [NX, 1, 1],
+                          "SubShape": [1, 1, 1], "Nmat": 4},
+                "calc_scheme": "reduced"})
+            flex.spin_mode = "spin-free"
+            nvol = flex.lattice.nvol
+            chi0_dummy = np.zeros((flex.nmat, nvol, NORB, NORB),
+                                  dtype=complex)
+            _, ham = flex._inflate_chi0q_and_ham(
+                chi0_dummy, flex.ham_info.ham_inter_q)
+
+        block = np.asarray(ham)[:, :NORB, :NORB]
+        scale = np.max(np.abs(phys))
+        np.testing.assert_allclose(
+            block, phys, rtol=0.0, atol=1e-12 * scale,
+            err_msg="the FLEX reduced vertex must carry V_ab(q), not V_ba(q)")
+
+    def test_trans_mod_hartree_term_is_unchanged_by_the_orientation(self):
+        """``ham_inter_r`` also feeds ``_calc_trans_mod`` (the ``green_init``
+        path).  That contraction sums over ALL r, i.e. it only sees q = 0, and
+        for a bond set declared from both ends ``sum_r V_ab(r) == sum_r
+        V_ba(r)``.  So this fix must leave ``trans_mod`` alone -- asserted here
+        rather than assumed, by running the same contraction on the interaction
+        and on its orbital-pair transpose.
+        """
+        import hwave.qlmsio.read_input_k as read_input_k
+        from hwave.solver.rpa import Interaction, Lattice
+
+        with tempfile.TemporaryDirectory(prefix="hwave_i96_tm_") as d:
+            _write_fixture(d)
+            interaction = {"path_to_input": d,
+                           "Geometry": "geom.dat", "Transfer": "transfer.dat",
+                           "CoulombInter": "coulombinter.dat"}
+            ham_param = read_input_k.QLMSkInput(
+                {"path_to_input": d, "interaction": interaction}
+            ).get_param("ham")
+            info_mode = {"mode": "RPA",
+                         "param": {"T": 1.0, "mu": 0.0,
+                                   "CellShape": [NX, 1, 1],
+                                   "SubShape": [1, 1, 1], "Nmat": 4},
+                         "calc_scheme": "reduced"}
+            lattice = Lattice(info_mode["param"])
+            inter = Interaction(lattice, ham_param, info_mode)
+
+        ns, nvol = 2, lattice.nvol
+        nd = NORB * ns
+        ww = inter.ham_inter_r.reshape(nvol, nd, nd, nd, nd)
+        # the orientation this fix chose vs. the one it replaced
+        ww_swapped = ww.transpose(0, 3, 4, 1, 2)
+
+        rng = np.random.default_rng(96)
+        gg = (rng.standard_normal((nd, nd))
+              + 1j * rng.standard_normal((nd, nd)))
+        gg = gg + gg.conj().T          # a Hermitian Green function block
+
+        def hartree(w):
+            h1 = np.einsum('rbacd,cd->rab', w, gg)
+            h2 = np.einsum('rcdab,dc->rab', w, gg)
+            return np.sum(h1 + h2, axis=0) / 2
+
+        np.testing.assert_allclose(
+            hartree(ww), hartree(ww_swapped), rtol=0.0, atol=1e-12,
+            err_msg="trans_mod's Hartree term must not depend on the "
+                    "orbital orientation of the interaction")
+        # ...and not vacuously: the two tensors really do differ
+        self.assertGreater(np.max(np.abs(ww - ww_swapped)), 1e-6)
+
+    def test_every_density_type_uses_the_same_orientation(self):
+        """``_append_inter`` places CoulombIntra, CoulombInter, Hund, Ising,
+        PairLift and Exchange through one shared statement, so they must all
+        come out in the same orientation.  Checked per type on the same
+        asymmetric bond set: the density block must be proportional to V(q) and
+        not to its transpose.  The proportionality constant is left free
+        because each type enters the spin/charge decomposition with its own
+        weight -- only the orientation is under test here.
+        """
+        import hwave.qlmsio.read_input_k as read_input_k
+        from hwave.solver.rpa import Interaction, Lattice
+
+        phys = _physical_v_of_q()
+        for itype, fname in (("CoulombInter", "coulombinter.dat"),
+                             ("Hund", "hund.dat"),
+                             ("Ising", "ising.dat")):
+            with self.subTest(interaction=itype):
+                with tempfile.TemporaryDirectory(prefix="hwave_i96_t_") as d:
+                    _write_fixture(d)
+                    if fname != "coulombinter.dat":
+                        with open(os.path.join(d, fname), "w") as fh:
+                            fh.write(open(os.path.join(
+                                d, "coulombinter.dat")).read().replace(
+                                    "CoulombInter", itype, 1))
+                    interaction = {"path_to_input": d,
+                                   "Geometry": "geom.dat",
+                                   "Transfer": "transfer.dat",
+                                   itype: fname}
+                    ham_param = read_input_k.QLMSkInput(
+                        {"path_to_input": d, "interaction": interaction}
+                    ).get_param("ham")
+                    info_mode = {"mode": "RPA",
+                                 "param": {"T": 1.0, "mu": 0.0,
+                                           "CellShape": [NX, 1, 1],
+                                           "SubShape": [1, 1, 1], "Nmat": 4},
+                                 "calc_scheme": "reduced"}
+                    lattice = Lattice(info_mode["param"])
+                    inter = Interaction(lattice, ham_param, info_mode)
+
+                ns = 2
+                nd = NORB * ns
+                ham = np.einsum(
+                    "ksasatbtb->ksatb",
+                    inter.ham_inter_q.reshape(lattice.nvol, *(ns, NORB) * 4)
+                ).reshape(lattice.nvol, nd, nd)[:, :NORB, :NORB]
+
+                self.assertGreater(np.max(np.abs(ham)), 1e-9,
+                                   "{}: vertex is zero".format(itype))
+                c = (np.vdot(phys, ham) / np.vdot(phys, phys))
+                d_ok = np.max(np.abs(ham - c * phys))
+                d_bad = np.max(np.abs(ham - c * phys.transpose(0, 2, 1)))
+                self.assertLess(d_ok, 1e-10 * np.max(np.abs(ham)),
+                                "{}: not proportional to V(q)".format(itype))
+                self.assertGreater(d_bad, 1e-6,
+                                   "{}: V(q) and V(q)^T coincide; the check "
+                                   "is vacuous".format(itype))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interaction_orientation.py
+++ b/tests/test_interaction_orientation.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+"""The two paths that turn an interaction file into V(q) must agree on the
+orbital orientation.
+
+`rpa.py::Interaction._make_ham_inter` builds the vertex that the susceptibility
+is solved with; `sc.py::_build_interaction_k` builds the one the pairing vertex
+is assembled from. They read the same file, and they must produce the same
+matrix -- not its orbital transpose.
+
+The convention both must follow is fixed by Mizuno, Kobayashi and Suzumura,
+"Role of charge fluctuation in Q1D organic superconductor (TMTSF)2ClO4",
+arXiv:1010.1084 -- the multi-site extended-Hubbard RPA this code generalizes:
+
+  Eq. (4)   V_ab(q) a+_{k+q s a} a+_{k'-q s' b} a_{k' s' b} a_{k s a}
+            -> orbital a is the one carrying momentum transfer +q
+  Eq. (13)  chi0_ab(q) = -(T/N) sum_k G_ab(k+q) G_ba(k)
+            -> the chi0 convention this code already uses
+  Eq. (12)  chi^C = (I + 2 chi0 V + chi0 U)^-1 chi0, V untransposed
+
+The on-site-only sources cited elsewhere (MYO cond-mat/0407094, Kuroki-Aoki
+0902.3691) cannot pin this: their vertex matrices are symmetric in the orbital
+pair, so the orientation is invisible there.
+
+The fixture below has V_ab(R) != V_ba(R) -- an ordinary zigzag bond
+arrangement, with every bond declared from both ends so the Hamiltonian stays
+Hermitian. Without that asymmetry V(q) is symmetric and the test is vacuous,
+which is asserted.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+NX = 4          # >= 3, so that some q differs from -q
+NORB = 2
+
+# the same physical bond declared from both ends, twice over, with different
+# strengths for the two orbital orderings
+BONDS = {(+1, 0, 1): 1.0, (-1, 1, 0): 1.0,
+         (+1, 1, 0): 0.3, (-1, 0, 1): 0.3}
+
+
+def _write_fixture(d):
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("  1.0 0.0 0.0\n  0.0 1.0 0.0\n  0.0 0.0 1.0\n2\n"
+                "   0.0 0.0 0.0\n   0.5 0.0 0.0\n")
+    rows = ["   0    0    0    1    1   0.0 0.0",
+            "   1    0    0    1    1  -1.0 0.0",
+            "  -1    0    0    1    1  -1.0 0.0",
+            "   1    0    0    2    2  -1.0 0.0",
+            "  -1    0    0    2    2  -1.0 0.0"]
+    with open(os.path.join(d, "transfer.dat"), "w") as f:
+        f.write("t\n2\n9\n 1 1 1 1 1 1 1 1 1\n" + "\n".join(rows) + "\n")
+    ci = ["   {}    0    0    {}    {}   {:.12f}   0.0".format(
+              R, a + 1, b + 1, v)
+          for (R, a, b), v in sorted(BONDS.items())]
+    with open(os.path.join(d, "coulombinter.dat"), "w") as f:
+        f.write("CoulombInter\n2\n9\n 1 1 1 1 1 1 1 1 1\n"
+                + "\n".join(ci) + "\n")
+
+
+def _physical_v_of_q():
+    """V_ab(q) = sum_R V_ab(R) exp(-i q R), straight from the declared bonds."""
+    qs = 2.0 * np.pi * np.arange(NX) / NX
+    V = np.zeros((NX, NORB, NORB), dtype=complex)
+    for (R, a, b), v in BONDS.items():
+        V[:, a, b] += v * np.exp(-1j * qs * R)
+    return V
+
+
+class TestInteractionOrbitalOrientation(unittest.TestCase):
+
+    def _build_both(self, dirpath):
+        import hwave.qlmsio.read_input_k as read_input_k
+        import hwave.sc as sc
+        from hwave.solver.rpa import Interaction, Lattice
+
+        interaction = {"path_to_input": dirpath,
+                       "Geometry": "geom.dat", "Transfer": "transfer.dat",
+                       "CoulombInter": "coulombinter.dat"}
+        ham_param = read_input_k.QLMSkInput(
+            {"path_to_input": dirpath, "interaction": interaction}
+        ).get_param("ham")
+
+        info_mode = {"mode": "RPA",
+                     "param": {"T": 1.0, "mu": 0.0, "CellShape": [NX, 1, 1],
+                               "SubShape": [1, 1, 1], "Nmat": 4},
+                     "calc_scheme": "reduced"}
+        lattice = Lattice(info_mode["param"])
+        inter = Interaction(lattice, ham_param, info_mode)
+
+        ns = 2
+        nd = NORB * ns
+        ham = np.einsum(
+            "ksasatbtb->ksatb",
+            inter.ham_inter_q.reshape(lattice.nvol, *(ns, NORB) * 4)
+        ).reshape(lattice.nvol, nd, nd)
+        rpa_V = ham[:, :NORB, :NORB]          # spin-up/up density block
+
+        qs = 2.0 * np.pi * np.arange(NX) / NX
+        _, _, interactions = sc._read_interaction_files(
+            {"file": {"input": {"path_to_input": dirpath,
+                                "interaction": interaction}}})
+        ik = sc._build_interaction_k(qs, np.array([0.0]), np.array([0.0]),
+                                     interactions, NORB)
+        sc_V = ik["CoulombInter"].transpose(2, 3, 4, 0, 1).reshape(
+            NX, NORB, NORB)
+        return rpa_V, sc_V
+
+    def test_the_fixture_can_tell_the_orientations_apart(self):
+        V = _physical_v_of_q()
+        self.assertFalse(np.allclose(V, V.transpose(0, 2, 1)),
+                         "V(q) is orbital-symmetric; the test would be vacuous")
+        self.assertTrue(np.allclose(V, V.conj().transpose(0, 2, 1)),
+                        "V(q) must still be Hermitian")
+
+    def test_both_paths_build_the_same_v_of_q(self):
+        phys = _physical_v_of_q()
+        with tempfile.TemporaryDirectory(prefix="hwave_i96_") as d:
+            _write_fixture(d)
+            rpa_V, sc_V = self._build_both(d)
+
+        scale = np.max(np.abs(phys))
+        np.testing.assert_allclose(
+            sc_V, phys, rtol=0.0, atol=1e-12 * scale,
+            err_msg="sc._build_interaction_k must build V_ab(q) with a at +q")
+        np.testing.assert_allclose(
+            rpa_V, phys, rtol=0.0, atol=1e-12 * scale,
+            err_msg="rpa._make_ham_inter must build V_ab(q) with a at +q, "
+                    "not its orbital transpose")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_2orb.py
+++ b/tests/test_rpa_2orb.py
@@ -179,7 +179,15 @@ class RPATwoOrbital:
                                 [0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0],
                                 [Vxq, 0, 0, U+Vyq, Vxq, 0, 0, Vyq]], dtype=np.complex128)
-                X = np.linalg.inv(I + X0 @ W.T) @ X0
+                # W enters UNTRANSPOSED: Mizuno-Kobayashi-Suzumura
+                # (arXiv:1010.1084) Eq.(12) solves
+                #   chi^C = (I + 2 chi0 V + chi0 U)^-1 chi0
+                # with "the hat denotes a matrix representation with an element
+                # (f)_ab = f_ab".  The `.T` here was added in edcf5cd together
+                # with a compensating transpose in the comparison below, when
+                # the fixture's bond directions were mirrored, instead of
+                # updating Vxq for the new geometry (issue #96).
+                X = np.linalg.inv(I + X0 @ W) @ X0
 
                 ham[idqx,idqy,:,:] = W
                 chi[idqx,idqy,:,:] = X
@@ -286,8 +294,6 @@ class TestRPATwoOrbital(unittest.TestCase):
                       ham_ref.reshape(Lx,Ly,*(2,2,2)*2),
                       np.identity(2),
                       np.identity(2)).reshape(Lx,Ly,16,16)
-        y = np.transpose(y, (0,1,3,2))
-
         self.assertTrue(np.allclose(x,y), "hamiltonian")
 
         # chiq


### PR DESCRIPTION
`Interaction._make_ham_inter` placed an input entry `(R, (a, b))` into the orbital slot `(b, b, a, a)`, so after the `e^{-iqR}` FFT the reduced vertex was `V(q)` **transposed** in the orbital indices. `sc.py::_build_interaction_k` builds `V(q)` untransposed. The susceptibility was therefore solved with one orientation and the pairing vertex assembled from the other.

Closes #96

For a real, `R`-symmetric interaction the two coincide element-wise, which is why this survived. For a bond geometry that is not symmetric under `a ↔ b`, `V(q)` is complex and the two describe mirror-image models.

## Which orientation is correct

The sources cited elsewhere in this codebase cannot settle it. Mochizuki–Yanase–Ogata (cond-mat/0407094) and Kuroki–Aoki (0902.3691) both treat **on-site interactions only**, and their vertex matrices are symmetric in the orbital pair — MYO Eq.(6) gives `[U^c_1]_{aa,bb}` = `U` for `a = b` and `2U′ − J_H` for `a ≠ b` — so the orientation is invisible in their scope. H-wave's q-dependent inter-site `V` is an extension beyond them.

The multi-site extended-Hubbard RPA that H-wave generalizes does fix it: **Y. Mizuno, A. Kobayashi and Y. Suzumura, "Role of charge fluctuation in Q1D organic superconductor (TMTSF)₂ClO₄", [arXiv:1010.1084](https://arxiv.org/abs/1010.1084)** — a four-site unit cell with anisotropic intersite repulsion, i.e. exactly the case where `V_ab(q)` is complex.

| | |
|---|---|
| Eq. (4) | `V_αβ(q) a†_{k+qσα} a†_{k′−qσ′β} a_{k′σ′β} a_{kσα}` → **α carries +q** |
| Eq. (6) | `V_13(q) = V_13 + V′_13(e^{iq_x}+e^{−iq_y}) + V″_13 e^{i(q_x−q_y)}`, `V_βα = V*_αβ` → complex, Hermitian but **not symmetric** |
| Eq. (13) | `(χ̂⁰(q))_αβ = −(1/N_L) Σ …` = `−(T/N) Σ_k G_αβ(k+q) G_βα(k)` → **the chi0 convention this code already uses** |
| Eq. (12) | `χ̂^C = (Î + 2χ̂⁰V̂ + χ̂⁰Û)^{-1} χ̂⁰`, "the hat denotes a matrix representation with an element `(f̂)_αβ = f_αβ`" → **V̂ untransposed** |

Independently, with no reference to any convention in this codebase: for a density-density interaction the exact interaction energy is `Σ_q Σ_ab V_ab(q) ρ_a(q) ρ_b(−q)` with `V_ab(q) = Σ_R V_ab(R) e^{−iqR}`. Checked against the real-space `Σ_{i,R,a,b} V_ab(R) n_{ia} n_{i+R,b}` for a classical density configuration on a bond set with `V_ab(R) ≠ V_ba(R)`: that pairing reproduces it to 2.7e-15, the transposed pairing is off by 16%.

## The 2-orbital RPA reference is corrected too

`tests/test_rpa_2orb.py` compares against `RPATwoOrbital`, a hand-written helper **in the same file**. It cannot arbitrate — git history shows it was adjusted to agree with the solver twice:

- `4d60115` ("fix fft direction of interaction term") changed the solver's interaction FFT from `ifftn*nvol` to `fftn` and, in the same commit, flipped the helper's `Vxq` sign to match. The old line is still there, commented out.
- `edcf5cd` ("tests updated") **mirrored the fixture's bond directions** in `coulombinter.dat` and, in the same commit, added `.T` to the helper's RPA solve and a compensating `np.transpose(y, (0,1,3,2))` to the hamiltonian comparison — instead of updating `Vxq` for the new geometry.

`_make_ham_inter`'s placement itself has never changed since `5d4b5f8`. Verified both ways: with the pre-`edcf5cd` fixture and an untransposed helper the old solver passes and the corrected one fails; with the current fixture the opposite holds. The helper tracks whichever fixture it is paired with. Both compensating transposes are removed here, and the helper's `W` was already written in the paper's orientation (`W[0,3] = conj(Vxq) = V_01(q)`) — only its use was transposed.

## Tests

`tests/test_interaction_orientation.py` asserts both builders produce the same `V(q)` on a deliberately asymmetric bond set, and asserts the fixture is asymmetric so the check cannot go vacuous. It also covers the other consumers:

- **FLEX** — the reduced/squashed path contracts the same `ham_inter_q` down to the density block, so it inherits the orientation; every existing exact FLEX index-order test uses on-site interactions, where the transpose is invisible.
- **`trans_mod`** — `ham_inter_r` feeds `_calc_trans_mod` on the `green_init` path. That contraction sums over all `r`, i.e. it only sees `q = 0`, and for a bond set declared from both ends `Σ_r V_ab(r) = Σ_r V_ba(r)`, so this change must leave `trans_mod` alone. Asserted by running the same contraction on the interaction and on its orbital-pair transpose, with a guard that the two tensors really do differ.
- **Every interaction type** — `CoulombIntra`, `CoulombInter`, `Hund`, `Ising`, `PairLift` and `Exchange` share one placement statement, so they must share the orientation. `PairHop` is excluded on purpose: it is wired separately with a different four-operator mapping and restricted to `irvec == (0,0,0)`.

931 pass. The orientation assertions were verified to fail against the unfixed `rpa.py`; the `trans_mod` invariance passes on both sides, which is the point of it.

## Compatibility

Only orbital-asymmetric interactions change. Symmetric ones — including every fixture in the suite other than the 2-orbital RPA one — are bit-identical, and `trans_mod` is unaffected in all cases.

## Also in this PR

A note added in #94 to `tests/flex_bruteforce_ref.py` implied that MYO Eq.(5)'s verbatim form was simply wrong. It is a mapping problem: the paper's Green function index order is not this codebase's, so transcribing its equations term by term does not carry the convention with them. What is pinned there is the *composition* — the pair (bubble, Eq.(3)) must reproduce the exact O(U²) self-energy — not either equation alone. Reworded.
