### PR TITLE
Abandoned: transverse (ladder) vertex — the proposed fix was the wrong direction

### DIFF
--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -2218,6 +2218,8 @@ class RPA:
         # Verification for each interaction type:
         #   CoulombIntra U: ham[↑↑↑↑]=0, ham[↓↓↑↑]=U  → W_+-= -U  (correct)
         #   CoulombInter V: ham[↑↑↑↑]=V, ham[↓↓↑↑]=V  → W_+-=  0  (SU(2) correct)
+        #                   -- and the cancellation is only exact if the two
+        #                      blocks are taken in the SAME index order; see #90
         #   Exchange J:     ham[↑↑↑↑]=0, ham[↓↓↑↑]=0   → W_+-=  0  (SU(2) correct)
         #   PairLift J:     ham[↑↑↑↑]=0, ham[↓↓↑↑]=0   → W_+-=  0  (SU(2) correct)
         #   Hund J:         ham[↑↑↑↑]=-J, ham[↓↓↑↑]=0  → W_+-= -J  (not SU(2) alone)
@@ -2225,14 +2227,37 @@ class RPA:
         #   Full Kanamori:  W_+- = -(U-2J) = W_zz  (SU(2) correct)
         ham_4d = ham_orig.reshape(nvol, nd, nd, nd, nd)
 
-        # Vectorized extraction using index arrays (replaces norb^4 Python loop)
         # Same-spin block: ham[(↑,a),(↑,c),(↑,b),(↑,d)]
         up_block = ham_4d[:, :norb, :norb, :norb, :norb]  # (nvol, norb, norb, norb, norb)
