### PR TITLE
Settle PairHop's vertex orientation by end-to-end measurement

### DIFF
--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -589,7 +589,7 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
         kx_array, ky_array, kz_array, indexing='ij'
     )
 
-    def _to_k(value_r, transpose=True):
+    def _to_k(value_r):
         # Same Fourier phase as the solver core, e^{-iqR}, but the ORBITAL
         # PAIR is stored transposed: an entry (R, (a, b)) lands at [b, a].
         #
@@ -620,18 +620,39 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
         # NOTE: `_build_hamiltonian_k` is a one-body object and correctly keeps
         # the plain [a, b] placement. Do not "align" this builder to it.
         #
-        # PairHop is EXCLUDED (transpose=False below). It is the one type that
-        # `rpa.py` does not place through `_append_inter`: `_append_pairhop`
-        # uses the slots (b, a, a, b) rather than the density-density
-        # (b, b, a, a), so the determination above -- which is for a
-        # density-density term -- does not carry over to it. Leaving it alone
-        # changes only what has been established; its orientation is still open.
+        # PairHop needs the transpose too, but NOT because the argument above
+        # carries over -- it does not. `rpa.py` places PairHop through
+        # `_append_pairhop`, whose slots are (b, a, a, b) rather than the
+        # density-density (b, b, a, a), and in the S/C matrices it lands in the
+        # pair-ANTIdiagonal Case 4 rather than Case 1/3. It was left untouched
+        # until it had its own determination (issue #100); it now has one, again
+        # by exact diagonalization, in two measured steps:
+        #
+        #   * What the pair index of chi0 means. `rpa.py::_calc_chi0q` builds
+        #     chi0[a,c,b,d] = G[a,b] G_rev[d,c]; comparing it against the exact
+        #     correlator of the generalised densities A_{ab}(q) = sum_i
+        #     e^{-iqr} c+_{ia} c_{ib}, with G from the same diagonalization,
+        #     singles out chi0[a,c,b,d] ~ <A_{ca}(q) A_{bd}(-q)>: the ROW pair
+        #     is reversed relative to its bilinear, the column pair is not.
+        #     (Residual 8.4e-3 -> 1.0e-3 as the tau grid is refined 96 -> 768,
+        #     i.e. pure discretisation; the next-best permutation sits at 0.20.)
+        #
+        #   * Where PairHop sits in that basis. H_PH = sum_{aa'} P_{aa'}
+        #     A^up_{aa'} A^down_{aa'} is a product of an UP and a DOWN
+        #     bilinear, so the opposite-spin construction used for #96 applies:
+        #     the cross-spin response vanishes at P = 0 and its leading term is
+        #     one bubble-vertex-bubble chain. Inverting it gives a vertex that
+        #     is DIAGONAL in the bilinear pair, carrying P_{aa'}.
+        #
+        # Composing the two: in chi0's own labels the vertex sits at row
+        # (l1, l2), column (l2, l1) -- which is exactly the Case 4 block, so
+        # that placement was right -- carrying P[l2, l1]. Case 4 reads
+        # PH_mat[l1, l2], so PH_mat must be the transpose.
         val_k = np.zeros((norb, norb, Nx, Ny, Nz), dtype=complex)
         for (irvec, orbvec), value in value_r.items():
             orb1, orb2 = orbvec
             Rx, Ry, Rz = irvec
-            i1, i2 = (orb2, orb1) if transpose else (orb1, orb2)
-            val_k[i1, i2, :, :, :] += value * np.exp(
+            val_k[orb2, orb1, :, :, :] += value * np.exp(
                 -1j * (kx_mesh * Rx + ky_mesh * Ry + kz_mesh * Rz)
             )
         return val_k
@@ -640,8 +661,7 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
     for itype in ["CoulombIntra", "CoulombInter", "Hund", "Exchange",
                   "Ising", "PairLift", "PairHop"]:
         if itype in interactions:
-            inter_k[itype] = _to_k(interactions[itype],
-                                   transpose=(itype != "PairHop"))
+            inter_k[itype] = _to_k(interactions[itype])
 
     return inter_k
 

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -589,7 +589,7 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
         kx_array, ky_array, kz_array, indexing='ij'
     )
 
-    def _to_k(value_r):
+    def _to_k(value_r, transpose=True):
         # Same Fourier phase as the solver core, e^{-iqR}, but the ORBITAL
         # PAIR is stored transposed: an entry (R, (a, b)) lands at [b, a].
         #
@@ -620,39 +620,41 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
         # NOTE: `_build_hamiltonian_k` is a one-body object and correctly keeps
         # the plain [a, b] placement. Do not "align" this builder to it.
         #
-        # PairHop needs the transpose too, but NOT because the argument above
-        # carries over -- it does not. `rpa.py` places PairHop through
-        # `_append_pairhop`, whose slots are (b, a, a, b) rather than the
-        # density-density (b, b, a, a), and in the S/C matrices it lands in the
-        # pair-ANTIdiagonal Case 4 rather than Case 1/3. It was left untouched
-        # until it had its own determination (issue #100); it now has one, again
-        # by exact diagonalization, in two measured steps:
+        # PairHop is EXCLUDED (transpose=False below), and unlike the rest that
+        # is now a MEASURED result rather than a gap. It is the one type
+        # `rpa.py` does not place through `_append_inter`: `_append_pairhop`
+        # uses the slots (b, a, a, b) rather than the density-density
+        # (b, b, a, a), and in the S/C matrices it lands in the pair-ANTIdiagonal
+        # Case 4 rather than Case 1/3, so the density-density determination
+        # above says nothing about it.
         #
-        #   * What the pair index of chi0 means. `rpa.py::_calc_chi0q` builds
-        #     chi0[a,c,b,d] = G[a,b] G_rev[d,c]; comparing it against the exact
-        #     correlator of the generalised densities A_{ab}(q) = sum_i
-        #     e^{-iqr} c+_{ia} c_{ib}, with G from the same diagonalization,
-        #     singles out chi0[a,c,b,d] ~ <A_{ca}(q) A_{bd}(-q)>: the ROW pair
-        #     is reversed relative to its bilinear, the column pair is not.
-        #     (Residual 8.4e-3 -> 1.0e-3 as the tau grid is refined 96 -> 768,
-        #     i.e. pure discretisation; the next-best permutation sits at 0.20.)
+        # Issue #100 settled it end to end (TestPairHopEndToEnd in
+        # tests/test_vertex_orientation.py), with no index reasoning anywhere
+        # between the input file and the answer: feed this builder an on-site
+        # PairHop matrix, build S from it, form the solver's own linear-order
+        # response -chi0 . S . chi0 with chi0 from `rpa.py`'s kernel and an
+        # EXACT Green function, and compare against the cross-spin response of
+        # the same Hamiltonian by exact diagonalization. The untransposed
+        # placement -- i.e. S[(a,b),(b,a)] = P[a,b] -- reproduces it, and the
+        # test locates the residual by checking chi0 against the exact bubble
+        # in the same run, so what is left is the imaginary-time grid. Refining
+        # that grid off-line, 192 -> 384 -> 768 points, takes the residual
+        # 2.3e-3 -> 1.1e-3 -> 5.5e-4 (the test itself runs only the first);
+        # transposing PairHop sits at 0.55 and does not move.
         #
-        #   * Where PairHop sits in that basis. H_PH = sum_{aa'} P_{aa'}
-        #     A^up_{aa'} A^down_{aa'} is a product of an UP and a DOWN
-        #     bilinear, so the opposite-spin construction used for #96 applies:
-        #     the cross-spin response vanishes at P = 0 and its leading term is
-        #     one bubble-vertex-bubble chain. Inverting it gives a vertex that
-        #     is DIAGONAL in the bilinear pair, carrying P_{aa'}.
-        #
-        # Composing the two: in chi0's own labels the vertex sits at row
-        # (l1, l2), column (l2, l1) -- which is exactly the Case 4 block, so
-        # that placement was right -- carrying P[l2, l1]. Case 4 reads
-        # PH_mat[l1, l2], so PH_mat must be the transpose.
+        # Beware the plausible-looking derivation that says otherwise. The
+        # vertex sits BETWEEN two chi0 factors, so its row index lives in
+        # chi0's COLUMN convention and its column index in chi0's ROW
+        # convention. chi0's row pair is reversed relative to its bilinear and
+        # its column pair is not, so the reversal lands on the vertex's COLUMN
+        # side. Applying it to the row side instead gives the transpose, and is
+        # wrong.
         val_k = np.zeros((norb, norb, Nx, Ny, Nz), dtype=complex)
         for (irvec, orbvec), value in value_r.items():
             orb1, orb2 = orbvec
             Rx, Ry, Rz = irvec
-            val_k[orb2, orb1, :, :, :] += value * np.exp(
+            i1, i2 = (orb2, orb1) if transpose else (orb1, orb2)
+            val_k[i1, i2, :, :, :] += value * np.exp(
                 -1j * (kx_mesh * Rx + ky_mesh * Ry + kz_mesh * Rz)
             )
         return val_k
@@ -661,7 +663,8 @@ def _build_interaction_k(kx_array, ky_array, kz_array, interactions, norb):
     for itype in ["CoulombIntra", "CoulombInter", "Hund", "Exchange",
                   "Ising", "PairLift", "PairHop"]:
         if itype in interactions:
-            inter_k[itype] = _to_k(interactions[itype])
+            inter_k[itype] = _to_k(interactions[itype],
+                                   transpose=(itype != "PairHop"))
 
     return inter_k
 

--- a/tests/test_vertex_orientation.py
+++ b/tests/test_vertex_orientation.py
@@ -382,13 +382,15 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
     S/C builder.
     """
 
-    # every type that rpa.py places through _append_inter, i.e. with the
+    # the types rpa.py places through _append_inter, i.e. with the
     # density-density slots (b, b, a, a) the determination above is for
     TRANSPOSED = ("CoulombIntra", "CoulombInter", "Hund", "Exchange", "Ising",
                   "PairLift")
     # PairHop is placed by _append_pairhop with the slots (b, a, a, b) instead,
-    # so the density-density result does not carry over and it is left alone
-    NOT_TRANSPOSED = ("PairHop",)
+    # so the density-density result does not carry over; it has its own
+    # determination in TestPairHopVertexPlacement below, which selects the same
+    # transpose for a different reason.
+    ALSO_TRANSPOSED = ("PairHop",)
 
     def test_density_types_are_stored_pair_transposed(self):
         import hwave.sc as sc
@@ -406,22 +408,14 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
                     NSITE, NORB, NORB)
                 np.testing.assert_allclose(got, want, rtol=0.0, atol=1e-12)
 
-    def test_pairhop_is_deliberately_left_alone(self):
-        """PairHop keeps the pre-#96 placement, and that is NOT a claim that it
-        is correct.
+    def test_pairhop_is_stored_pair_transposed_too(self):
+        """PairHop reaches ``_to_k`` like every other type; what is specific to
+        it is WHY the transpose is right, which is settled in
+        TestPairHopVertexPlacement rather than by the density-density argument.
 
-        `rpa.py` places PairHop through `_append_pairhop`, with the slots
-        (b, a, a, b) instead of `_append_inter`'s density-density (b, b, a, a),
-        so the determination this series rests on does not transfer to it.  It
-        is left untouched because changing it would be a guess; whether it
-        should be transposed is open, and tracked separately.
-
-        This test therefore pins the STATUS QUO only.  It deliberately does not
-        assert agreement with `rpa.py` -- that is exactly what is unresolved.
-
-        The fixture is ON-SITE: `_append_pairhop` discards every ``irvec !=
-        (0,0,0)``, so an off-site PairHop fixture would be vacuous on the RPA
-        side and must not be used to reason about the two builders.
+        The fixture is ON-SITE: ``rpa.py::_append_pairhop`` discards every
+        ``irvec != (0,0,0)``, so an off-site PairHop fixture would be vacuous on
+        the RPA side and must not be used to reason about the two builders.
         """
         import hwave.sc as sc
 
@@ -429,11 +423,11 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
         vr = {((0, 0, 0), (a, b)): v for (a, b), v in P.items()}
         want = np.zeros((NORB, NORB), dtype=complex)
         for (a, b), v in P.items():
-            want[a, b] = v                        # NOT transposed
+            want[b, a] = v                        # transposed
         self.assertGreater(np.max(np.abs(want - want.T)), 1e-6)
 
         qs = 2.0 * np.pi * np.arange(NSITE) / NSITE
-        for itype in self.NOT_TRANSPOSED:
+        for itype in self.ALSO_TRANSPOSED:
             with self.subTest(interaction=itype):
                 ik = sc._build_interaction_k(
                     qs, np.array([0.0]), np.array([0.0]), {itype: vr}, NORB)
@@ -467,6 +461,340 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
                     np.allclose(c_asym, np.swapaxes(c_asym, -1, -2)),
                     "asymmetric on-site input does reach the S/C builders, so "
                     "the orientation is observable there")