-        # Cross-spin block: ham[(↓,d),(↓,b),(↑,c),(↑,a)] with index reordering
-        cross_block = ham_4d[:, norb:, norb:, :norb, :norb]  # (nvol, norb, norb, norb, norb)
-        # cross_block[:, d, b, c, a] -> need to transpose to match ham_pm[:, a, c, b, d]
-        cross_reordered = cross_block.transpose(0, 4, 3, 2, 1)  # (nvol, a, c, b, d)
-        ham_pm = up_block - cross_reordered
+        # Cross-spin block: ham[(↓,a),(↓,c),(↑,b),(↑,d)], taken with the SAME
+        # index order as the same-spin block.
+        #
+        # This used to be `cross_block.transpose(0, 4, 3, 2, 1)`, which
+        # reverses the orbital-pair index, and that is a bug (issue #90). The
+        # table above is right -- a spin-independent density-density
+        # interaction has no transverse spin vertex, so CoulombInter must
+        # cancel between the two blocks -- but with the reversal it cancels
+        # only when V(q) happens to be symmetric under the pair transpose. For
+        # a general V(q) it leaves the antisymmetric remainder V(q) - V(q)^T as
+        # a spurious vertex, and SU(2) is broken by that amount.
+        #
+        # Measured on the two-orbital fixture with CoulombInter: the vertex the
+        # transverse channel needs in order to reproduce the longitudinal
+        # chi_zz -- which is chi_zz^-1 - chi0_pm^-1, computed from the solver's
+        # own output -- is 7e-15, i.e. zero, while the reversed form builds a
+        # vertex of magnitude 2.0 that is purely antisymmetric (its symmetric
+        # part is exactly 0). Searching all 24 axis permutations against that
+        # requirement, over CoulombIntra / CoulombInter / Hund / Exchange /
+        # PairLift / Ising / Kanamori, leaves only permutations that agree with
+        # the plain block here; every other one, the previous form included, is
+        # off by twelve orders of magnitude.
+        #
+        # Residual freedom: those fixtures cannot separate this from swapping
+        # within either pair, because they are all symmetric in those slots. An
+        # interaction asymmetric there would distinguish them, and none is
+        # reachable through the readers today (see #93).
+        cross_block = ham_4d[:, norb:, norb:, :norb, :norb]
+        ham_pm = up_block - cross_block
 
         logger.info("ring+ladder: built transverse channel "
                     "(chi0_pm shape={}, ham_pm shape={})".format(

--- a/tests/test_rpa_ladder.py
+++ b/tests/test_rpa_ladder.py
@@ -236,24 +236,31 @@ class TestRPALadder(unittest.TestCase):
 
 
     def _assert_su2(self, green_info, norb=1, msg=""):
-        """Assert SU(2) symmetry: chi_zz = chi_+- at all q-points for iw0."""
+        """Assert SU(2) symmetry: chi_zz = chi_+- at all q-points for iw0.
+
+        Over the FULL norb^2 x norb^2 orbital-pair matrix. This used to sum
+        only the pair-DIAGONAL elements ``chiq[..., a,a,a,a]`` at norb > 1,
+        which are invariant under the orbital-pair transpose -- so it could not
+        see a transverse vertex built with that index reversed (issue #90).
+        """
         chiq = green_info["chiq"]
         chiq_pm = green_info["chiq_pm"]
 
         nfreq = chiq.shape[0]
         iw0 = nfreq // 2
+        npair = norb * norb
 
-        if norb == 1:
-            chi_zz = chiq[iw0, :, 0, 0, 0, 0] - chiq[iw0, :, 0, 0, 1, 1]
-            chi_pm = chiq_pm[iw0, :, 0, 0, 0, 0]
-        else:
-            nd = norb * 2
-            chi_zz = np.zeros(chiq.shape[1], dtype=complex)
-            chi_pm = np.zeros(chiq.shape[1], dtype=complex)
-            for a in range(norb):
-                chi_zz += (chiq[iw0, :, a, a, a, a]
-                           - chiq[iw0, :, a, a, norb + a, norb + a])
-                chi_pm += chiq_pm[iw0, :, a, a, a, a]
+        chi_zz = np.zeros((chiq.shape[1], npair, npair), dtype=complex)
+        chi_pm = np.zeros_like(chi_zz)
+        for a in range(norb):
+            for c in range(norb):
+                for b in range(norb):
+                    for d in range(norb):
+                        i, j = a * norb + c, b * norb + d
+                        chi_zz[:, i, j] = (
+                            chiq[iw0, :, a, c, b, d]
+                            - chiq[iw0, :, a, c, norb + b, norb + d])
+                        chi_pm[:, i, j] = chiq_pm[iw0, :, a, c, b, d]
 
         np.testing.assert_allclose(
             chi_zz, chi_pm,
@@ -302,6 +309,87 @@ class TestRPALadder(unittest.TestCase):
             },
         )
         self._assert_su2(green_info, msg="CoulombIntra + Hund")
+
+    def test_su2_coulombinter_2orb(self):
+        """CoulombInter at TWO orbitals: the case that separates the vertices.
+
+        `test_su2_coulombinter` and `_only` run on `tests/rpa/input`, which has
+        ONE orbital, so the orbital-pair index takes a single value and a
+        vertex built with that index reversed is indistinguishable from the
+        correct one. With two orbitals and an on-site inter-orbital entry V(q)
+        is not symmetric under the pair transpose at general q, and the
+        reversed form leaves the antisymmetric remainder V(q) - V(q)^T behind
+        as a spurious transverse vertex.
+
+        Before the #90 fix this failed by 2.9e-2 on a scale of 1.2e-1.
+        """
+        solver, green_info = self._run_rpa(
+            calc_type="ring+ladder",
+            calc_scheme="general",
+            input_path='tests/rpa/input_2orb',
+            Lx=4, Ly=4, Nmat=32,
+            T=2.0, filling=0.5,
+            interactions={'CoulombInter': 'coulombinter.dat'},
+        )
+        self._assert_su2(green_info, norb=2, msg="CoulombInter (2-orbital)")
+
+    def test_transverse_vertex_vanishes_for_a_spin_independent_interaction(self):
+        """A spin-independent density-density interaction has no transverse
+        spin vertex -- and the requirement is measured, not asserted.
+
+        From chi = [I + chi0 W]^-1 chi0, the vertex the transverse channel
+        would need in order to reproduce the longitudinal chi_zz is
+
+            W_needed = chi_zz^-1 - chi0_pm^-1
+
+        computed from the solver's own output. For CoulombInter it comes out
+        zero, so the vertex the builder produces must be zero too. Before #90
+        it was 2.0, and purely antisymmetric.
+        """
+        import hwave.solver.rpa as rpa_mod
+
+        captured = {}
+        original = rpa_mod.RPA._build_transverse_channel
+
+        def spy(inner_self, chi0q_orig, ham_orig):
+            out = original(inner_self, chi0q_orig, ham_orig)
+            captured["chi0_pm"] = np.asarray(out[0])
+            captured["ham_pm"] = np.asarray(out[1])
+            return out
+
+        rpa_mod.RPA._build_transverse_channel = spy
+        try:
+            _, green_info = self._run_rpa(
+                calc_type="ring+ladder", calc_scheme="general",
+                input_path='tests/rpa/input_2orb',
+                Lx=4, Ly=4, Nmat=32, T=2.0, filling=0.5,
+                interactions={'CoulombInter': 'coulombinter.dat'},
+            )
+        finally:
+            rpa_mod.RPA._build_transverse_channel = original
+
+        norb = 2
+        npair = norb * norb
+        chiq = green_info["chiq"]
+        iw0 = chiq.shape[0] // 2
+        nq = chiq.shape[1]
+        zz = np.zeros((nq, npair, npair), dtype=complex)
+        for a in range(norb):
+            for c in range(norb):
+                for b in range(norb):
+                    for d in range(norb):
+                        zz[:, a * norb + c, b * norb + d] = (
+                            chiq[iw0, :, a, c, b, d]
+                            - chiq[iw0, :, a, c, norb + b, norb + d])
+        x0 = captured["chi0_pm"][iw0].reshape(nq, npair, npair)
+        needed = np.array([np.linalg.inv(zz[i]) - np.linalg.inv(x0[i])
+                           for i in range(nq)])
+        self.assertLess(
+            float(np.max(np.abs(needed))), 1e-10,
+            "CoulombInter must not enter the transverse spin vertex")
+        self.assertLess(
+            float(np.max(np.abs(captured["ham_pm"]))), 1e-12,
+            "so the vertex the builder produces must vanish as well")
 
     def test_su2_hund_2orb(self):
         """2-orbital Hund: chi_zz = chi_pm at the RPA level.

--- a/tests/test_rpa_ladder.py
+++ b/tests/test_rpa_ladder.py
@@ -2,14 +2,24 @@
 """Tests for RPA ladder diagram (ring+ladder calc_type).
 
 Tests verify:
-1. chi_zz = chi_+- consistency: At the RPA level for paramagnetic states,
-   the longitudinal spin vertex V_spin = W_uu - W_ud is identical to the
-   transverse vertex W_pm = ham[↑↑↑↑] - ham[↓↓↑↑]. This holds for ANY
-   interaction, not just SU(2)-symmetric ones.
+1. chi_zz = chi_+- consistency: at the RPA level for paramagnetic states, the
+   longitudinal spin vertex W_uu - W_ud equals the transverse vertex
+   ham[↑↑↑↑] - ham[↓↓↑↑], PROVIDED both spin blocks are taken in the same
+   orbital-pair index order. Taking one of them reversed leaves the
+   antisymmetric remainder of the interaction behind as a spurious vertex; that
+   was the defect in issue #90, and it cancelled only for interactions whose
+   V(q) happens to be pair-symmetric.
 2. Ring-only regression: calc_type="ring" results unchanged
 3. Bare susceptibility validation: chi0 from RPA matches Lindhard function
 4. Multi-interaction consistency: CoulombIntra, CoulombInter, Hund, Exchange,
    Ising, PairLift, and full Kanamori all satisfy chi_zz = chi_pm.
+
+Discriminating power is the thing to protect here. Most of the cases below run
+on `tests/rpa/input`, which has ONE orbital, so the orbital-pair index takes a
+single value and any pair-index error is invisible; `_assert_su2` must
+therefore compare the full norb^2 x norb^2 matrix, not just its diagonal, and
+at least one case must run at two orbitals with an interaction that is not
+pair-symmetric.
 """
 
 import os
@@ -390,6 +400,73 @@ class TestRPALadder(unittest.TestCase):
         self.assertLess(
             float(np.max(np.abs(captured["ham_pm"]))), 1e-12,
             "so the vertex the builder produces must vanish as well")
+
+    def test_the_projected_spin_channel_obeys_a_pair_space_rpa_equation(self):
+        """Guard the premise behind reading `chi_zz^-1 - chi0_pm^-1` as a vertex.
+
+        The longitudinal solve is a norb^2*4 problem in spin-orbital space, and
+        chi_zz is a projection of it onto the spin sector. Treating
+        `chi_zz^-1 - chi0_pm^-1` as "the vertex the transverse channel needs"
+        assumes that projection CLOSES -- that chi_zz itself satisfies a
+        norb^2 x norb^2 equation chi = [I + chi0_pm W]^-1 chi0_pm.
+
+        Test it rather than assume it: for an ON-SITE interaction the vertex is
+        q-independent, so the extracted W must be q-independent too. If the
+        projection did not close, no single q-independent W could reproduce the
+        projected object and the extraction would vary with q.
+
+        Measured: spread over q of 2.7e-15 (CoulombIntra) and 5.2e-15 (Hund),
+        with |W| equal to the interaction strength itself (U = 4 -> 4.0).
+        """
+        import hwave.solver.rpa as rpa_mod
+
+        for label, interactions in (
+            ("CoulombIntra", {'CoulombIntra': 'coulombintra.dat'}),
+            ("Hund", {'Hund': 'hund_onsite.dat'}),
+        ):
+            with self.subTest(interaction=label):
+                captured = {}
+                original = rpa_mod.RPA._build_transverse_channel
+
+                def spy(inner_self, chi0q_orig, ham_orig):
+                    out = original(inner_self, chi0q_orig, ham_orig)
+                    captured["chi0_pm"] = np.asarray(out[0])
+                    return out
+
+                rpa_mod.RPA._build_transverse_channel = spy
+                try:
+                    _, green_info = self._run_rpa(
+                        calc_type="ring+ladder", calc_scheme="general",
+                        input_path='tests/rpa/input_2orb',
+                        Lx=4, Ly=4, Nmat=32, T=2.0, filling=0.5,
+                        interactions=interactions,
+                    )
+                finally:
+                    rpa_mod.RPA._build_transverse_channel = original
+
+                norb = 2
+                npair = norb * norb
+                chiq = green_info["chiq"]
+                iw0 = chiq.shape[0] // 2
+                nq = chiq.shape[1]
+                zz = np.zeros((nq, npair, npair), dtype=complex)
+                for a in range(norb):
+                    for c in range(norb):
+                        for b in range(norb):
+                            for d in range(norb):
+                                zz[:, a * norb + c, b * norb + d] = (
+                                    chiq[iw0, :, a, c, b, d]
+                                    - chiq[iw0, :, a, c, norb + b, norb + d])
+                x0 = captured["chi0_pm"][iw0].reshape(nq, npair, npair)
+                w = np.array([np.linalg.inv(zz[i]) - np.linalg.inv(x0[i])
+                              for i in range(nq)])
+                self.assertGreater(float(np.max(np.abs(w))), 0.5,
+                                   "this interaction must give a nonzero "
+                                   "vertex, or the test proves nothing")
+                self.assertLess(float(np.max(np.abs(w - w.mean(axis=0)))),
+                                1e-10,
+                                "an on-site interaction must give a "
+                                "q-independent vertex")
 
     def test_su2_hund_2orb(self):
         """2-orbital Hund: chi_zz = chi_pm at the RPA level.


### PR DESCRIPTION
**Closed without merging. The production change here is wrong and must not be applied.** The findings are recorded in #90, which stays open.

## What this branch proposed

`_build_transverse_channel` builds the ladder vertex as `up_block - cross_block.transpose(0,4,3,2,1)`. This branch dropped the transpose, making `CoulombInter` cancel exactly between the two spin blocks — matching the comment table in the method, which says `CoulombInter V -> W_+- = 0`.

That restored `chi_zz = chi_pm` for a two-orbital CoulombInter, from 2.9e-2 to 1.0e-16, and I took the agreement as confirmation.

## Why it is wrong

Exact diagonalization, with the O(lambda) self-energy subtracted exactly via the response to the Hartree-Fock one-body potential, gives a q-independent transverse vertex of **-V** for on-site CoulombInter, not zero. Numbers and method in #90.

The oracle was the problem. `_assert_su2` compares the **ring** `chi_zz` against the **ring+ladder** `chi_pm` and demands equality. Those sit at different diagrammatic levels — the ring puts a spin-independent density interaction entirely in the charge channel and leaves spin bare (measured: spin vertex 7.4e-15, charge vertex 4.0), while the exchange contribution that also feeds the spin channel is exactly what a ladder is for. So the equality is only satisfiable by making the ladder contribute nothing for V, and this branch achieved it by doing precisely that. The table entry `CoulombInter -> W_+- = 0` appears to have been derived from that test rather than from the physics.

## What still stands, and is not addressed here

1. **The shipped vertex is wrong under any reading.** It evaluates to `V(q) - V(q)^T`, purely antisymmetric — matching neither 0 nor -V. It cancels only when V(q) is symmetric under the pair transpose.
2. **The test suite cannot see pair-index errors.** Every CoulombInter SU(2) case runs on a one-orbital fixture, where the orbital-pair index takes a single value; and `_assert_su2` compared only the pair-diagonal elements at norb > 1, which are invariant under the transpose at issue.
3. **The SU(2) oracle is not valid as written**, per above.
4. **PairHop is the only interaction type that separates the tied index permutations**, and it was absent from the search here.

The tests added on this branch encode the wrong conclusion and are discarded with it. Items 1-4 belong to #90.