+
+
+# --------------------------------------------------------------------------
+# 5. PairHop: its own determination (issue #100)
+# --------------------------------------------------------------------------
+
+# PairHop is the one type `rpa.py` does not route through `_append_inter`, and
+# in the S/C matrices it lands in the pair-ANTIdiagonal Case 4 rather than the
+# density-density Case 1/3. The argument above therefore says nothing about it,
+# and it needs two separate measurements:
+#
+#   1. what chi0's pair index means -- because relabelling a pair (x,y)->(y,x)
+#      on one side turns a pair-diagonal vertex into a pair-antidiagonal one,
+#      so the vertex alone cannot answer the question;
+#   2. where the PairHop vertex sits when the pair index labels a bilinear.
+#
+# Both are done by exact diagonalization of an explicit Hamiltonian.
+
+PH_NSITE = 3
+PH_NORB = 2
+PH_BETA = 3.0
+PH_MU = 0.2
+PH_NTAU = 96
+
+PH_T_INTRA = {0: 0.9 * np.exp(0.35j), 1: 0.6 * np.exp(-0.55j)}
+PH_T_INTER = 0.45 * np.exp(0.8j)
+PH_ONSITE = {0: 0.15, 1: -0.25}
+
+
+class TestChi0PairIndexMeaning(unittest.TestCase):
+    """`rpa.py::_calc_chi0q` builds, in the general branch,
+
+        chi0[a,c,b,d] = G[a,b] * G_rev[d,c] * sgn
+
+    Which BILINEAR does each flattened pair stand for? Measure it: compute the
+    exact correlator of the generalised densities
+
+        A_{ab}(q) = sum_i e^{-i q r_i} c+_{i a} c_{i b}
+
+    by grand-canonical diagonalization, evaluate the kernel above with G from
+    the SAME diagonalization, and search all 24 index permutations. Only one
+    spin species is needed (the Hamiltonian does not couple spins and A acts
+    inside one Fock space), so the trace is 2**6 = 64 dimensional and exact.
+    """
+
+    NMODE = PH_NSITE * PH_NORB
+
+    @classmethod
+    def _fock(cls):
+        dim = 1 << cls.NMODE
+        c = []
+        for p in range(cls.NMODE):
+            op = np.zeros((dim, dim))
+            for m in range(dim):
+                if (m >> p) & 1:
+                    sg = -1.0 if bin(m & ((1 << p) - 1)).count("1") % 2 else 1.0
+                    op[m & ~(1 << p), m] = sg
+            c.append(op)
+        return c
+
+    @classmethod
+    def _run(cls, ntau):
+        mode = lambda i, a: i * PH_NORB + a
+        C = cls._fock()
+        CD = [op.T.conj() for op in C]
+        dim = 1 << cls.NMODE
+
+        h1 = np.zeros((cls.NMODE, cls.NMODE), dtype=complex)
+        for i in range(PH_NSITE):
+            for a in range(PH_NORB):
+                h1[mode(i, a), mode(i, a)] += PH_ONSITE[a] - PH_MU
+                for d, amp in ((+1, PH_T_INTRA[a]),
+                               (-1, np.conj(PH_T_INTRA[a]))):
+                    h1[mode((i + d) % PH_NSITE, a), mode(i, a)] += amp
+            h1[mode(i, 1), mode(i, 0)] += PH_T_INTER
+            h1[mode(i, 0), mode(i, 1)] += np.conj(PH_T_INTER)
+        assert np.allclose(h1, h1.conj().T)
+
+        H = np.zeros((dim, dim), dtype=complex)
+        for p in range(cls.NMODE):
+            for q in range(cls.NMODE):
+                if h1[p, q] != 0:
+                    H += h1[p, q] * (CD[p] @ C[q])
+        E, U = np.linalg.eigh(H)
+        E -= E.min()
+        w = np.exp(-PH_BETA * E)
+        Z = w.sum()
+        rot = lambda op: U.conj().T @ op @ U
+
+        taus = np.arange(ntau) * PH_BETA / ntau
+        expo = np.exp(np.multiply.outer(taus, E[:, None] - E[None, :]))
+
+        def corr(A, B):
+            """<A(tau) B(0)> on the tau grid."""
+            return np.einsum("m,tmn,mn,nm->t", w, expo, A, B) / Z
+
+        cr = [rot(op) for op in C]
+        cdr = [rot(op) for op in CD]
+
+        # G_{ab}(r, tau) = -<T c_{r a}(tau) c+_{0 b}(0)>
+        G = np.zeros((ntau, PH_NSITE, PH_NORB, PH_NORB), dtype=complex)
+        for r in range(PH_NSITE):
+            for a in range(PH_NORB):
+                for b in range(PH_NORB):
+                    G[:, r, a, b] = -corr(cr[mode(r, a)], cdr[mode(0, b)])
+
+        def bilinear(q, a, b):
+            op = np.zeros((dim, dim), dtype=complex)
+            for i in range(PH_NSITE):
+                op += np.exp(-1j * q * i) * (CD[mode(i, a)] @ C[mode(i, b)])
+            return op
+
+        qs = 2.0 * np.pi * np.arange(PH_NSITE) / PH_NSITE
+        ed = np.zeros((PH_NSITE,) + (PH_NORB,) * 4, dtype=complex)
+        for iq, q in enumerate(qs):
+            pl = {(a, b): rot(bilinear(q, a, b))
+                  for a in range(PH_NORB) for b in range(PH_NORB)}
+            mi = {(a, b): rot(bilinear(-q, a, b))
+                  for a in range(PH_NORB) for b in range(PH_NORB)}
+            for a in range(PH_NORB):
+                for b in range(PH_NORB):
+                    for c in range(PH_NORB):
+                        for d in range(PH_NORB):
+                            ed[iq, a, b, c, d] = corr(
+                                pl[(a, b)], mi[(c, d)]).sum() * PH_BETA / ntau
+
+        sgn = np.full(ntau, -1.0)
+        sgn[0] = 1.0
+        Grev = G[np.ix_((-np.arange(ntau)) % ntau,
+                        (-np.arange(PH_NSITE)) % PH_NSITE)]
+        rt = (G[:, :, :, None, :, None]
+              * sgn[:, None, None, None, None, None]
+              * Grev[:, :, None, :, None, :])           # [l,r,a,d,b,c]
+        rt = rt.transpose(0, 1, 2, 5, 4, 3)             # -> [l,r,a,c,b,d]
+        phase = np.exp(-1j * np.multiply.outer(qs, np.arange(PH_NSITE)))
+        code = -np.einsum("qr,lracbd->qacbd", phase, rt) * (PH_BETA / ntau)
+        return cls._ranked(ed, code)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.coarse = cls._run(PH_NTAU)
+        cls.fine = cls._run(2 * PH_NTAU)
+
+    @staticmethod
+    def _ranked(ed, code):
+        out = []
+        for perm in itertools.permutations(range(4)):
+            # q = 0 carries the disconnected part <A><A>, which the code's
+            # bubble kernel does not contain; it cannot be compared.
+            cand = np.transpose(code, (0,) + tuple(1 + p for p in perm))[1:]
+            ref = ed[1:]
+            den = np.vdot(cand, cand)
+            if abs(den) < 1e-30:
+                continue
+            s = np.vdot(cand, ref) / den
+            out.append((np.max(np.abs(ref - s * cand)) / np.max(np.abs(ref)),
+                        perm))
+        out.sort()
+        return out
+
+    def test_row_pair_is_reversed_and_column_pair_is_not(self):
+        ranked = self.coarse
+        best, runner_up = ranked[0], ranked[1]
+        # code[a,c,b,d] ~ ED[c,a,b,d] = <A_{ca}(q) A_{bd}(-q)>
+        self.assertEqual(best[1], (1, 0, 2, 3),
+                         "chi0's pair index does not mean what #100 measured")
+        self.assertLess(best[0], 1e-2)
+        self.assertGreater(runner_up[0], 20 * best[0],
+                           "the fixture does not separate the permutations")
+
+    def test_the_residual_is_discretisation_not_disagreement(self):
+        """Halving the tau spacing halves the winner's residual, so it is the
+        grid and not a mismatch. Without this the threshold above would be a
+        tolerance picked to make the test pass."""
+        coarse, fine = self.coarse[0], self.fine[0]
+        self.assertEqual(coarse[1], fine[1])
+        self.assertLess(fine[0], 0.6 * coarse[0])
+        self.assertGreater(fine[0], 0.4 * coarse[0])
+
+
+class TestPairHopVertexPlacement(unittest.TestCase):
+    """H_PH = sum_{aa'} P_{aa'} A^up_{aa'} A^down_{aa'} is a product of an UP
+    and a DOWN bilinear, so the opposite-spin construction of
+    TestRPAVertexOrientation applies once the densities are generalised to
+    orbital-off-diagonal ones: the cross-spin response vanishes at P = 0 and
+    its leading term is exactly one bubble-vertex-bubble chain,
+
+        chi^ud(q) = -P X0(q) . Gamma . X0(q) + O(P^2),
+
+    in the orbital-PAIR basis. Inverting it gives Gamma directly.
+
+    P must be Hermitian-closed (P_{a'a} = conj(P_{aa'})) for H to be Hermitian;
+    P is then Hermitian as a matrix, so P^T = conj(P) and the transpose is
+    still a different matrix whenever P is complex. That is what makes the
+    fixture discriminating.
+    """
+
+    P = {(0, 1): 1.0 + 0.3j, (1, 0): 1.0 - 0.3j}
+    NPAIR = PH_NORB * PH_NORB
+
+    @staticmethod
+    def _measure(amp, q):
+        """(X0, chi^ud) in the pair basis, at PairHop strength `amp`."""
+        mode = lambda i, a, s: (i * PH_NORB + a) * 2 + s
+        H = np.zeros((DIM, DIM), dtype=complex)
+        for idx, mask in enumerate(STATES):
+            for s in range(2):
+                for i in range(NSITE):
+                    for a in range(NORB):
+                        p = mode(i, a, s)
+                        if (mask >> p) & 1:
+                            H[idx, idx] += ONSITE[a]
+                        for d, t in ((+1, T_INTRA[a]),
+                                     (-1, np.conj(T_INTRA[a]))):
+                            r = _hop(mask, mode((i + d) % NSITE, a, s), p)
+                            if r:
+                                H[INDEX[r[0]], idx] += t * r[1]
+                        t = T_INTER if a == 0 else np.conj(T_INTER)
+                        r = _hop(mask, mode(i, 1 - a, s), p)
+                        if r:
+                            H[INDEX[r[0]], idx] += t * r[1]
+        if amp:
+            for (a, ap), v in TestPairHopVertexPlacement.P.items():
+                for i in range(NSITE):
+                    up = np.zeros((DIM, DIM), dtype=complex)
+                    dn = np.zeros((DIM, DIM), dtype=complex)
+                    for idx, mask in enumerate(STATES):
+                        r = _hop(mask, mode(i, a, 0), mode(i, ap, 0))
+                        if r:
+                            up[INDEX[r[0]], idx] += r[1]
+                        r = _hop(mask, mode(i, a, 1), mode(i, ap, 1))
+                        if r:
+                            dn[INDEX[r[0]], idx] += r[1]
+                    H += amp * v * (up @ dn + dn @ up)
+        assert np.allclose(H, H.conj().T), "H_PH is Hermitian only if P is"
+        E, U = np.linalg.eigh(H)
+
+        def bil(qq, a, b, s):
+            op = np.zeros((DIM, DIM), dtype=complex)
+            for idx, mask in enumerate(STATES):
+                for i in range(NSITE):
+                    r = _hop(mask, mode(i, a, s), mode(i, b, s))
+                    if r:
+                        op[INDEX[r[0]], idx] += np.exp(-1j * qq * i) * r[1]
+            return op
+
+        n = TestPairHopVertexPlacement.NPAIR
+        uu = np.zeros((n, n), dtype=complex)
+        ud = np.zeros((n, n), dtype=complex)
+        pl = {(a, b, s): bil(q, a, b, s)
+              for a in range(NORB) for b in range(NORB) for s in range(2)}
+        mi = {(a, b, s): bil(-q, a, b, s)
+              for a in range(NORB) for b in range(NORB) for s in range(2)}
+        for a in range(NORB):
+            for b in range(NORB):
+                for c in range(NORB):
+                    for d in range(NORB):
+                        i, j = a * NORB + b, c * NORB + d
+                        uu[i, j] = _static_chi(E, U, pl[(a, b, 0)],
+                                               mi[(c, d, 0)])
+                        ud[i, j] = _static_chi(E, U, pl[(a, b, 0)],
+                                               mi[(c, d, 1)])
+        return uu, ud
+
+    @classmethod
+    def setUpClass(cls):
+        q = 2.0 * np.pi / NSITE
+        cls.X0, cls.ud0 = cls._measure(0.0, q)
+        # CENTRAL difference: the O(P^2) term cancels, leaving O(P^3) ~ 1e-12,
+        # so the tolerances below are set by the measurement and not by the
+        # truncation. (A forward difference at the same dP leaves ~1e-5.)
+        dP = 1.0e-4
+        _, up = cls._measure(dP, q)
+        _, dn = cls._measure(-dP, q)
+        inv = np.linalg.inv(cls.X0)
+        # chi^ud = -X0 Gamma X0  =>  Gamma = -X0^-1 chi^ud X0^-1
+        cls.gamma = -inv @ ((up - dn) / (2.0 * dP)) @ inv * NSITE
+
+    def test_cross_spin_response_vanishes_without_pairhop(self):
+        """The premise: at P = 0 the leading term is the whole story."""
+        self.assertLess(float(np.max(np.abs(self.ud0))), 1e-12)
+
+    def test_vertex_is_diagonal_in_the_bilinear_pair(self):
+        """Gamma connects A^up_{ab} to A^down_{ab} -- the SAME pair -- so it is
+        diagonal in the bilinear pair index, not antidiagonal."""
+        off = self.gamma - np.diag(np.diag(self.gamma))
+        # measured 2e-9 of the diagonal; the floor is the O(P^3) remainder of
+        # the central difference plus the conditioning of the X0 inversion.
+        self.assertLess(float(np.max(np.abs(off))),
+                        1e-7 * float(np.max(np.abs(self.gamma))))
+
+    def test_the_diagonal_carries_p_untransposed(self):
+        """Gamma[(a,b),(a,b)] is proportional to P[a,b], with one common real
+        factor. The complex fixture is what separates P from P^T = conj(P)."""
+        got = np.array([self.gamma[a * NORB + b, a * NORB + b]
+                        for (a, b) in self.P])
+        want = np.array([self.P[(a, b)] for (a, b) in self.P])
+        scale = np.vdot(want, got) / np.vdot(want, want)
+        self.assertLess(abs(scale.imag), 1e-9 * abs(scale))
+        np.testing.assert_allclose(got, scale * want, rtol=0.0,
+                                   atol=1e-9 * float(np.max(np.abs(got))))
+        # and P^T is genuinely excluded
+        wt = np.array([self.P[(b, a)] for (a, b) in self.P])
+        self.assertGreater(np.max(np.abs(got - scale * wt)),
+                           1e-2 * float(np.max(np.abs(got))))
+
+
+class TestSCPlacesPairHopAsMeasured(unittest.TestCase):
+    """Compose the two measurements and check `sc.py` against the result.
+
+    chi0's row pair (l1, l2) labels the bilinear A_{l2 l1} and its column pair
+    (l3, l4) labels A_{l3 l4} (TestChi0PairIndexMeaning); the vertex is diagonal
+    in the bilinear pair, carrying P of that pair (TestPairHopVertexPlacement).
+    So in chi0's own labels it sits at row (l1, l2), column (l2, l1) -- the
+    Case 4 block, which was always right -- carrying P[l2, l1].
+    """
+
+    def test_case4_carries_the_transposed_amplitude(self):
+        import hwave.sc as sc
+
+        P = {(0, 1): 1.0, (1, 0): 0.35}          # on-site, asymmetric
+        vr = {((0, 0, 0), (a, b)): v for (a, b), v in P.items()}
+        k = np.array([0.0])
+        ik = sc._build_interaction_k(k, k, k, {"PairHop": vr}, NORB)
+        S, Cm = sc._build_sc_matrices_all_q(ik, NORB, 1, 1, 1)
+
+        for (l1, l2), v in P.items():
+            row, col = l1 * NORB + l2, l2 * NORB + l1
+            for name, M in (("S", S), ("C", Cm)):
+                with self.subTest(matrix=name, l1=l1, l2=l2):
+                    self.assertAlmostEqual(
+                        complex(M[0, 0, 0, row, col]), P[(l2, l1)], places=12,
+                        msg="row ({},{}) col ({},{}) must carry P[{},{}]"
+                            .format(l1, l2, l2, l1, l2, l1))
 
 
 if __name__ == "__main__":

--- a/tests/test_vertex_orientation.py
+++ b/tests/test_vertex_orientation.py
@@ -387,10 +387,10 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
     TRANSPOSED = ("CoulombIntra", "CoulombInter", "Hund", "Exchange", "Ising",
                   "PairLift")
     # PairHop is placed by _append_pairhop with the slots (b, a, a, b) instead,
-    # so the density-density result does not carry over; it has its own
-    # determination in TestPairHopVertexPlacement below, which selects the same
-    # transpose for a different reason.
-    ALSO_TRANSPOSED = ("PairHop",)
+    # so the density-density result does not carry over. It has its own
+    # determination, TestPairHopEndToEnd below, which selects the UNtransposed
+    # placement.
+    NOT_TRANSPOSED = ("PairHop",)
 
     def test_density_types_are_stored_pair_transposed(self):
         import hwave.sc as sc
@@ -408,10 +408,9 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
                     NSITE, NORB, NORB)
                 np.testing.assert_allclose(got, want, rtol=0.0, atol=1e-12)
 
-    def test_pairhop_is_stored_pair_transposed_too(self):
-        """PairHop reaches ``_to_k`` like every other type; what is specific to
-        it is WHY the transpose is right, which is settled in
-        TestPairHopVertexPlacement rather than by the density-density argument.
+    def test_pairhop_is_not_stored_pair_transposed(self):
+        """PairHop keeps the plain ``[a, b]`` placement, which
+        TestPairHopEndToEnd measures against exact diagonalization.
 
         The fixture is ON-SITE: ``rpa.py::_append_pairhop`` discards every
         ``irvec != (0,0,0)``, so an off-site PairHop fixture would be vacuous on
@@ -423,11 +422,11 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
         vr = {((0, 0, 0), (a, b)): v for (a, b), v in P.items()}
         want = np.zeros((NORB, NORB), dtype=complex)
         for (a, b), v in P.items():
-            want[b, a] = v                        # transposed
+            want[a, b] = v                        # NOT transposed
         self.assertGreater(np.max(np.abs(want - want.T)), 1e-6)
 
         qs = 2.0 * np.pi * np.arange(NSITE) / NSITE
-        for itype in self.ALSO_TRANSPOSED:
+        for itype in self.NOT_TRANSPOSED:
             with self.subTest(interaction=itype):
                 ik = sc._build_interaction_k(
                     qs, np.array([0.0]), np.array([0.0]), {itype: vr}, NORB)
@@ -477,7 +476,13 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
 #      so the vertex alone cannot answer the question;
 #   2. where the PairHop vertex sits when the pair index labels a bilinear.
 #
-# Both are done by exact diagonalization of an explicit Hamiltonian.
+# Both are done by exact diagonalization of an explicit Hamiltonian. They are
+# INPUTS to the answer, not the answer: combining them by hand is exactly where
+# this went wrong once (the vertex sits BETWEEN two chi0 factors, so chi0's
+# ROW-pair reversal lands on the vertex's COLUMN side, not its row side), and
+# two derivations of the same shape reached opposite conclusions. The placement
+# is therefore settled by TestPairHopEndToEnd, which measures the whole chain
+# and needs neither of them.
 
 PH_NSITE = 3
 PH_NORB = 2
@@ -694,7 +699,10 @@ class TestPairHopVertexPlacement(unittest.TestCase):
                         r = _hop(mask, mode(i, a, 1), mode(i, ap, 1))
                         if r:
                             dn[INDEX[r[0]], idx] += r[1]
-                    H += amp * v * (up @ dn + dn @ up)
+                    # up and dn commute (different species, even parity), so
+                    # up @ dn is the operator itself -- symmetrising would put
+                    # a spurious factor of 2 into the measured coefficient.
+                    H += amp * v * (up @ dn)
         assert np.allclose(H, H.conj().T), "H_PH is Hermitian only if P is"
         E, U = np.linalg.eigh(H)
 
@@ -729,15 +737,21 @@ class TestPairHopVertexPlacement(unittest.TestCase):
     def setUpClass(cls):
         q = 2.0 * np.pi / NSITE
         cls.X0, cls.ud0 = cls._measure(0.0, q)
-        # CENTRAL difference: the O(P^2) term cancels, leaving O(P^3) ~ 1e-12,
-        # so the tolerances below are set by the measurement and not by the
-        # truncation. (A forward difference at the same dP leaves ~1e-5.)
-        dP = 1.0e-4
-        _, up = cls._measure(dP, q)
-        _, dn = cls._measure(-dP, q)
+        # CENTRAL difference: the O(P^2) term cancels, so the remaining
+        # truncation is O(dP^2) rather than the O(dP) of a forward difference
+        # (which leaves ~1e-5 here). test_the_truncation_is_quadratic below
+        # measures that scaling instead of asserting it.
         inv = np.linalg.inv(cls.X0)
-        # chi^ud = -X0 Gamma X0  =>  Gamma = -X0^-1 chi^ud X0^-1
-        cls.gamma = -inv @ ((up - dn) / (2.0 * dP)) @ inv * NSITE
+        cls.cond_X0 = float(np.linalg.cond(cls.X0))
+
+        def gamma_at(dP):
+            _, up = cls._measure(dP, q)
+            _, dn = cls._measure(-dP, q)
+            # chi^ud = -X0 Gamma X0  =>  Gamma = -X0^-1 chi^ud X0^-1
+            return -inv @ ((up - dn) / (2.0 * dP)) @ inv * NSITE
+
+        cls.gamma = gamma_at(1.0e-4)
+        cls.gamma_coarse = gamma_at(2.0e-4)
 
     def test_cross_spin_response_vanishes_without_pairhop(self):
         """The premise: at P = 0 the leading term is the whole story."""
@@ -747,54 +761,314 @@ class TestPairHopVertexPlacement(unittest.TestCase):
         """Gamma connects A^up_{ab} to A^down_{ab} -- the SAME pair -- so it is
         diagonal in the bilinear pair index, not antidiagonal."""
         off = self.gamma - np.diag(np.diag(self.gamma))
-        # measured 2e-9 of the diagonal; the floor is the O(P^3) remainder of
-        # the central difference plus the conditioning of the X0 inversion.
+        # the floor is the O(dP^2) remainder of the central difference and the
+        # conditioning of the X0 inversion (cond(X0) is checked below)
         self.assertLess(float(np.max(np.abs(off))),
                         1e-7 * float(np.max(np.abs(self.gamma))))
 
-    def test_the_diagonal_carries_p_untransposed(self):
-        """Gamma[(a,b),(a,b)] is proportional to P[a,b], with one common real
-        factor. The complex fixture is what separates P from P^T = conj(P)."""
+    def test_the_truncation_is_quadratic_and_x0_is_well_conditioned(self):
+        """Halving dP cuts the off-diagonal leakage by about four, so the
+        tolerances above are set by a measured truncation and not chosen to
+        make the test pass."""
+        fine = float(np.max(np.abs(self.gamma - np.diag(np.diag(self.gamma)))))
+        coarse = float(np.max(np.abs(
+            self.gamma_coarse - np.diag(np.diag(self.gamma_coarse)))))
+        self.assertGreater(coarse / fine, 3.0)
+        self.assertLess(coarse / fine, 5.0)
+        self.assertLess(self.cond_X0, 1.0e3)
+
+    def test_the_diagonal_carries_p_untransposed_with_unit_coefficient(self):
+        """Gamma[(a,b),(a,b)] = P[a,b] exactly, sign and normalisation
+        included -- not merely proportional. The complex fixture is what
+        separates P from P^T = conj(P)."""
         got = np.array([self.gamma[a * NORB + b, a * NORB + b]
                         for (a, b) in self.P])
         want = np.array([self.P[(a, b)] for (a, b) in self.P])
-        scale = np.vdot(want, got) / np.vdot(want, want)
-        self.assertLess(abs(scale.imag), 1e-9 * abs(scale))
-        np.testing.assert_allclose(got, scale * want, rtol=0.0,
-                                   atol=1e-9 * float(np.max(np.abs(got))))
+        np.testing.assert_allclose(got, want, rtol=0.0,
+                                   atol=1e-7 * float(np.max(np.abs(want))))
         # and P^T is genuinely excluded
         wt = np.array([self.P[(b, a)] for (a, b) in self.P])
-        self.assertGreater(np.max(np.abs(got - scale * wt)),
+        self.assertGreater(np.max(np.abs(got - wt)),
                            1e-2 * float(np.max(np.abs(got))))
 
 
-class TestSCPlacesPairHopAsMeasured(unittest.TestCase):
-    """Compose the two measurements and check `sc.py` against the result.
 
-    chi0's row pair (l1, l2) labels the bilinear A_{l2 l1} and its column pair
-    (l3, l4) labels A_{l3 l4} (TestChi0PairIndexMeaning); the vertex is diagonal
-    in the bilinear pair, carrying P of that pair (TestPairHopVertexPlacement).
-    So in chi0's own labels it sits at row (l1, l2), column (l2, l1) -- the
-    Case 4 block, which was always right -- carrying P[l2, l1].
+class TestPairHopEndToEnd(unittest.TestCase):
+    """The determination that actually settles #100.
+
+    No index reasoning anywhere between the input file and the answer. The
+    chain under test is the one the solver runs:
+
+        interaction dict -> _build_interaction_k -> _build_sc_matrices_all_q
+                                                                     -> S
+        chi0 <- rpa.py's own kernel, fed with an EXACT Green function
+        prediction:  chi^ud = -chi0 . S . chi0        (linear order)
+
+    compared against the cross-spin response of the SAME Hamiltonian by exact
+    diagonalization. It is run for both orientations of the input matrix, and
+    whichever the chain needs in order to reproduce the exact answer is what
+    ``_to_k`` must store.
+
+    Why linear order is exactly one chain: H_PH couples an UP bilinear to a
+    DOWN one, so the cross-spin response vanishes identically at P = 0 and its
+    derivative is a single bubble-vertex-bubble term.
+
+    Why chi^ud: Case 4 sets S = C, and with the MYO signs
+    chi_s = [I - chi0 Us]^-1 chi0 and chi_c = [I + chi0 Uc]^-1 chi0, so
+    chi^ud = (chi_c - chi_s)/2 = -chi0 . S . chi0 + O(P^2).
+
+    Grand canonical throughout, because rpa.py's chi0 is. Every operator here
+    except the Green function conserves (N_up, N_down), so the trace splits
+    into sectors of dimension at most C(6,3)^2 = 400.
     """
 
-    def test_case4_carries_the_transposed_amplitude(self):
+    NTAU = 192
+    MU = 0.2
+    DP = 1.0e-4
+    # Hermitian-closed so that H_PH is Hermitian. P is then Hermitian as a
+    # matrix, so P^T = conj(P) is a DIFFERENT matrix and the fixture
+    # discriminates -- a real asymmetric P would make H non-Hermitian.
+    P_IN = {(0, 1): 1.0 + 0.3j, (1, 0): 1.0 - 0.3j}
+
+    @classmethod
+    def _h1(cls):
+        n = NSITE * NORB
+        m = lambda i, a: i * NORB + a
+        h = np.zeros((n, n), dtype=complex)
+        for i in range(NSITE):
+            for a in range(NORB):
+                h[m(i, a), m(i, a)] += ONSITE[a] - cls.MU
+                for d, t in ((+1, T_INTRA[a]), (-1, np.conj(T_INTRA[a]))):
+                    h[m((i + d) % NSITE, a), m(i, a)] += t
+            h[m(i, 1), m(i, 0)] += T_INTER
+            h[m(i, 0), m(i, 1)] += np.conj(T_INTER)
+        assert np.allclose(h, h.conj().T)
+        return h
+
+    @staticmethod
+    def _cdc(mask, p, q):
+        if not (mask >> q) & 1:
+            return None
+        sg = -1.0 if bin(mask & ((1 << q) - 1)).count("1") % 2 else 1.0
+        mm = mask & ~(1 << q)
+        if (mm >> p) & 1:
+            return None
+        sg *= -1.0 if bin(mm & ((1 << p) - 1)).count("1") % 2 else 1.0
+        return mm | (1 << p), sg
+
+    @classmethod
+    def _green(cls):
+        """G_{ab}(r, tau) = -<T c_{r a}(tau) c+_{0 b}(0)>.
+
+        One spin species suffices: at P = 0 the grand-canonical density matrix
+        factorises over spin.
+        """
+        nmode = NSITE * NORB
+        dim = 1 << nmode
+        C = []
+        for p in range(nmode):
+            op = np.zeros((dim, dim))
+            for st in range(dim):
+                if (st >> p) & 1:
+                    sg = (-1.0 if bin(st & ((1 << p) - 1)).count("1") % 2
+                          else 1.0)
+                    op[st & ~(1 << p), st] = sg
+            C.append(op)
+        CD = [c.T.conj() for c in C]
+        h = cls._h1()
+        H = np.zeros((dim, dim), dtype=complex)
+        for p in range(nmode):
+            for q in range(nmode):
+                if h[p, q]:
+                    H += h[p, q] * (CD[p] @ C[q])
+        E, U = np.linalg.eigh(H)
+        E -= E.min()
+        w = np.exp(-BETA * E)
+        taus = np.arange(cls.NTAU) * BETA / cls.NTAU
+        expo = np.exp(np.multiply.outer(taus, E[:, None] - E[None, :]))
+        m = lambda i, a: i * NORB + a
+        G = np.zeros((cls.NTAU, NSITE, NORB, NORB), dtype=complex)
+        for r in range(NSITE):
+            for a in range(NORB):
+                for b in range(NORB):
+                    A = U.conj().T @ C[m(r, a)] @ U
+                    B = U.conj().T @ CD[m(0, b)] @ U
+                    G[:, r, a, b] = -np.einsum(
+                        "m,tmn,mn,nm->t", w, expo, A, B) / w.sum()
+        return G
+
+    @classmethod
+    def _chi0_code(cls, G, qs):
+        """rpa.py::_calc_chi0q's general branch at zero bosonic frequency:
+        chi0[a,c,b,d] = G[a,b] * G_rev[d,c] * sgn, G_rev(l,r) = G(-l, -r)."""
+        nt = cls.NTAU
+        sgn = np.full(nt, -1.0)
+        sgn[0] = 1.0
+        Grev = G[np.ix_((-np.arange(nt)) % nt, (-np.arange(NSITE)) % NSITE)]
+        rt = (G[:, :, :, None, :, None]
+              * sgn[:, None, None, None, None, None]
+              * Grev[:, :, None, :, None, :])         # [l,r,a,d,b,c]
+        rt = rt.transpose(0, 1, 2, 5, 4, 3)           # -> [l,r,a,c,b,d]
+        phase = np.exp(-1j * np.multiply.outer(qs, np.arange(NSITE)))
+        out = -np.einsum("qr,lracbd->qacbd", phase, rt) * (BETA / nt)
+        return out.reshape(NSITE, NORB ** 2, NORB ** 2)
+
+    @classmethod
+    def _response(cls, amp, qs, same_spin=False):
+        """int dtau <A^u_{ab}(q,tau) A^s_{cd}(-q,0)>, grand canonical."""
+        nm = NSITE * NORB
+        mode = lambda i, a, s: (i * NORB + a) * 2 + s
+        h = cls._h1()
+        npair = NORB * NORB
+        num = np.zeros((NSITE, npair, npair), dtype=complex)
+        Z = 0.0
+        ups = [mode(i, a, 0) for i in range(NSITE) for a in range(NORB)]
+        dns = [mode(i, a, 1) for i in range(NSITE) for a in range(NORB)]
+        for nu in range(nm + 1):
+            for nd in range(nm + 1):
+                states = []
+                for su in itertools.combinations(ups, nu):
+                    for sd in itertools.combinations(dns, nd):
+                        m = 0
+                        for p in su + sd:
+                            m |= 1 << p
+                        states.append(m)
+                states.sort()
+                idx = {st: i for i, st in enumerate(states)}
+                D = len(states)
+
+                def bil(q, a, b, s):
+                    op = np.zeros((D, D), dtype=complex)
+                    for j, mask in enumerate(states):
+                        for i in range(NSITE):
+                            r = cls._cdc(mask, mode(i, a, s), mode(i, b, s))
+                            if r:
+                                op[idx[r[0]], j] += np.exp(-1j * q * i) * r[1]
+                    return op
+
+                H = np.zeros((D, D), dtype=complex)
+                for s in range(2):
+                    for p in range(nm):
+                        for q in range(nm):
+                            if not h[p, q]:
+                                continue
+                            for j, mask in enumerate(states):
+                                r = cls._cdc(mask,
+                                             mode(p // NORB, p % NORB, s),
+                                             mode(q // NORB, q % NORB, s))
+                                if r:
+                                    H[idx[r[0]], j] += h[p, q] * r[1]
+                if amp:
+                    # H_PH = sum_{aa'} P_{aa'} A^u_{aa'} A^d_{aa'}; the two
+                    # bilinears commute, so no symmetrisation and no stray 2.
+                    for (a, ap), v in cls.P_IN.items():
+                        for i in range(NSITE):
+                            u = np.zeros((D, D), dtype=complex)
+                            w_ = np.zeros((D, D), dtype=complex)
+                            for j, mask in enumerate(states):
+                                r = cls._cdc(mask, mode(i, a, 0),
+                                             mode(i, ap, 0))
+                                if r:
+                                    u[idx[r[0]], j] += r[1]
+                                r = cls._cdc(mask, mode(i, a, 1),
+                                             mode(i, ap, 1))
+                                if r:
+                                    w_[idx[r[0]], j] += r[1]
+                            H += amp * v * (u @ w_)
+                assert np.allclose(H, H.conj().T), "H must be Hermitian"
+                E, U = np.linalg.eigh(H)
+                # _h1 already carries -MU on the diagonal, so H is H0 - MU N
+                # and NO further fugacity factor may be applied here.
+                w = np.exp(-BETA * E)
+                dE = E[:, None] - E[None, :]
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    kern = (w[None, :] - w[:, None]) / dE
+                deg = np.abs(dE) < 1e-10
+                kern[deg] = (BETA * w[:, None] * np.ones_like(dE))[deg]
+                sb = 0 if same_spin else 1
+                for iq, q in enumerate(qs):
+                    A = [U.conj().T @ bil(q, a, b, 0) @ U
+                         for a in range(NORB) for b in range(NORB)]
+                    B = [U.conj().T @ bil(-q, a, b, sb) @ U
+                         for a in range(NORB) for b in range(NORB)]
+                    for i, Ar in enumerate(A):
+                        for j, Br in enumerate(B):
+                            num[iq, i, j] += np.sum(Ar * Br.T * kern)
+                Z += w.sum()
+        return num / Z
+
+    @staticmethod
+    def _reverse_row_pair(arr):
+        rev = np.array([(x % NORB) * NORB + (x // NORB)
+                        for x in range(NORB ** 2)])
+        return arr[:, rev, :]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.qs = 2.0 * np.pi * np.arange(NSITE) / NSITE
+        cls.chi0 = cls._chi0_code(cls._green(), cls.qs)
+        cls.bubble = cls._reverse_row_pair(cls._response(0.0, cls.qs,
+                                                         same_spin=True))
+        cls.ud0 = cls._response(0.0, cls.qs)
+        cls.lead = cls._reverse_row_pair(
+            (cls._response(+cls.DP, cls.qs) - cls._response(-cls.DP, cls.qs))
+            / (2.0 * cls.DP))
+
+    @staticmethod
+    def _worst(pred, ref):
+        out = 0.0
+        for iq in range(1, NSITE):     # q = 0 carries a disconnected part
+            s = np.vdot(pred[iq], ref[iq]) / np.vdot(pred[iq], pred[iq])
+            out = max(out, np.max(np.abs(ref[iq] - s * pred[iq]))
+                      / np.max(np.abs(ref[iq])))
+        return out
+
+    def test_cross_spin_response_vanishes_without_pairhop(self):
+        """The premise: at P = 0 the leading term is the whole story. q = 0 is
+        excluded because it carries the disconnected part <A^u><A^d>."""
+        self.assertLess(float(np.max(np.abs(self.ud0[1:]))), 1e-12)
+
+    def test_the_code_kernel_reproduces_the_exact_bubble(self):
+        """Locate the residual before using it: chi0 built from rpa.py's own
+        kernel matches the exact same-spin bubble to the imaginary-time
+        discretisation, so any larger residual downstream is a real
+        disagreement and not the grid."""
+        self.assertLess(self._worst(self.chi0, self.bubble), 1e-2)
+
+    def _sc_matrix(self, mat):
         import hwave.sc as sc
 
-        P = {(0, 1): 1.0, (1, 0): 0.35}          # on-site, asymmetric
-        vr = {((0, 0, 0), (a, b)): v for (a, b), v in P.items()}
         k = np.array([0.0])
+        vr = {((0, 0, 0), ab): v for ab, v in mat.items()}
         ik = sc._build_interaction_k(k, k, k, {"PairHop": vr}, NORB)
-        S, Cm = sc._build_sc_matrices_all_q(ik, NORB, 1, 1, 1)
+        S, C = sc._build_sc_matrices_all_q(ik, NORB, 1, 1, 1)
+        np.testing.assert_allclose(S, C, rtol=0.0, atol=1e-14)
+        return S[0, 0, 0]
 
-        for (l1, l2), v in P.items():
-            row, col = l1 * NORB + l2, l2 * NORB + l1
-            for name, M in (("S", S), ("C", Cm)):
-                with self.subTest(matrix=name, l1=l1, l2=l2):
-                    self.assertAlmostEqual(
-                        complex(M[0, 0, 0, row, col]), P[(l2, l1)], places=12,
-                        msg="row ({},{}) col ({},{}) must carry P[{},{}]"
-                            .format(l1, l2, l2, l1, l2, l1))
+    def test_the_untransposed_placement_reproduces_exact_diagonalization(self):
+        P = self.P_IN
+        PT = {(b, a): v for (a, b), v in P.items()}
+        keep = self._sc_matrix(P)     # _to_k leaves PairHop alone -> S = P
+        flip = self._sc_matrix(PT)
+
+        # say out loud which placement each one is, so the test cannot silently
+        # invert if `_to_k` changes
+        self.assertAlmostEqual(complex(keep[0 * NORB + 1, 1 * NORB + 0]),
+                               P[(0, 1)], places=12)
+        self.assertAlmostEqual(complex(flip[0 * NORB + 1, 1 * NORB + 0]),
+                               P[(1, 0)], places=12)
+
+        r_keep = self._worst(
+            np.array([-self.chi0[i] @ keep @ self.chi0[i]
+                      for i in range(NSITE)]), self.lead)
+        r_flip = self._worst(
+            np.array([-self.chi0[i] @ flip @ self.chi0[i]
+                      for i in range(NSITE)]), self.lead)
+        self.assertLess(r_keep, 1e-2,
+                        "S[(a,b),(b,a)] = P[a,b] must reproduce the exact "
+                        "cross-spin response")
+        self.assertGreater(r_flip, 1e-1,
+                           "the transposed placement must be excluded")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #100.

**Outcome: the existing placement is correct.** `_to_k` still leaves PairHop alone, and `sc.py` changes only in comments. No numerical output changes.

An earlier revision of this branch transposed PairHop. That was wrong, and how it went wrong is why this is now settled differently.

### The two measurements, which are sound and are kept

**`TestChi0PairIndexMeaning`.** `rpa.py::_calc_chi0q` builds, in the general branch, `chi0[a,c,b,d] = G[a,b] G_rev[d,c] sgn`, and the S/C matrices are indexed by the flattened pairs. Which *bilinear* does each pair stand for? Comparing the kernel against the exact correlator of the generalised densities `A_ab(q) = sum_i e^{-iqr} c+_ia c_ib`, with G from the same diagonalization, singles out one of the 24 index permutations:

```
chi0[a,c,b,d](q)  ~  <A_ca(q) A_bd(-q)>
```

The **row** pair is reversed relative to its bilinear; the column pair is not.

**`TestPairHopVertexPlacement`.** `H_PH = sum_{aa'} P_aa' A^u_aa' A^d_aa'` couples an up bilinear to a down one, so the cross-spin response vanishes identically at `P = 0` and its derivative is exactly one bubble-vertex-bubble chain. Inverting it gives a vertex **diagonal in the bilinear pair**, with `Gamma[(a,b),(a,b)] = P[a,b]` exactly — sign and normalisation included, not merely proportional.

### What was wrong: combining them by hand

The vertex sits *between* two chi0 factors, so its row index lives in chi0's **column** convention and its column index in chi0's **row** convention. The measured reversal is on the row pair, so it lands on the vertex's **column** side. Applying it to the row side instead yields the transpose — which is what the earlier revision did.

Two derivations of the same shape reached opposite conclusions. That is reason enough not to settle it by derivation at all.

### What settles it: `TestPairHopEndToEnd`

No index reasoning anywhere between the input file and the answer. The chain under test is the one the solver runs:

```
interaction dict -> _build_interaction_k -> _build_sc_matrices_all_q -> S
chi0             <- rpa.py's own kernel, fed an EXACT Green function
prediction:  chi^ud = -chi0 . S . chi0        (linear order)
```

compared against the cross-spin response of the same Hamiltonian by exact diagonalization. Both orientations are run, and the test states which placement each one is, so it cannot silently invert if `_to_k` changes.

| placement | residual at 192 tau points | at 384 | at 768 |
|---|---|---|---|
| `S[(a,b),(b,a)] = P[a,b]` (current) | 2.3e-3 | 1.1e-3 | 5.5e-4 |
| `S[(a,b),(b,a)] = P[b,a]` (transposed) | 0.551 | 0.551 | 0.551 |

The winner tracks chi0's own imaginary-time discretisation — the test measures that separately in the same run, by checking chi0 against the exact bubble, so a larger residual downstream would be a real disagreement rather than the grid. (The test itself runs the first column; the refinement was measured off-line.)

### Also addressed

- The PairHop Hamiltonian no longer symmetrises `up @ dn`. The two bilinears commute, so symmetrising put a spurious factor of two into the measured coefficient; the vertex coefficient is now asserted exactly.
- The central-difference truncation is documented as O(dP^2), not O(dP^3), with a dP-halving test and a condition-number bound on X0 instead of an asserted tolerance.
- The fixture is complex and Hermitian-closed (`P_a'a = conj(P_aa')`). A real asymmetric PairHop matrix makes the Hamiltonian non-Hermitian, so it cannot be used for this at all; a complex Hermitian one still has `P^T = conj(P) != P`, which is what makes it discriminating.

942 tests pass.