### PR TITLE
Correct the S/C vertex content for Hund, Exchange and Ising against exact diagonalization

### DIFF
--- a/docs/en/source/algorithm/eliashberg.rst
+++ b/docs/en/source/algorithm/eliashberg.rst
@@ -125,16 +125,30 @@ The matrix elements are:
      - :math:`U`
    * - :math:`l_1 = l_3 \neq l_2 = l_4`
      - Cross
-     - :math:`U' - I`
-     - :math:`-U' + J - I`
+     - :math:`U' + I - J + J'`
+     - :math:`-U' - I + J + J'`
    * - :math:`l_1 = l_2 \neq l_3 = l_4`
      - Density
      - :math:`J - 2I`
      - :math:`2U' - J`
    * - :math:`l_1 = l_4 \neq l_2 = l_3`
-     - Exchange
-     - :math:`J' + P`
-     - :math:`J' + P`
+     - Pair hop
+     - :math:`P`
+     - :math:`P`
+
+.. note::
+
+   The Cross-row entries for :math:`J`, :math:`J'` and :math:`I`, and the
+   placement of :math:`J'` in the Cross row rather than the last row, follow
+   the exact-diagonalization adjudication of the interaction vertices: the
+   Hund term contributes :math:`S \mathrel{-}= J`, :math:`C \mathrel{+}= J`,
+   the Exchange term :math:`S \mathrel{+}= J'`, :math:`C \mathrel{+}= J'`,
+   and the Ising term enters :math:`S` with :math:`+I`. For the
+   SU(2)-symmetric Kanamori combination (:math:`J' = J`) these reproduce the
+   standard literature matrices (no :math:`J` in the Cross :math:`S` entry and
+   :math:`-U' + 2J` in the Cross :math:`C` entry). Susceptibility files
+   produced before this correction carry no ``sc_vertex_version`` field and
+   are rejected when the interaction set contains Hund, Exchange or Ising.
 
 The RPA susceptibilities are
 

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -542,7 +542,10 @@ The FLEX solver produces NumPy ``.npz`` files with the following contents:
   to be paired with, and which shape family they have: ``"kuroki"`` for the
   reduced/squashed schemes (spin-orbital shape, ``nd = norb * ns``) or
   ``"myo"`` for the general full-vertex scheme (orbital-pair shape,
-  ``nd = norb^2``, and the MYO value of the ``C(ab,ab)`` charge vertex). The
+  ``nd = norb^2``; the historical MYO-vs-Kuroki difference in the
+  ``C(ab,ab)`` charge vertex was resolved by the exact-diagonalization
+  adjudication of the per-type vertex content, so the two builders now
+  coincide). The
   Eliashberg loader (``hwave_sc``) uses this tag to interpret the orbital
   indices; it is essential for two-orbital systems, where the spin-orbital and
   orbital-pair dimensions coincide (both ``4``) and shape alone is ambiguous.

--- a/docs/ja/source/algorithm/eliashberg.rst
+++ b/docs/ja/source/algorithm/eliashberg.rst
@@ -125,16 +125,29 @@ RPA感受率は
      - :math:`U`
    * - :math:`l_1 = l_3 \neq l_2 = l_4`
      - クロス
-     - :math:`U' - I`
-     - :math:`-U' + J - I`
+     - :math:`U' + I - J + J'`
+     - :math:`-U' - I + J + J'`
    * - :math:`l_1 = l_2 \neq l_3 = l_4`
      - 密度
      - :math:`J - 2I`
      - :math:`2U' - J`
    * - :math:`l_1 = l_4 \neq l_2 = l_3`
-     - 交換
-     - :math:`J' + P`
-     - :math:`J' + P`
+     - ペアホップ
+     - :math:`P`
+     - :math:`P`
+
+.. note::
+
+   クロス行の :math:`J` 、 :math:`J'` 、 :math:`I` の各項、および :math:`J'`
+   が最終行ではなくクロス行に現れる配置は、相互作用頂点の厳密対角化による
+   裁定に従っています。Hund 項は :math:`S` に :math:`-J` ・ :math:`C` に
+   :math:`+J` を、Exchange 項は両行列に :math:`+J'` を、Ising 項は :math:`S`
+   に :math:`+I` を与えます。SU(2) 対称な Kanamori の組（ :math:`J' = J` ）
+   ではこれらが標準的な文献の行列（クロス :math:`S` に :math:`J` なし、
+   クロス :math:`C` に :math:`-U' + 2J` ）を再現します。この修正より前に
+   生成された感受率ファイルは ``sc_vertex_version`` フィールドを持たず、
+   相互作用に Hund・Exchange・Ising が含まれる場合は読み込み時に拒否され
+   ます。
 
 RPA感受率は
 

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -513,8 +513,9 @@ FLEXソルバーは以下の内容を持つNumPy ``.npz`` ファイルを生成�
 - ``chi_convention``: 感受率をどのスピン/電荷頂点と組み合わせるべきか、および
   形状の系統を示すタグ。reduced/squashed スキームは ``"kuroki"``\ （スピン軌道
   形状、``nd = norb * ns``\ ）、general full-vertex スキームは ``"myo"``\
-  （orbital-pair 形状 ``nd = norb^2``\ 、および ``C(ab,ab)`` 電荷頂点にMYOの値を
-  用いること）。Eliashberg ローダー（\ ``hwave_sc``\ ）はこのタグで軌道
+  （orbital-pair 形状 ``nd = norb^2``\ 。かつて ``C(ab,ab)`` 電荷頂点にあった
+  MYO と Kuroki の差は、型別頂点内容の厳密対角化による裁定で解消され、現在は
+  両ビルダーは一致します）。Eliashberg ローダー（\ ``hwave_sc``\ ）はこのタグで軌道
   インデックスを解釈します。2軌道系ではスピン軌道次元と orbital-pair 次元が
   一致（ともに ``4``\ ）し形状だけでは区別できないため、このタグが必須です。
 - ``chi_orbital_layout``: **general** スキームのみが書き出します。値は

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -818,8 +818,19 @@ def _symmetrise_interactions_k(inter_k):
         input on-site and off-site, and preserves the physical complex phase.
 
     Idempotent, so it is safe that both the all-q and per-q builders apply it.
-    This matches `uhfk.py`'s reading of the files ((jab + jba)/2) and the
-    transverse channel's slot-family rule (#105/#106/#113).
+
+    Relation to UHFk: `uhfk.py` stores the HERMITIAN mean -- vba there is the
+    CONJUGATED r-reversed transpose (`_make_ham_inter`) -- which keeps a
+    complex Hermitian-closed coefficient p intact, while this helper folds it
+    to Re(p). The two tables serve different contractions and give the SAME
+    physical Hamiltonian: UHFk sums its table over both ordered orbital
+    pairs, so p + conj(p) appears there; the S/C builders here use each slot
+    exactly once, so the effective real coefficient must already be folded
+    in. That the imaginary part of a Hermitian-closed same-operator
+    declaration is physically inert was adjudicated against exact
+    diagonalization in #105/#106; the slot content is #113. For real
+    declarations -- everything the documented input format produces -- the
+    two conventions coincide identically.
     """
     out = {}
     for itype, M in inter_k.items():
@@ -1461,10 +1472,20 @@ def _read_flex_chi_raw(input_dict, allow_ir=False, interactions=None):
                         "silently mix two different interactions -- "
                         "regenerate the susceptibilities with the current "
                         "code.".format(path, ", ".join(affected)))
+                # strict decode: the tag must be a single integral scalar.
+                # A plain int() would silently truncate (2.9 -> 2, accepted)
+                # and non-finite values would escape as OverflowError.
                 try:
-                    versions[path] = int(np.asarray(
-                        data["sc_vertex_version"]).item())
-                except (TypeError, ValueError):
+                    arr = np.asarray(data["sc_vertex_version"])
+                    if arr.size != 1:
+                        raise ValueError("not a scalar")
+                    val = complex(arr.reshape(())[()])
+                    if val.imag != 0.0 or not (
+                            np.isfinite(val.real)
+                            and float(val.real).is_integer()):
+                        raise ValueError("not an integer")
+                    versions[path] = int(val.real)
+                except (TypeError, ValueError, OverflowError):
                     raise ValueError(
                         "FLEX susceptibility file '{}' carries a malformed "
                         "sc_vertex_version field ({!r}).".format(

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -862,10 +862,30 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
             s_q += Up_mat[_l1, _l2]
             c_q -= Up_mat[_l1, _l2]
         if I_mat is not None:
-            s_q -= I_mat[_l1, _l2]
+            # SIGN adjudicated by exact diagonalization (issue #113): the
+            # exact spin vertex carries -I at this slot in the
+            # [I + chi0 W]^-1 convention, i.e. +I here (S enters as -S).
+            # The previous -I produced the wrong sign end to end.
+            s_q += I_mat[_l1, _l2]
             c_q -= I_mat[_l1, _l2]
         if J_mat is not None:
+            # Hund contributes to BOTH channels at this slot (issue #113):
+            # the exact vertices are W_zz = +J and W_cc = +J, i.e. S -= J and
+            # C += J. The S term was missing entirely.
+            s_q -= J_mat[_l1, _l2]
             c_q += J_mat[_l1, _l2]
+        if Jp_mat is not None:
+            # Exchange lives HERE, not in the pair-antidiagonal Case 4 where
+            # it sat before (issue #113): exact diagonalization puts its
+            # vertex at this slot family in both channels, W_zz = -J and
+            # W_cc = +J, i.e. S += J and C += J. Consistency check that this
+            # split is right: for the SU(2) Kanamori combination
+            # (Hund + Exchange at equal J) the channel matrices become
+            # S(ab,ab) with no J at all and C(ab,ab) = -U' + 2J -- exactly
+            # the standard literature result, which the previous bookkeeping
+            # reproduced in neither channel per type.
+            s_q += Jp_mat[_l1, _l2]
+            c_q += Jp_mat[_l1, _l2]
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
@@ -899,8 +919,10 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
     for i in np.where(mask4)[0]:
         s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         _l1, _l2 = l1f[i], l2f[i]
-        if Jp_mat is not None:
-            s_q += Jp_mat[_l1, _l2]
+        # Exchange used to sit here; exact diagonalization (issue #113) puts
+        # its vertex on the pair-DIAGONAL slot family (Case 2), and end to end
+        # the antidiagonal placement produced the right magnitude at the wrong
+        # slots in both channels. Only PairHop belongs here (#100/#102).
         if PH_mat is not None:
             s_q += PH_mat[_l1, _l2]
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
@@ -910,85 +932,23 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
 
 
 def _build_sc_matrices(inter_k, norb, ix, iy, iz):
-    """Build spin (S) and charge (C) interaction matrices at a given q-point.
+    """Spin (S) and charge (C) matrices at a single q-point.
 
-    Follows Kuroki et al., Eq.(5) in arXiv:0902.3691:
-        S_{l1l2,l3l4}, C_{l1l2,l3l4} for multi-orbital systems.
-
-    The composite index maps as (l1,l2) -> l1*norb + l2,
-    giving norb^2 x norb^2 matrices.
-
-    Parameters
-    ----------
-    inter_k : dict
-        Interactions in k-space from _build_interaction_k.
-    norb : int
-        Number of orbitals.
-    ix, iy, iz : int
-        q-point indices.
-
-    Returns
-    -------
-    S_mat : ndarray
-        Spin interaction matrix, shape (norb^2, norb^2).
-    C_mat : ndarray
-        Charge interaction matrix, shape (norb^2, norb^2).
+    Delegates to :func:`_build_sc_matrices_all_q` and slices, so there is ONE
+    implementation of the S/C content. The previous hand-maintained copy had
+    already drifted from the all-q builder once; after the issue #113 vertex
+    corrections a second parallel copy would be a liability.
     """
-    nd = norb * norb
-    S_mat = np.zeros((nd, nd), dtype=complex)
-    C_mat = np.zeros((nd, nd), dtype=complex)
-
-    # Extract interaction values at this q-point
-    def _get(itype):
-        if itype in inter_k:
-            return inter_k[itype][:, :, ix, iy, iz]
-        return np.zeros((norb, norb), dtype=complex)
-
-    U_mat = _get("CoulombIntra")    # U_mm (intra-orbital)
-    Up_mat = _get("CoulombInter")   # U'_mm' (inter-orbital)
-    J_mat = _get("Hund")            # J_mm' (Hund's coupling)
-    Jp_mat = _get("Exchange")       # J'_mm' (pair-hopping)
-    I_mat = _get("Ising")           # I_mm' (Ising S^z S^z)
-    PH_mat = _get("PairHop")        # P_mm' (pair hopping)
-
-    for l1 in range(norb):
-        for l2 in range(norb):
-            idx12 = l1 * norb + l2
-            for l3 in range(norb):
-                for l4 in range(norb):
-                    idx34 = l3 * norb + l4
-
-                    s_val = 0.0 + 0.0j
-                    c_val = 0.0 + 0.0j
-
-                    if l1 == l2 == l3 == l4:
-                        # Same orbital: S = U, C = U + 2 V_aa(q).  The charge
-                        # (Hartree) diagonal also carries the INTER-SITE
-                        # same-orbital CoulombInter (issue #95); the simple
-                        # two-index formulation builds the same thing as
-                        # `Wc = U_k + 2 V_k`.  Hund/Ising are deliberately not
-                        # included: an orbital has no such coupling with itself.
-                        s_val = U_mat[l1, l1]
-                        c_val = U_mat[l1, l1] + 2.0 * Up_mat[l1, l1]
-                    elif l1 == l3 and l2 == l4 and l1 != l2:
-                        # l1=l3 != l2=l4 (cross): S = U' - I, C = -U' + J - I
-                        s_val = Up_mat[l1, l2] - I_mat[l1, l2]
-                        c_val = (-Up_mat[l1, l2] + J_mat[l1, l2]
-                                 - I_mat[l1, l2])
-                    elif l1 == l2 and l3 == l4 and l1 != l3:
-                        # l1=l2 != l3=l4 (dens): S = J - 2I, C = 2U' - J
-                        s_val = J_mat[l1, l3] - 2.0 * I_mat[l1, l3]
-                        c_val = 2.0 * Up_mat[l1, l3] - J_mat[l1, l3]
-                    elif l1 == l4 and l2 == l3 and l1 != l2:
-                        # l1=l4 != l2=l3 (exch): S = J' + P, C = J' + P
-                        s_val = Jp_mat[l1, l2] + PH_mat[l1, l2]
-                        c_val = Jp_mat[l1, l2] + PH_mat[l1, l2]
-
-                    S_mat[idx12, idx34] = s_val
-                    C_mat[idx12, idx34] = c_val
-
-    return S_mat, C_mat
-
+    Nx = Ny = Nz = None
+    for v in inter_k.values():
+        Nx, Ny, Nz = v.shape[2], v.shape[3], v.shape[4]
+        break
+    if Nx is None:
+        nd = norb * norb
+        return (np.zeros((nd, nd), dtype=complex),
+                np.zeros((nd, nd), dtype=complex))
+    S_all, C_all = _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz)
+    return S_all[ix, iy, iz], C_all[ix, iy, iz]
 
 def _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
                       pairing_type="singlet", static_index=None):

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -820,9 +820,25 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
     C_all = np.zeros((Nx, Ny, Nz, nd, nd), dtype=complex)
 
     def _get(itype):
-        if itype in inter_k:
-            return inter_k[itype]  # (norb, norb, Nx, Ny, Nz)
-        return None
+        if itype not in inter_k:
+            return None
+        M = inter_k[itype]  # (norb, norb, Nx, Ny, Nz)
+        # Symmetrise the two redundant declarations of each orbital pair with
+        # the MEAN, which is what an interaction file means in this codebase
+        # (`uhfk.py` builds every table as `(jab + jba)/2`; adjudicated for the
+        # transverse channel in #105/#106). For every type except PairHop the
+        # two entries are coefficients of the SAME operator (n_a n_b = n_b n_a;
+        # X_ab = X_ba for Exchange since different-spin bilinears commute), so
+        # the partner is the plain transpose and a declared imaginary
+        # antisymmetry is inert. PairHop's entries are HERMITIAN-PARTNER
+        # coefficients (P_ba = conj(P_ab)) and its complex phase is physical
+        # (#100/#102), so its partner conjugates. Without this, an asymmetric
+        # declaration J_01 != J_10 put unequal values at the two (ab,ab) slots
+        # and an antisymmetric declaration -- an identically zero Hamiltonian
+        # -- produced a nonzero vertex.
+        if itype == "PairHop":
+            return 0.5 * (M + np.conj(M.transpose(1, 0, 2, 3, 4)))
+        return 0.5 * (M + M.transpose(1, 0, 2, 3, 4))
 
     U_mat = _get("CoulombIntra")
     Up_mat = _get("CoulombInter")
@@ -939,16 +955,13 @@ def _build_sc_matrices(inter_k, norb, ix, iy, iz):
     already drifted from the all-q builder once; after the issue #113 vertex
     corrections a second parallel copy would be a liability.
     """
-    Nx = Ny = Nz = None
-    for v in inter_k.values():
-        Nx, Ny, Nz = v.shape[2], v.shape[3], v.shape[4]
-        break
-    if Nx is None:
-        nd = norb * norb
-        return (np.zeros((nd, nd), dtype=complex),
-                np.zeros((nd, nd), dtype=complex))
-    S_all, C_all = _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz)
-    return S_all[ix, iy, iz], C_all[ix, iy, iz]
+    # Slice each interaction down to the requested q-point FIRST, then
+    # delegate on a 1x1x1 grid: delegating on the full grid would turn a
+    # single-point request into O(Nq) work and memory.
+    inter_1 = {t: np.ascontiguousarray(M[:, :, ix:ix+1, iy:iy+1, iz:iz+1])
+               for t, M in inter_k.items()}
+    S_all, C_all = _build_sc_matrices_all_q(inter_1, norb, 1, 1, 1)
+    return S_all[0, 0, 0], C_all[0, 0, 0]
 
 def _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
                       pairing_type="singlet", static_index=None):
@@ -1164,17 +1177,16 @@ def _compute_vertices_flex(chis, chic, inter_k, norb, Nx, Ny, Nz,
     chi_s and chi_c directly instead of computing them from chi0q via RPA.
     This allows using dressed susceptibilities from the FLEX solver.
 
-    ``convention`` selects the S/C interaction matrices applied to the
-    susceptibilities: "kuroki" (default, arXiv:0902.3691, used by the reduced
-    FLEX path and the rest of the Eliashberg solver) or "myo"
-    (cond-mat/0407094). The two differ ONLY in the charge ``C(ab,ab) = -U'+2J``
-    vs ``-U'+J`` element; they share the native [a,c,b,d] orbital-pair index
-    layout. Susceptibilities produced by the general (full-vertex) FLEX path
-    were computed with the MYO S/C and MUST be paired with ``convention='myo'``
-    so the vertex stays self-consistent (mixing them with Kuroki S/C silently
-    changes the physics in the C(ab,ab) channel). ``convention`` is a S/C-charge
-    selector, not an index-layout flag: ``chis``/``chic`` are expected in the
-    native [a,c,b,d] orbital-pair order regardless (issue #78).
+    ``convention`` records which FLEX path produced the susceptibilities:
+    "kuroki" (default; reduced path) or "myo" (general full-vertex path). The
+    two S/C builders historically differed in the charge ``C(ab,ab)`` element
+    (``-U'+2J`` vs ``-U'+J``); the exact-diagonalization adjudication of the
+    per-type vertex content (issue #113: Hund ``+J`` and Exchange ``+J'``
+    there) made them IDENTICAL, so the flag no longer selects different
+    matrices -- it remains a provenance / layout discriminator, and legacy
+    files are guarded by ``sc_vertex_version`` instead. ``chis``/``chic`` are
+    expected in the native [a,c,b,d] orbital-pair order regardless
+    (issue #78).
 
     Parameters
     ----------
@@ -1255,7 +1267,7 @@ def _resolve_flex_paths(input_dict):
 
 
 def _load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz,
-                                     allow_ir=False):
+                                     allow_ir=False, interactions=None):
     """Load FLEX-computed susceptibilities from NPZ files (full frequency axis).
 
     Parameters
@@ -1282,7 +1294,8 @@ def _load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz,
         Provenance/S-C-convention tag of chis_w/chic_w: "myo" (general
         full-vertex FLEX) or "kuroki" (reduced FLEX / legacy files). It selects
         which S/C interaction matrices _compute_vertices_flex pairs the
-        susceptibilities with (they differ only in the C(ab,ab) charge value)
+        susceptibilities with (one implementation since the #113
+        adjudication; the tag is a layout/provenance discriminator)
         and which orbital-pair shape family the file uses (orbital-pair
         nd=norb^2 for "myo", spin-orbital nd=norb*ns for "kuroki"). It is NOT an
         index-layout flag: chis_w/chic_w are returned in the public RPA
@@ -1293,12 +1306,13 @@ def _load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz,
         ("green" absent when there is no green file). Mixed encodings raise.
     """
     if not allow_ir:
-        chi_s_raw, chi_c_raw, chi_convention = _read_flex_chi_raw(input_dict)
+        chi_s_raw, chi_c_raw, chi_convention = _read_flex_chi_raw(
+            input_dict, interactions=interactions)
         ir_meta = None
         green_w = _load_flex_green(input_dict, norb, Nx, Ny, Nz)
     else:
         chi_s_raw, chi_c_raw, chi_convention, ir_meta = _read_flex_chi_raw(
-            input_dict, allow_ir=True)
+            input_dict, allow_ir=True, interactions=interactions)
         green_w, green_meta = _load_flex_green(input_dict, norb, Nx, Ny, Nz,
                                                allow_ir=True)
         if green_w is not None and (green_meta is None) != (ir_meta is None):
@@ -1329,7 +1343,7 @@ _STATIC_IR_HINT = (
     "\"dynamic\" with [eliashberg] matsubara_basis = \"ir\".")
 
 
-def _read_flex_chi_raw(input_dict, allow_ir=False):
+def _read_flex_chi_raw(input_dict, allow_ir=False, interactions=None):
     """Read the raw FLEX chi_s / chi_c NPZ arrays and their orbital convention.
 
     Returns ``(chi_s_raw, chi_c_raw, chi_convention)`` in the H-wave layout
@@ -1379,6 +1393,28 @@ def _read_flex_chi_raw(input_dict, allow_ir=False):
             "FLEX chi_s and chi_c have different conventions ('{}' vs '{}'); "
             "they must come from the same run. Check flex_chi_s/flex_chi_c.".format(
                 chi_convention, chi_convention_c))
+
+    # S/C vertex-content versioning (#113). The Hund / Exchange / Ising vertex
+    # entries were corrected against exact diagonalization; susceptibilities
+    # computed with the OLD entries must not be paired with the corrected
+    # matrices when the interaction set contains an affected type -- the
+    # kernel would silently mix two different interactions. U/V-only inputs
+    # are provably unchanged, so legacy files stay usable there.
+    if interactions is not None:
+        affected = [t for t in ("Hund", "Exchange", "Ising")
+                    if t in interactions]
+        if affected:
+            for data, path in ((data_s, chi_s_path), (data_c, chi_c_path)):
+                if "sc_vertex_version" not in data:
+                    raise ValueError(
+                        "FLEX susceptibility file '{}' predates the #113 "
+                        "S/C vertex corrections (no sc_vertex_version "
+                        "field), and the interaction set contains {} whose "
+                        "vertex content changed. Pairing the old "
+                        "susceptibilities with the corrected vertices would "
+                        "silently mix two different interactions -- "
+                        "regenerate the susceptibilities with the current "
+                        "code.".format(path, ", ".join(affected)))
     # Self-describing index-order marker (issue #78 follow-up). Current files
     # always store [a,c,b,d]; the marker exists so a pre-#78 dev output (the
     # general path stored MYO-transposed arrays under the SAME "myo" tag,
@@ -1556,7 +1592,8 @@ def _load_flex_green(input_dict, norb, Nx, Ny, Nz, allow_ir=False):
     return green, meta
 
 
-def _load_flex_susceptibilities(input_dict, norb, Nx, Ny, Nz):
+def _load_flex_susceptibilities(input_dict, norb, Nx, Ny, Nz,
+                                interactions=None):
     """Load FLEX-computed susceptibilities at the static (zero bosonic
     frequency) limit from NPZ files.
 
@@ -1586,7 +1623,8 @@ def _load_flex_susceptibilities(input_dict, norb, Nx, Ny, Nz):
     # so the static slice is taken before the spin-orbital expansion -- the full
     # loader would otherwise allocate the whole Nmat-long expanded array only to
     # keep one frequency (a memory regression proportional to Nmat).
-    chi_s_raw, chi_c_raw, chi_convention = _read_flex_chi_raw(input_dict)
+    chi_s_raw, chi_c_raw, chi_convention = _read_flex_chi_raw(
+        input_dict, interactions=interactions)
 
     # The zero bosonic frequency is located via the freq_index/nmat metadata
     # (RPA chiq files can carry a restricted matsubara_frequency axis whose
@@ -3263,7 +3301,7 @@ def calc_eliashberg(input_dict):
         logger.info("FLEX mode: loading dressed susceptibilities and Green's function")
 
         chis, chic, green_dressed, chi_convention = _load_flex_susceptibilities(
-            input_dict, norb, Nx, Ny, Nz)
+            input_dict, norb, Nx, Ny, Nz, interactions=interactions)
         logger.info("FLEX susceptibility convention: {}".format(chi_convention))
 
         # Use dressed Green's function if available, otherwise use bare

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -793,7 +793,48 @@ def _calc_green(eigenvalues, eigenvectors, mu, beta, nmat):
 # RPA vertices
 # ---------------------------------------------------------------------------
 
-def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
+def _symmetrise_interactions_k(inter_k):
+    """Reduce each interaction to its physical symmetric coefficient.
+
+    An interaction file may declare the same term from both ends, and the two
+    declarations of a bond are (R, a, b) and (-R, b, a). In momentum space
+    (arrays carry e^{-iqR} phases) the same-operator partner of M[b,a](q) is
+    therefore the ORBITAL-TRANSPOSED entry AT -q -- averaging with the same-q
+    transpose instead corrupted every off-site interaction, collapsing a
+    one-direction bond's V(q) = v e^{-iqR} to v cos(qR) (measured: the S/C
+    entry vanished outright at q = pi/2). The mean used here:
+
+      * every type except PairHop: 0.5 * (M(q) + M(-q)^T). The two entries
+        multiply the SAME operator (n_a n_b = n_b n_a; X_ab = X_ba for
+        Exchange), with the same coefficient at the reversed displacement.
+        For a both-ends declaration this mean is an identity; for an on-site
+        complex Hermitian-closed declaration it drops the inert imaginary
+        part; for an antisymmetric declaration -- an identically zero
+        Hamiltonian -- it gives zero.
+      * PairHop: 0.5 * (M(q) + conj(M(q)^T)) at the SAME q. Its partner entry
+        carries the conjugated coefficient at the reversed displacement, and
+        conjugation at fixed q is the Fourier image of {conjugate, R -> -R}
+        (the #105 derivation), so this is an identity for Hermitian-closed
+        input on-site and off-site, and preserves the physical complex phase.
+
+    Idempotent, so it is safe that both the all-q and per-q builders apply it.
+    This matches `uhfk.py`'s reading of the files ((jab + jba)/2) and the
+    transverse channel's slot-family rule (#105/#106/#113).
+    """
+    out = {}
+    for itype, M in inter_k.items():
+        if itype == "PairHop":
+            out[itype] = 0.5 * (M + np.conj(M.transpose(1, 0, 2, 3, 4)))
+            continue
+        nx, ny, nz = M.shape[2], M.shape[3], M.shape[4]
+        Mrev = M[:, :, (-np.arange(nx)) % nx][:, :, :, (-np.arange(ny)) % ny][
+            :, :, :, :, (-np.arange(nz)) % nz]
+        out[itype] = 0.5 * (M + Mrev.transpose(1, 0, 2, 3, 4))
+    return out
+
+
+def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
+                             _presymmetrised=False):
     """Build spin (S) and charge (C) interaction matrices for all q-points at once.
 
     Follows Kuroki et al., Eq.(5) in arXiv:0902.3691:
@@ -819,26 +860,17 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz):
     S_all = np.zeros((Nx, Ny, Nz, nd, nd), dtype=complex)
     C_all = np.zeros((Nx, Ny, Nz, nd, nd), dtype=complex)
 
+    # _presymmetrised is set by the per-q wrapper, which has already
+    # symmetrised on the FULL grid: the -q partner of an off-site entry is
+    # unreachable from a single-point slice, so re-symmetrising here would
+    # average with the wrong (same-q) partner and corrupt off-site input.
+    if not _presymmetrised:
+        inter_k = _symmetrise_interactions_k(inter_k)
+
     def _get(itype):
-        if itype not in inter_k:
-            return None
-        M = inter_k[itype]  # (norb, norb, Nx, Ny, Nz)
-        # Symmetrise the two redundant declarations of each orbital pair with
-        # the MEAN, which is what an interaction file means in this codebase
-        # (`uhfk.py` builds every table as `(jab + jba)/2`; adjudicated for the
-        # transverse channel in #105/#106). For every type except PairHop the
-        # two entries are coefficients of the SAME operator (n_a n_b = n_b n_a;
-        # X_ab = X_ba for Exchange since different-spin bilinears commute), so
-        # the partner is the plain transpose and a declared imaginary
-        # antisymmetry is inert. PairHop's entries are HERMITIAN-PARTNER
-        # coefficients (P_ba = conj(P_ab)) and its complex phase is physical
-        # (#100/#102), so its partner conjugates. Without this, an asymmetric
-        # declaration J_01 != J_10 put unequal values at the two (ab,ab) slots
-        # and an antisymmetric declaration -- an identically zero Hamiltonian
-        # -- produced a nonzero vertex.
-        if itype == "PairHop":
-            return 0.5 * (M + np.conj(M.transpose(1, 0, 2, 3, 4)))
-        return 0.5 * (M + M.transpose(1, 0, 2, 3, 4))
+        if itype in inter_k:
+            return inter_k[itype]  # (norb, norb, Nx, Ny, Nz)
+        return None
 
     U_mat = _get("CoulombIntra")
     Up_mat = _get("CoulombInter")
@@ -955,12 +987,23 @@ def _build_sc_matrices(inter_k, norb, ix, iy, iz):
     already drifted from the all-q builder once; after the issue #113 vertex
     corrections a second parallel copy would be a liability.
     """
-    # Slice each interaction down to the requested q-point FIRST, then
-    # delegate on a 1x1x1 grid: delegating on the full grid would turn a
-    # single-point request into O(Nq) work and memory.
-    inter_1 = {t: np.ascontiguousarray(M[:, :, ix:ix+1, iy:iy+1, iz:iz+1])
-               for t, M in inter_k.items()}
-    S_all, C_all = _build_sc_matrices_all_q(inter_1, norb, 1, 1, 1)
+    # Symmetrise on the FULL grid first -- the same-operator partner of an
+    # off-site entry lives at -q, so slicing before symmetrising would discard
+    # it -- then slice the (small, norb^2 per point) interaction arrays down to
+    # the requested q and delegate on a 1x1x1 grid, so the (nd^2 per point) S/C
+    # matrices are never built for the whole grid. Indexing goes through
+    # np.arange so numpy negative indices keep their usual meaning and
+    # out-of-range indices raise instead of returning empty slices.
+    inter_sym = _symmetrise_interactions_k(inter_k)
+    inter_1 = {}
+    for t, M in inter_sym.items():
+        jx = np.arange(M.shape[2])[ix]
+        jy = np.arange(M.shape[3])[iy]
+        jz = np.arange(M.shape[4])[iz]
+        inter_1[t] = np.ascontiguousarray(
+            M[:, :, jx:jx+1, jy:jy+1, jz:jz+1])
+    S_all, C_all = _build_sc_matrices_all_q(inter_1, norb, 1, 1, 1,
+                                            _presymmetrised=True)
     return S_all[0, 0, 0], C_all[0, 0, 0]
 
 def _compute_vertices(chi0q, inter_k, norb, Nx, Ny, Nz, nmat,
@@ -1401,9 +1444,12 @@ def _read_flex_chi_raw(input_dict, allow_ir=False, interactions=None):
     # kernel would silently mix two different interactions. U/V-only inputs
     # are provably unchanged, so legacy files stay usable there.
     if interactions is not None:
+        # activation requires actual CONTENT, not key presence: an explicitly
+        # configured but empty Hund/Exchange/Ising file contributes nothing
         affected = [t for t in ("Hund", "Exchange", "Ising")
-                    if t in interactions]
+                    if interactions.get(t)]
         if affected:
+            versions = {}
             for data, path in ((data_s, chi_s_path), (data_c, chi_c_path)):
                 if "sc_vertex_version" not in data:
                     raise ValueError(
@@ -1415,6 +1461,26 @@ def _read_flex_chi_raw(input_dict, allow_ir=False, interactions=None):
                         "silently mix two different interactions -- "
                         "regenerate the susceptibilities with the current "
                         "code.".format(path, ", ".join(affected)))
+                try:
+                    versions[path] = int(np.asarray(
+                        data["sc_vertex_version"]).item())
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        "FLEX susceptibility file '{}' carries a malformed "
+                        "sc_vertex_version field ({!r}).".format(
+                            path, data["sc_vertex_version"]))
+            if len(set(versions.values())) != 1:
+                raise ValueError(
+                    "FLEX chi_s and chi_c carry different sc_vertex_version "
+                    "values ({}); they must come from the same run.".format(
+                        versions))
+            ver = next(iter(versions.values()))
+            if ver != 2:
+                raise ValueError(
+                    "FLEX susceptibility files carry sc_vertex_version = {} "
+                    "but this code supports version 2 (the #113 exact-"
+                    "diagonalization vertex content); regenerate the "
+                    "susceptibilities with the current code.".format(ver))
     # Self-describing index-order marker (issue #78 follow-up). Current files
     # always store [a,c,b,d]; the marker exists so a pre-#78 dev output (the
     # general path stored MYO-transposed arrays under the SAME "myo" tag,

--- a/src/hwave/solver/_sc_matrices_myo.py
+++ b/src/hwave/solver/_sc_matrices_myo.py
@@ -1,137 +1,24 @@
-"""MYO-convention spin/charge interaction matrices for full-vertex FLEX.
+"""Spin/charge interaction matrices for the full-vertex FLEX path.
 
-This module provides :func:`build_sc_matrices_myo`, a sibling of
-``hwave.sc._build_sc_matrices_all_q`` that builds the spin (S) and charge (C)
-interaction matrices in the **MYO (Mochizuki-Yanase-Ogata)** convention,
-following cond-mat/0407094 Eq.(6), rather than the Kuroki convention used in
-``hwave.sc`` (arXiv:0902.3691 Eq.(5)).
+Historically this module carried a hand-maintained sibling of
+``hwave.sc._build_sc_matrices_all_q`` differing in exactly one element: the
+charge (ab, ab) slot, where it used the MYO (cond-mat/0407094) value ``-U'+2J``
+against the Kuroki (arXiv:0902.3691) value ``-U'+J`` used by ``sc.py``.
 
-The two conventions differ in EXACTLY ONE matrix element: the charge (ab,ab)
-element (Case 2 below). MYO uses ``-U'+2J`` while Kuroki (``sc.py``) uses
-``-U'+J``. All spin elements and all other charge elements are identical.
-
-The structure of this builder is copied verbatim from
-``hwave.sc._build_sc_matrices_all_q`` so that the two stay element-for-element
-comparable; only the single Case 2 charge term is modified.
+Exact diagonalization of H-wave's documented file operators adjudicated that
+difference (issue #113): per interaction type the exact charge vertex at that
+slot is ``+J`` from the Hund file term and ``+J`` from the Exchange file term.
+For the SU(2) Kanamori combination (Hund + Exchange at equal J) their sum
+reproduces the standard literature value ``-U'+2J`` -- so the MYO matrix was
+right for the COMBINATION but wrong as a per-type attribution, assigning the
+whole ``2J`` to the Hund file entry and nothing to Exchange. With the
+per-type values fixed in ``sc.py``, the two builders are identical, and this
+module now simply re-exports the single implementation.
 """
 
-import numpy as np
+from hwave.sc import _build_sc_matrices_all_q
 
 
 def build_sc_matrices_myo(inter_k, norb, Nx, Ny, Nz):
-    """Build MYO-convention spin (S) and charge (C) matrices for all q-points.
-
-    Follows MYO (Mochizuki-Yanase-Ogata), cond-mat/0407094 Eq.(6):
-        S_{l1l2,l3l4}, C_{l1l2,l3l4} for multi-orbital systems.
-
-    Parameters
-    ----------
-    inter_k : dict
-        Interactions in k-space from _build_interaction_k. Each entry is an
-        ndarray of shape (norb, norb, Nx, Ny, Nz).
-    norb : int
-        Number of orbitals.
-    Nx, Ny, Nz : int
-        Grid dimensions.
-
-    Returns
-    -------
-    S_all : ndarray
-        Spin interaction matrices, shape (Nx, Ny, Nz, norb^2, norb^2).
-    C_all : ndarray
-        Charge interaction matrices, shape (Nx, Ny, Nz, norb^2, norb^2).
-    """
-    nd = norb * norb
-    S_all = np.zeros((Nx, Ny, Nz, nd, nd), dtype=complex)
-    C_all = np.zeros((Nx, Ny, Nz, nd, nd), dtype=complex)
-
-    def _get(itype):
-        if itype in inter_k:
-            return inter_k[itype]  # (norb, norb, Nx, Ny, Nz)
-        return None
-
-    U_mat = _get("CoulombIntra")
-    Up_mat = _get("CoulombInter")
-    J_mat = _get("Hund")
-    Jp_mat = _get("Exchange")
-    I_mat = _get("Ising")
-    PH_mat = _get("PairHop")
-
-    # Build using precomputed index arrays to avoid Python loops
-    # for small norb (1-3), the loop overhead is negligible;
-    # for larger norb the vectorized approach helps
-    l1_arr, l2_arr, l3_arr, l4_arr = np.meshgrid(
-        np.arange(norb), np.arange(norb), np.arange(norb), np.arange(norb),
-        indexing='ij')
-    l1f, l2f, l3f, l4f = l1_arr.ravel(), l2_arr.ravel(), l3_arr.ravel(), l4_arr.ravel()
-    idx12 = l1f * norb + l2f
-    idx34 = l3f * norb + l4f
-
-    # Case 1: l1 == l2 == l3 == l4
-    # Accumulate rather than assign: this element is also reached by Case 3
-    # below (which now includes l1 == l3), where an inter-site same-orbital
-    # CoulombInter contributes 2 V_aa(q) to the charge channel.
-    mask1 = (l1f == l2f) & (l2f == l3f) & (l3f == l4f)
-    if U_mat is not None and np.any(mask1):
-        for i in np.where(mask1)[0]:
-            _l = l1f[i]
-            S_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
-            C_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
-
-    # Case 2: l1==l3, l2==l4, l1!=l2
-    mask2 = (l1f == l3f) & (l2f == l4f) & (l1f != l2f)
-    for i in np.where(mask2)[0]:
-        s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
-        c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
-        _l1, _l2 = l1f[i], l2f[i]
-        if Up_mat is not None:
-            s_q += Up_mat[_l1, _l2]
-            c_q -= Up_mat[_l1, _l2]
-        if I_mat is not None:
-            s_q -= I_mat[_l1, _l2]
-            c_q -= I_mat[_l1, _l2]
-        if J_mat is not None:
-            # MYO cond-mat/0407094 Eq.(6): charge (ab,ab) = -U'+2J
-            # (Kuroki sc.py uses -U'+J, i.e. coefficient 1 here).
-            c_q += 2.0 * J_mat[_l1, _l2]
-        S_all[:, :, :, idx12[i], idx34[i]] = s_q
-        C_all[:, :, :, idx12[i], idx34[i]] = c_q
-
-    # Case 3: l1==l2, l3==l4 -- INCLUDING l1 == l3, but for CoulombInter ONLY.
-    # The l1 != l3 exclusion dropped the inter-site same-orbital CoulombInter
-    # from the charge diagonal C[(a,a),(a,a)], which must be U_a + 2 V_aa(q)
-    # (issue #95); the simple two-index formulation used by chi0q_mode="load"
-    # builds exactly that (`Wc = U_k + 2 V_k`, _compute_vertices_simple).
-    # Case 1 above writes U_a into the same element, so both accumulate.
-    # Hund and Ising stay restricted to l1 != l3: an orbital has no Hund or
-    # Ising coupling with itself, and letting a stray diagonal entry through
-    # here would silently move S as well.
-    mask3 = (l1f == l2f) & (l3f == l4f)
-    for i in np.where(mask3)[0]:
-        s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
-        c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
-        _l1, _l3 = l1f[i], l3f[i]
-        if _l1 != _l3:
-            if J_mat is not None:
-                s_q += J_mat[_l1, _l3]
-                c_q -= J_mat[_l1, _l3]
-            if I_mat is not None:
-                s_q -= 2.0 * I_mat[_l1, _l3]
-        if Up_mat is not None:
-            c_q += 2.0 * Up_mat[_l1, _l3]
-        S_all[:, :, :, idx12[i], idx34[i]] += s_q
-        C_all[:, :, :, idx12[i], idx34[i]] += c_q
-
-    # Case 4: l1==l4, l2==l3, l1!=l2
-    mask4 = (l1f == l4f) & (l2f == l3f) & (l1f != l2f)
-    for i in np.where(mask4)[0]:
-        s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
-        _l1, _l2 = l1f[i], l2f[i]
-        if Jp_mat is not None:
-            s_q += Jp_mat[_l1, _l2]
-        if PH_mat is not None:
-            s_q += PH_mat[_l1, _l2]
-        S_all[:, :, :, idx12[i], idx34[i]] = s_q
-        C_all[:, :, :, idx12[i], idx34[i]] = s_q  # S = C for this channel
-
-    return S_all, C_all
+    """One implementation: see :func:`hwave.sc._build_sc_matrices_all_q`."""
+    return _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz)

--- a/src/hwave/solver/eliashberg_dynamic.py
+++ b/src/hwave/solver/eliashberg_dynamic.py
@@ -381,7 +381,8 @@ def _npz_is_ir_native(path):
         return False
 
 
-def load_flex_chi_dynamic(input_dict, norb, Nx, Ny, Nz, allow_ir=False):
+def load_flex_chi_dynamic(input_dict, norb, Nx, Ny, Nz, allow_ir=False,
+                          interactions=None):
     import hwave.sc as sc
     cfg_nmat = int(input_dict["mode"]["param"].get("Nmat", 1024))
     if cfg_nmat % 2 != 0:
@@ -449,10 +450,12 @@ def load_flex_chi_dynamic(input_dict, norb, Nx, Ny, Nz, allow_ir=False):
     if allow_ir:
         chis_w, chic_w, green_w, chi_convention, ir_meta = \
             sc._load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz,
-                                                allow_ir=True)
+                                                allow_ir=True,
+                                                interactions=interactions)
     else:
         chis_w, chic_w, green_w, chi_convention = \
-            sc._load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz)
+            sc._load_flex_susceptibilities_full(input_dict, norb, Nx, Ny, Nz,
+                                                interactions=interactions)
         ir_meta = None
     # Belt-and-suspenders: the header check above already rejected a mismatch,
     # but keep a post-load assertion in case the loader reshapes unexpectedly.
@@ -1183,10 +1186,10 @@ def solve_dynamic(input_dict):
     if use_ir:
         chis_w, chic_w, green_w, chi_convention, ir_file_meta = \
             load_flex_chi_dynamic(input_dict, norb, Nx, Ny, Nz,
-                                  allow_ir=True)
+                                  allow_ir=True, interactions=interactions)
     else:
         chis_w, chic_w, green_w, chi_convention = load_flex_chi_dynamic(
-            input_dict, norb, Nx, Ny, Nz)
+            input_dict, norb, Nx, Ny, Nz, interactions=interactions)
         ir_file_meta = None
     if green_w is None:
         raise ValueError(

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -1738,11 +1738,10 @@ class FLEX(RPA):
         # orbital-pair convention (see _inflate_chi0q_and_ham_general), which is
         # what the public output and the Eliashberg loader expect: the loader
         # (_compute_vertices_flex) builds S @ chi @ S with S/C matrices in that
-        # native layout (build_sc_matrices_myo shares the layout with the Kuroki
-        # builder; convention='myo' only changes the C(ab,ab) charge value), so a
-        # transposed chi here would build a transposed pairing vertex and a wrong
-        # static lambda (issue #78).  The "myo" chi_convention tag still marks
-        # these as general-path (orbital-pair shape + MYO S/C charge convention).
+        # native layout (the two builders are one implementation since the #113
+        # adjudication), so a transposed chi here would build a transposed
+        # pairing vertex and a wrong static lambda (issue #78).  The "myo"
+        # chi_convention tag marks these as general-path (orbital-pair shape).
         #
         # This used to transpose the pair axes on the way IN, which is what
         # issue #91 was: the transpose reached V_eff, so Sigma was built from
@@ -2621,17 +2620,24 @@ class FLEX(RPA):
 
         # Save susceptibilities (spin and charge channels separately for
         # Eliashberg). The chi_convention tag tells the downstream consumer
-        # (_load_flex_susceptibilities / _compute_vertices_flex) which S/C
-        # matrices to pair the susceptibilities with: "myo" (general full-vertex
-        # path) selects build_sc_matrices_myo, "kuroki" (reduced path) the
-        # default builder; the two differ only in the C(ab,ab) charge value.
-        # It also marks the general path's orbital-pair shape (nd = norb^2) vs
-        # the reduced path's spin-orbital shape (nd = norb*ns).
+        # (_load_flex_susceptibilities / _compute_vertices_flex) how to
+        # interpret the array layout: "myo" marks the general full-vertex
+        # path's orbital-pair shape (nd = norb^2), "kuroki" the reduced path's
+        # spin-orbital shape (nd = norb*ns). (The two builders' S/C VALUES
+        # were unified by the #113 adjudication; the tag remains a layout /
+        # provenance discriminator.)
+        #
+        # sc_vertex_version records which S/C vertex content the run used, so
+        # a downstream Eliashberg run cannot silently pair these
+        # susceptibilities with vertices from a different adjudication.
+        # Version 2 = the #113 exact-diagonalization values (Hund / Exchange /
+        # Ising corrected); files without the field predate #113.
         common_meta = dict(nmat=self.nmat,
                            wavevector_unit=self.kvec,
                            wavevector_index=self.wavenum_table,
                            chi_convention=("myo" if self._flex_general
                                            else "kuroki"),
+                           sc_vertex_version=2,
                            **_freq_meta("B"))
         if self._flex_general:
             # Self-describing index-order marker for the ORBITAL-PAIR files

--- a/tests/test_flex_general.py
+++ b/tests/test_flex_general.py
@@ -1066,44 +1066,37 @@ class TestMYOSCMatrices(unittest.TestCase):
         def el(M, l1, l2, l3, l4):
             return M[0, 0, 0, l1 * 2 + l2, l3 * 2 + l4]
 
-        # Case 2 (ab,ab): the MYO-specific charge element
-        self.assertAlmostEqual(el(S, 0, 1, 0, 1), Up)
-        self.assertAlmostEqual(el(C, 0, 1, 0, 1), -Up + 2 * J)
+        # Case 2 (ab,ab): S = U' - J + J', C = -U' + J + J' (issue #113;
+        # for J = J' the charge value equals the standard Kanamori -U' + 2J,
+        # now from the corrected per-type split)
+        self.assertAlmostEqual(el(S, 0, 1, 0, 1), Up - J + Jp)
+        self.assertAlmostEqual(el(C, 0, 1, 0, 1), -Up + J + Jp)
         # Case 3 (aa,bb)
         self.assertAlmostEqual(el(S, 0, 0, 1, 1), J)
         self.assertAlmostEqual(el(C, 0, 0, 1, 1), 2 * Up - J)
-        # Case 4 (ab,ba)
-        self.assertAlmostEqual(el(S, 0, 1, 1, 0), Jp)
-        self.assertAlmostEqual(el(C, 0, 1, 1, 0), Jp)
+        # Case 4 (ab,ba): PairHop only (issue #113)
+        self.assertAlmostEqual(el(S, 0, 1, 1, 0), 0.0)
+        self.assertAlmostEqual(el(C, 0, 1, 1, 0), 0.0)
         # Case 1 (aaaa)
         self.assertAlmostEqual(el(S, 0, 0, 0, 0), U)
         self.assertAlmostEqual(el(C, 0, 0, 0, 0), U)
 
-    def test_diverges_from_kuroki_only_at_charge_abab(self):
+    def test_the_two_builders_are_one_implementation(self):
+        """The MYO-vs-Kuroki charge (ab,ab) divergence was adjudicated by
+        exact diagonalization (issue #113): the exact per-type values are
+        Hund +J and Exchange +J', whose sum reproduces MYO's -U'+2J for the
+        Kanamori combination. With that fixed, `build_sc_matrices_myo`
+        delegates to `_build_sc_matrices_all_q`; assert equality so any
+        future re-divergence fails loudly."""
         from hwave.sc import _build_sc_matrices_all_q
         from hwave.solver._sc_matrices_myo import build_sc_matrices_myo
-        U, Up, J, Jp = 4.0, 2.0, 0.5, 0.5
+        U, Up, J, Jp = 4.0, 2.0, 0.5, 0.3   # J != J' on purpose
         ik = _kanamori_inter_k(norb=2, U=U, Up=Up, J=J, Jp=Jp,
                                Nx=2, Ny=2, Nz=1)
         Sm, Cm = build_sc_matrices_myo(ik, 2, 2, 2, 1)
         Sk, Ck = _build_sc_matrices_all_q(ik, 2, 2, 2, 1)
-
-        # Spin matrices identical.
-        np.testing.assert_allclose(Sm, Sk)
-
-        # Charge differs ONLY at the (ab,ab) entries, by exactly +J there.
-        diff = Cm - Ck
-        # (ab,ab): idx12 == idx34 with l1!=l2; for norb=2 these are
-        # (0,1)&(0,1) -> flat (1,1) and (1,0)&(1,0) -> flat (2,2).
-        nonzero = [(1, 1), (2, 2)]
-        mask = np.zeros((4, 4), dtype=bool)
-        for (i, j) in nonzero:
-            mask[i, j] = True
-        nz = diff[..., mask]
-        np.testing.assert_allclose(nz, J)
-        zero = diff[..., ~mask]
-        np.testing.assert_allclose(zero, 0.0, atol=1.0e-12)
-
+        np.testing.assert_allclose(Sm, Sk, atol=0)
+        np.testing.assert_allclose(Cm, Ck, atol=0)
 
 class TestBruteForceRef(unittest.TestCase):
     """Structural sanity checks for the physical-index brute-force reference

--- a/tests/test_sc.py
+++ b/tests/test_sc.py
@@ -1387,9 +1387,9 @@ class TestFlexVertexMYOConvention(unittest.TestCase):
                                           convention="kuroki")
         v_myo = _compute_vertices_flex(chis, chic, inter_k, norb, Nx, Ny, Nz,
                                        convention="myo")
-        self.assertGreater(
-            np.linalg.norm(v_myo - v_kuroki), 1e-8,
-            "MYO and Kuroki pairing vertices must differ when Hund J != 0")
+        # Adjudicated by exact diagonalization (issue #113): the per-type
+        # values make the two builders identical, so the vertices must AGREE.
+        npt.assert_allclose(v_myo, v_kuroki, atol=1e-12)
 
     def test_myo_matches_myo_sc_formula(self):
         from hwave.solver._sc_matrices_myo import build_sc_matrices_myo
@@ -2080,10 +2080,14 @@ class TestSCMatrices(unittest.TestCase):
         npt.assert_allclose(S_mat[0, 0], U_val, atol=1e-10)
         npt.assert_allclose(C_mat[0, 0], U_val, atol=1e-10)
 
-        # (l1=0,l2=1,l3=0,l4=1) -> l1=l3!=l2=l4: S=U', C=-U'+J
+        # (l1=0,l2=1,l3=0,l4=1) -> l1=l3!=l2=l4:
+        #   S = U' - J + J' (= U' for J = J'),  C = -U' + J + J'
+        # (adjudicated by exact diagonalization, issue #113)
         idx_01 = 0 * norb + 1  # = 1
-        npt.assert_allclose(S_mat[idx_01, idx_01], Up_val, atol=1e-10)
-        npt.assert_allclose(C_mat[idx_01, idx_01], -Up_val + J_val, atol=1e-10)
+        npt.assert_allclose(S_mat[idx_01, idx_01],
+                            Up_val - J_val + Jp_val, atol=1e-10)
+        npt.assert_allclose(C_mat[idx_01, idx_01],
+                            -Up_val + J_val + Jp_val, atol=1e-10)
 
         # (l1=0,l2=0,l3=1,l4=1) -> l1=l2!=l3=l4: S=J, C=2U'-J
         idx_00 = 0 * norb + 0  # = 0
@@ -2091,17 +2095,18 @@ class TestSCMatrices(unittest.TestCase):
         npt.assert_allclose(S_mat[idx_00, idx_11], J_val, atol=1e-10)
         npt.assert_allclose(C_mat[idx_00, idx_11], 2 * Up_val - J_val, atol=1e-10)
 
-        # (l1=0,l2=1,l3=1,l4=0) -> l1=l4!=l2=l3: S=J', C=J'
+        # (l1=0,l2=1,l3=1,l4=0) -> l1=l4!=l2=l3: Exchange moved to the
+        # (ab,ab) slots (issue #113); with no PairHop these are zero.
         idx_01 = 0 * norb + 1  # = 1
         idx_10 = 1 * norb + 0  # = 2
-        npt.assert_allclose(S_mat[idx_01, idx_10], Jp_val, atol=1e-10)
-        npt.assert_allclose(C_mat[idx_01, idx_10], Jp_val, atol=1e-10)
+        npt.assert_allclose(S_mat[idx_01, idx_10], 0.0, atol=1e-10)
+        npt.assert_allclose(C_mat[idx_01, idx_10], 0.0, atol=1e-10)
 
     def test_ising_interaction(self):
         """Test S, C for 2 orbitals with Ising interaction.
 
         Ising contributes to cross and dens channels:
-        cross (l1=l3,l2=l4): S = -I, C = -I
+        cross (l1=l3,l2=l4): S = +I (sign per issue #113), C = -I
         dens  (l1=l2,l3=l4): S = -2I, C = 0
         """
         norb = 2
@@ -2115,9 +2120,10 @@ class TestSCMatrices(unittest.TestCase):
         inter_k = {"Ising": I_k}
         S_mat, C_mat = _build_sc_matrices(inter_k, norb, 0, 0, 0)
 
-        # cross (l1=0,l2=1,l3=0,l4=1): S = -I, C = -I
+        # cross (l1=0,l2=1,l3=0,l4=1): S = +I, C = -I. The S sign was
+        # adjudicated by exact diagonalization (issue #113).
         idx_01 = 0 * norb + 1
-        npt.assert_allclose(S_mat[idx_01, idx_01], -I_val, atol=1e-10)
+        npt.assert_allclose(S_mat[idx_01, idx_01], +I_val, atol=1e-10)
         npt.assert_allclose(C_mat[idx_01, idx_01], -I_val, atol=1e-10)
 
         # dens (l1=0,l2=0,l3=1,l4=1): S = -2I, C = 0
@@ -2224,10 +2230,12 @@ class TestSCMatrices(unittest.TestCase):
         npt.assert_allclose(S_full[0, 0], U, atol=1e-10)
         npt.assert_allclose(C_full[0, 0], U, atol=1e-10)
 
-        # cross: S = V - I, C = -V + J - I
+        # cross: S = V + I - J + J', C = -V + J + J' - I  (issue #113)
         idx_01 = 0 * norb + 1
-        npt.assert_allclose(S_full[idx_01, idx_01], V - I_val, atol=1e-10)
-        npt.assert_allclose(C_full[idx_01, idx_01], -V + J - I_val, atol=1e-10)
+        npt.assert_allclose(S_full[idx_01, idx_01],
+                            V + I_val - J + Jp, atol=1e-10)
+        npt.assert_allclose(C_full[idx_01, idx_01],
+                            -V + J + Jp - I_val, atol=1e-10)
 
         # dens: S = J - 2I, C = 2V - J
         idx_00 = 0 * norb + 0
@@ -2235,11 +2243,11 @@ class TestSCMatrices(unittest.TestCase):
         npt.assert_allclose(S_full[idx_00, idx_11], J - 2 * I_val, atol=1e-10)
         npt.assert_allclose(C_full[idx_00, idx_11], 2 * V - J, atol=1e-10)
 
-        # exch: S = Jp + P, C = Jp + P
+        # exch: PairHop only (Exchange moved to (ab,ab), issue #113)
         idx_01 = 0 * norb + 1
         idx_10 = 1 * norb + 0
-        npt.assert_allclose(S_full[idx_01, idx_10], Jp + P, atol=1e-10)
-        npt.assert_allclose(C_full[idx_01, idx_10], Jp + P, atol=1e-10)
+        npt.assert_allclose(S_full[idx_01, idx_10], P, atol=1e-10)
+        npt.assert_allclose(C_full[idx_01, idx_10], P, atol=1e-10)
 
 
 class TestTripletPairing(unittest.TestCase):
@@ -2898,24 +2906,24 @@ class TestKanamoriInteraction(unittest.TestCase):
         npt.assert_allclose(S_all[0, 0], U, atol=1e-10)
         npt.assert_allclose(S_all[3, 3], U, atol=1e-10)
         # cross (l1=l3 != l2=l4): S = U'
-        npt.assert_allclose(S_all[1, 1], Up, atol=1e-10)  # (01, 01)
-        npt.assert_allclose(S_all[2, 2], Up, atol=1e-10)  # (10, 10)
+        npt.assert_allclose(S_all[1, 1], Up - J + Jp, atol=1e-10)  # (01, 01)
+        npt.assert_allclose(S_all[2, 2], Up - J + Jp, atol=1e-10)  # (10, 10)
         # dens (l1=l2 != l3=l4): S = J
         npt.assert_allclose(S_all[0, 3], J, atol=1e-10)   # (00, 11)
         npt.assert_allclose(S_all[3, 0], J, atol=1e-10)   # (11, 00)
         # exch (l1=l4 != l2=l3): S = J'
-        npt.assert_allclose(S_all[1, 2], Jp, atol=1e-10)  # (01, 10)
-        npt.assert_allclose(S_all[2, 1], Jp, atol=1e-10)  # (10, 01)
+        npt.assert_allclose(S_all[1, 2], 0.0, atol=1e-10)  # (01, 10) #113
+        npt.assert_allclose(S_all[2, 1], 0.0, atol=1e-10)  # (10, 01)
 
         # Check C matrix
         # diag: C = U
         npt.assert_allclose(C_all[0, 0], U, atol=1e-10)
         # cross: C = -U' + J
-        npt.assert_allclose(C_all[1, 1], -Up + J, atol=1e-10)
+        npt.assert_allclose(C_all[1, 1], -Up + J + Jp, atol=1e-10)  # #113
         # dens: C = 2U' - J
         npt.assert_allclose(C_all[0, 3], 2 * Up - J, atol=1e-10)
         # exch: C = J'
-        npt.assert_allclose(C_all[1, 2], Jp, atol=1e-10)
+        npt.assert_allclose(C_all[1, 2], 0.0, atol=1e-10)  # #113
 
         # Now verify RPA susceptibility computation
         # Use a small chi0 so the series converges
@@ -3086,7 +3094,7 @@ class TestKanamoriInteraction(unittest.TestCase):
         npt.assert_allclose(S_diag, U, atol=1e-10)
         npt.assert_allclose(S_cross, Up, atol=1e-10)
         npt.assert_allclose(S_dens, J, atol=1e-10)
-        npt.assert_allclose(S_exch, J, atol=1e-10)
+        npt.assert_allclose(S_exch, 0.0, atol=1e-10)  # Exchange moved (#113)
         # U' = U - 2J
         npt.assert_allclose(S_cross, S_diag - 2 * S_dens, atol=1e-10,
                             err_msg="Kanamori relation U'=U-2J should hold in S matrix")
@@ -3098,9 +3106,11 @@ class TestKanamoriInteraction(unittest.TestCase):
         C_exch = C_mat[1, 2]       # J' = J
 
         npt.assert_allclose(C_diag, U, atol=1e-10)
-        npt.assert_allclose(C_cross, -Up + J, atol=1e-10)
+        # C_cross = -U' + J + J' = -U' + 2J for J = J' -- the standard
+        # Kanamori value, from the corrected per-type split (#113)
+        npt.assert_allclose(C_cross, -Up + 2 * J, atol=1e-10)
         npt.assert_allclose(C_dens, 2 * Up - J, atol=1e-10)
-        npt.assert_allclose(C_exch, J, atol=1e-10)
+        npt.assert_allclose(C_exch, 0.0, atol=1e-10)
 
     def test_kanamori_with_ising_pairhop_eliashberg(self):
         """End-to-end test with all interaction types: U, U', J, J', Ising, PairHop."""

--- a/tests/test_sc_vertex_adjudicated.py
+++ b/tests/test_sc_vertex_adjudicated.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""The adjudicated S/C vertex table, pinned per interaction type.
+
+Every value below was established by exact diagonalization of H-wave's
+documented file operators (issue #113; methodology in issue #107): the
+O(lambda) self-energy is removed exactly via the Hartree-Fock response, the
+extraction is validated by q-independence for on-site input, the label map is
+anchored computationally on the end-to-end-adjudicated CoulombInter case, and
+the per-channel scale is calibrated once on the CoulombIntra control.
+
+S enters the spin channel as [1 - chi0 S]^-1 chi0 and C the charge channel as
+[1 + chi0 C]^-1 chi0. Slots are (l1*norb+l2, l3*norb+l4).
+
+Internal consistency checks carried by the table itself:
+  * SU(2): for Hund + Exchange at equal J (the rotationally symmetric
+    combination), S(ab,ab) has no J at all and C(ab,ab) = -U' + 2J -- the
+    standard Kanamori literature values, reproduced from the corrected
+    per-type split (the old bookkeeping assigned the whole 2J to Hund and
+    nothing to Exchange, which is also why the "MYO vs Kuroki convention
+    difference" dissolved: it was a per-type attribution error).
+  * The transverse channel measured in the #105 series is consistent with
+    this table through the SU(2) identity for the same combination.
+"""
+
+import unittest
+
+import numpy as np
+
+
+def _single(itype, val, norb=2):
+    import hwave.sc as sc
+
+    k = np.array([0.0])
+    if itype == "CoulombIntra":
+        entries = {((0, 0, 0), (a, a)): val for a in range(norb)}
+    else:
+        entries = {((0, 0, 0), (0, 1)): val, ((0, 0, 0), (1, 0)): val}
+    ik = sc._build_interaction_k(k, k, k, {itype: entries}, norb)
+    S, C = sc._build_sc_matrices_all_q(ik, norb, 1, 1, 1)
+    return S[0, 0, 0], C[0, 0, 0]
+
+
+class TestAdjudicatedVertexTable(unittest.TestCase):
+
+    def test_per_type_sc_content(self):
+        J = 0.7
+        # slots: 0 = (0,0), 1 = (0,1), 2 = (1,0), 3 = (1,1)
+        expected = {
+            #            S nonzero slots            C nonzero slots
+            "CoulombIntra": ({(0, 0): J, (3, 3): J}, {(0, 0): J, (3, 3): J}),
+            "CoulombInter": ({(1, 1): J, (2, 2): J},
+                             {(1, 1): -J, (2, 2): -J,
+                              (0, 3): 2*J, (3, 0): 2*J}),
+            "Hund":         ({(0, 3): J, (3, 0): J,
+                              (1, 1): -J, (2, 2): -J},
+                             {(0, 3): -J, (3, 0): -J,
+                              (1, 1): J, (2, 2): J}),
+            "Exchange":     ({(1, 1): J, (2, 2): J},
+                             {(1, 1): J, (2, 2): J}),
+            "Ising":        ({(0, 3): -2*J, (3, 0): -2*J,
+                              (1, 1): J, (2, 2): J},
+                             {(1, 1): -J, (2, 2): -J}),
+            "PairLift":     ({}, {}),
+            "PairHop":      ({(1, 2): J, (2, 1): J},
+                             {(1, 2): J, (2, 1): J}),
+        }
+        for itype, (s_want, c_want) in expected.items():
+            with self.subTest(interaction=itype):
+                S, C = _single(itype, J)
+                for name, M, want in (("S", S, s_want), ("C", C, c_want)):
+                    built = np.zeros((4, 4), dtype=complex)
+                    for (i, j), v in want.items():
+                        built[i, j] = v
+                    np.testing.assert_allclose(
+                        M, built, atol=1e-12,
+                        err_msg="%s matrix of %s does not match the "
+                                "adjudicated table" % (name, itype))
+
+    def test_su2_combination_recovers_the_standard_kanamori_values(self):
+        """Hund + Exchange at equal J: S(ab,ab) carries no J and
+        C(ab,ab) = +2J (with U' = 0 here) -- the standard literature values,
+        obtained from the corrected per-type split."""
+        import hwave.sc as sc
+
+        J = 0.7
+        k = np.array([0.0])
+        both = {"Hund": {((0, 0, 0), (0, 1)): J, ((0, 0, 0), (1, 0)): J},
+                "Exchange": {((0, 0, 0), (0, 1)): J, ((0, 0, 0), (1, 0)): J}}
+        ik = sc._build_interaction_k(k, k, k, both, 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 1, 1, 1)
+        self.assertAlmostEqual(S[0, 0, 0, 1, 1].real, 0.0, places=12)
+        self.assertAlmostEqual(C[0, 0, 0, 1, 1].real, 2 * J, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sc_vertex_adjudicated.py
+++ b/tests/test_sc_vertex_adjudicated.py
@@ -141,50 +141,168 @@ class TestDeclarationSymmetrisation(unittest.TestCase):
         self.assertGreater(float(np.max(np.abs(S.imag))), 0.39)
 
 
+class TestOffsiteVqPreservation(unittest.TestCase):
+    """The declaration symmetrisation must not touch off-site structure.
+
+    The partner of an off-site entry (R, (a, b)) is (-R, (b, a)), which in
+    momentum space is the orbital transpose AT -q. Averaging with the same-q
+    transpose instead collapses V(q) = v e^{-iqR} to v cos(qR) -- at q = pi/2
+    the S/C entry vanished outright. Checked at a q with sin(q) != 0 so any
+    cos-collapse or conjugation error changes the answer.
+    """
+
+    def _sc(self):
+        import hwave.sc as sc
+
+        return sc
+
+    def _interactions(self):
+        # one-dimensional bond declared from both ends, as an interaction
+        # file does; V(q) = 0.7 e^{-iq} must survive verbatim
+        return {"CoulombInter": {((1, 0, 0), (0, 1)): 0.7,
+                                 ((-1, 0, 0), (1, 0)): 0.7}}
+
+    def test_offsite_vq_is_preserved_with_full_complex_phase(self):
+        sc = self._sc()
+        kx = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        kz = np.array([0.0])
+        ik = sc._build_interaction_k(kx, kx, kz, self._interactions(), 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 4, 4, 1)
+        q1 = kx[1]                          # pi/2: sin(q) = 1, maximal test
+        # builder stores entry (R, (a, b)) at [b, a] with e^{-iqR}: the two
+        # cross slots carry 0.7 e^{+iq} (from [0,1]) and 0.7 e^{-iq} ([1,0])
+        want = {(1, 1): 0.7 * np.exp(+1j * q1),
+                (2, 2): 0.7 * np.exp(-1j * q1)}
+        for (i, j), w in want.items():
+            for name, M in (("S", S), ("C", C)):
+                got = M[1, 0, 0, i, j]
+                mag = abs(got)
+                self.assertAlmostEqual(mag, 0.7, places=12,
+                                       msg="%s[%d,%d] magnitude" % (name, i, j))
+                self.assertAlmostEqual(
+                    abs(got - (w if name == "S" else -w)), 0.0, places=12,
+                    msg="%s[%d,%d] phase" % (name, i, j))
+
+    def test_per_q_builder_matches_all_q_including_negative_index(self):
+        sc = self._sc()
+        kx = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        kz = np.array([0.0])
+        ik = sc._build_interaction_k(kx, kx, kz, self._interactions(), 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 4, 4, 1)
+        for i in range(4):
+            Sp, Cp = sc._build_sc_matrices(ik, 2, i, 0, 0)
+            np.testing.assert_allclose(Sp, S[i, 0, 0], atol=1e-13)
+            np.testing.assert_allclose(Cp, C[i, 0, 0], atol=1e-13)
+        Sm, Cm = sc._build_sc_matrices(ik, 2, -1, 0, 0)   # numpy semantics
+        np.testing.assert_allclose(Sm, S[3, 0, 0], atol=1e-13)
+        with self.assertRaises(IndexError):
+            sc._build_sc_matrices(ik, 2, 7, 0, 0)
+
+    def test_one_sided_offsite_declaration_gets_the_mean(self):
+        # a single-direction declaration means (jab + jba)/2 in this codebase:
+        # half the weight at e^{-iq}, half at e^{+iq} on the transposed slot
+        sc = self._sc()
+        kx = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        kz = np.array([0.0])
+        ik = sc._build_interaction_k(
+            kx, kx, kz, {"CoulombInter": {((1, 0, 0), (0, 1)): 0.7}}, 2)
+        sym = sc._symmetrise_interactions_k(ik)["CoulombInter"]
+        q1 = kx[1]
+        self.assertAlmostEqual(
+            abs(sym[1, 0, 1, 0, 0] - 0.35 * np.exp(-1j * q1)), 0.0, places=12)
+        self.assertAlmostEqual(
+            abs(sym[0, 1, 1, 0, 0] - 0.35 * np.exp(+1j * q1)), 0.0, places=12)
+
+
 class TestLegacyFlexFileGuard(unittest.TestCase):
     """Susceptibility files that predate the #113 vertex corrections must not
     be silently paired with the corrected S/C matrices when the interaction
     set contains an affected type (Hund / Exchange / Ising). U/V-only inputs
-    are provably unchanged, so legacy files stay usable there.
+    are provably unchanged, so legacy files stay usable there. The guard
+    requires the version to DECODE to exactly 2 in BOTH files -- a version-1
+    tag, a mismatched pair, or a malformed field is as wrong as no tag.
+    Activation is by interaction CONTENT: an explicitly configured but empty
+    Hund file contributes nothing and must not trip the guard.
     """
 
-    def _write(self, d, **extra):
+    HUND = {((0, 0, 0), (0, 1)): 0.5}
+
+    def _write(self, d, extra_s=None, extra_c=None):
         nd = 4
         arr = np.zeros((4, 4, nd, nd), dtype=complex)
-        np.savez(os.path.join(d, "chiq_s.npz"), chiq_s=arr, **extra)
-        np.savez(os.path.join(d, "chiq_c.npz"), chiq_c=arr, **extra)
+        np.savez(os.path.join(d, "chiq_s.npz"), chiq_s=arr, **(extra_s or {}))
+        np.savez(os.path.join(d, "chiq_c.npz"), chiq_c=arr, **(extra_c or {}))
         return {"file": {"output": {"path_to_output": d}}, "eliashberg": {}}
+
+    def _load(self, inp, interactions):
+        import hwave.sc as sc
+
+        return sc._load_flex_susceptibilities(
+            inp, 2, 2, 2, 1, interactions=interactions)
 
     def test_legacy_file_with_affected_type_is_rejected(self):
         import tempfile
-        import hwave.sc as sc
 
         d = tempfile.mkdtemp()
         inp = self._write(d)               # no sc_vertex_version
         with self.assertRaises(ValueError) as cm:
-            sc._load_flex_susceptibilities(
-                inp, 2, 2, 2, 1, interactions={"Hund": {}})
+            self._load(inp, {"Hund": self.HUND})
         self.assertIn("sc_vertex_version", str(cm.exception))
 
     def test_legacy_file_with_uv_only_is_accepted(self):
         import tempfile
-        import hwave.sc as sc
 
         d = tempfile.mkdtemp()
         inp = self._write(d)
-        sc._load_flex_susceptibilities(
-            inp, 2, 2, 2, 1,
-            interactions={"CoulombIntra": {}, "CoulombInter": {}})
+        self._load(inp, {"CoulombIntra": {(0, 0): 4.0},
+                         "CoulombInter": {((0, 0, 0), (0, 1)): 0.7}})
+
+    def test_legacy_file_with_empty_affected_type_is_accepted(self):
+        # a configured-but-empty Hund file contributes no interaction, so the
+        # vertex content cannot differ; key PRESENCE must not trip the guard
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        inp = self._write(d)
+        self._load(inp, {"Hund": {}, "Exchange": {}, "Ising": {}})
 
     def test_tagged_file_with_affected_type_is_accepted(self):
         import tempfile
-        import hwave.sc as sc
 
         d = tempfile.mkdtemp()
-        inp = self._write(d, sc_vertex_version=2)
-        sc._load_flex_susceptibilities(
-            inp, 2, 2, 2, 1, interactions={"Exchange": {}})
+        v = {"sc_vertex_version": 2}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        self._load(inp, {"Exchange": self.HUND})
 
+    def test_version_1_is_rejected(self):
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        v = {"sc_vertex_version": 1}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        with self.assertRaises(ValueError) as cm:
+            self._load(inp, {"Hund": self.HUND})
+        self.assertIn("version 2", str(cm.exception))
+
+    def test_mismatched_versions_are_rejected(self):
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        inp = self._write(d, extra_s={"sc_vertex_version": 2},
+                          extra_c={"sc_vertex_version": 1})
+        with self.assertRaises(ValueError) as cm:
+            self._load(inp, {"Ising": self.HUND})
+        self.assertIn("different", str(cm.exception))
+
+    def test_malformed_version_is_rejected(self):
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        v = {"sc_vertex_version": np.array(["two"])}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        with self.assertRaises(ValueError) as cm:
+            self._load(inp, {"Hund": self.HUND})
+        self.assertIn("malformed", str(cm.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sc_vertex_adjudicated.py
+++ b/tests/test_sc_vertex_adjudicated.py
@@ -22,6 +22,7 @@ Internal consistency checks carried by the table itself:
     this table through the SU(2) identity for the same combination.
 """
 
+import os
 import unittest
 
 import numpy as np
@@ -90,6 +91,99 @@ class TestAdjudicatedVertexTable(unittest.TestCase):
         S, C = sc._build_sc_matrices_all_q(ik, 2, 1, 1, 1)
         self.assertAlmostEqual(S[0, 0, 0, 1, 1].real, 0.0, places=12)
         self.assertAlmostEqual(C[0, 0, 0, 1, 1].real, 2 * J, places=12)
+
+
+
+
+class TestDeclarationSymmetrisation(unittest.TestCase):
+    """The S/C builders symmetrise the two redundant declarations of each
+    orbital pair with the mean (plain transpose for every type whose two
+    entries multiply the same operator; conjugated for PairHop, whose entries
+    are Hermitian partners and whose complex phase is physical, #100/#105).
+
+    Without this, an asymmetric Exchange declaration put unequal values at the
+    two (ab,ab) slots -- diverging from the transverse channel, which
+    symmetrises -- and an antisymmetric declaration, an identically zero
+    Hamiltonian, produced a nonzero vertex.
+    """
+
+    def _sc(self, itype, entries):
+        import hwave.sc as sc
+
+        k = np.array([0.0])
+        ik = sc._build_interaction_k(k, k, k, {itype: entries}, 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 1, 1, 1)
+        return S[0, 0, 0], C[0, 0, 0]
+
+    def test_antisymmetric_declarations_give_zero(self):
+        entries = {((0, 0, 0), (0, 1)): 1.0, ((0, 0, 0), (1, 0)): -1.0}
+        for itype in ("Exchange", "CoulombInter", "Ising", "Hund"):
+            with self.subTest(interaction=itype):
+                S, C = self._sc(itype, entries)
+                self.assertLess(float(np.max(np.abs(S))), 1e-12)
+                self.assertLess(float(np.max(np.abs(C))), 1e-12)
+
+    def test_asymmetric_exchange_uses_the_mean(self):
+        S, C = self._sc("Exchange",
+                        {((0, 0, 0), (0, 1)): 1.0, ((0, 0, 0), (1, 0)): 0.35})
+        mean = (1.0 + 0.35) / 2
+        for M in (S, C):
+            self.assertAlmostEqual(M[1, 1].real, mean, places=12)
+            self.assertAlmostEqual(M[2, 2].real, mean, places=12)
+
+    def test_complex_hermitian_pairhop_keeps_its_phase(self):
+        p = 0.7 + 0.4j
+        S, C = self._sc("PairHop",
+                        {((0, 0, 0), (0, 1)): p,
+                         ((0, 0, 0), (1, 0)): np.conj(p)})
+        # Hermitian-closed input: the conjugated mean is an identity, so the
+        # full complex value survives (a plain mean would collapse it to Re p)
+        self.assertGreater(float(np.max(np.abs(S.imag))), 0.39)
+
+
+class TestLegacyFlexFileGuard(unittest.TestCase):
+    """Susceptibility files that predate the #113 vertex corrections must not
+    be silently paired with the corrected S/C matrices when the interaction
+    set contains an affected type (Hund / Exchange / Ising). U/V-only inputs
+    are provably unchanged, so legacy files stay usable there.
+    """
+
+    def _write(self, d, **extra):
+        nd = 4
+        arr = np.zeros((4, 4, nd, nd), dtype=complex)
+        np.savez(os.path.join(d, "chiq_s.npz"), chiq_s=arr, **extra)
+        np.savez(os.path.join(d, "chiq_c.npz"), chiq_c=arr, **extra)
+        return {"file": {"output": {"path_to_output": d}}, "eliashberg": {}}
+
+    def test_legacy_file_with_affected_type_is_rejected(self):
+        import tempfile
+        import hwave.sc as sc
+
+        d = tempfile.mkdtemp()
+        inp = self._write(d)               # no sc_vertex_version
+        with self.assertRaises(ValueError) as cm:
+            sc._load_flex_susceptibilities(
+                inp, 2, 2, 2, 1, interactions={"Hund": {}})
+        self.assertIn("sc_vertex_version", str(cm.exception))
+
+    def test_legacy_file_with_uv_only_is_accepted(self):
+        import tempfile
+        import hwave.sc as sc
+
+        d = tempfile.mkdtemp()
+        inp = self._write(d)
+        sc._load_flex_susceptibilities(
+            inp, 2, 2, 2, 1,
+            interactions={"CoulombIntra": {}, "CoulombInter": {}})
+
+    def test_tagged_file_with_affected_type_is_accepted(self):
+        import tempfile
+        import hwave.sc as sc
+
+        d = tempfile.mkdtemp()
+        inp = self._write(d, sc_vertex_version=2)
+        sc._load_flex_susceptibilities(
+            inp, 2, 2, 2, 1, interactions={"Exchange": {}})
 
 
 if __name__ == "__main__":

--- a/tests/test_sc_vertex_adjudicated.py
+++ b/tests/test_sc_vertex_adjudicated.py
@@ -198,6 +198,49 @@ class TestOffsiteVqPreservation(unittest.TestCase):
         with self.assertRaises(IndexError):
             sc._build_sc_matrices(ik, 2, 7, 0, 0)
 
+    def test_offsite_hermitian_pairhop_phase_is_preserved(self):
+        # PairHop's partner is the HERMITIAN entry (-R, (b,a), conj(p)); the
+        # same-q conjugated transpose must be an identity for that closure
+        # off-site too, keeping the full complex phase
+        sc = self._sc()
+        kx = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        kz = np.array([0.0])
+        p = 0.7 * np.exp(0.3j)
+        ik = sc._build_interaction_k(
+            kx, kx, kz,
+            {"PairHop": {((1, 0, 0), (0, 1)): p,
+                         ((-1, 0, 0), (1, 0)): np.conjugate(p)}}, 2)
+        raw = ik["PairHop"].copy()
+        sym = sc._symmetrise_interactions_k(ik)["PairHop"]
+        np.testing.assert_allclose(sym, raw, atol=1e-13)
+        # PairHop is stored UNtransposed (measured in #100): the entry
+        # (R, (a, b)) lands at [a, b], so [0, 1] carries p e^{-iqR}
+        q1 = kx[1]
+        self.assertAlmostEqual(
+            abs(sym[0, 1, 1, 0, 0] - p * np.exp(-1j * q1)), 0.0, places=12)
+
+    def test_reversal_on_mixed_odd_even_grid(self):
+        # (Nx, Ny, Nz) = (5, 4, 3): odd sizes pair i <-> n-i, even sizes make
+        # 0 and n/2 self-partners; the both-ends identity must hold per axis
+        sc = self._sc()
+        kx = np.linspace(0, 2 * np.pi, 5, endpoint=False)
+        ky = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        kz = np.linspace(0, 2 * np.pi, 3, endpoint=False)
+        ik = sc._build_interaction_k(
+            kx, ky, kz,
+            {"CoulombInter": {((1, 2, 0), (0, 1)): 0.7,
+                              ((-1, -2, 0), (1, 0)): 0.7,
+                              ((0, 0, 1), (0, 1)): 0.4,
+                              ((0, 0, -1), (1, 0)): 0.4}}, 2)
+        raw = ik["CoulombInter"].copy()
+        sym = sc._symmetrise_interactions_k(ik)["CoulombInter"]
+        np.testing.assert_allclose(sym, raw, atol=1e-13)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 5, 4, 3)
+        for idx in ((1, 0, 0), (2, 3, 1), (4, 2, 2), (0, 2, 0)):
+            Sp, Cp = sc._build_sc_matrices(ik, 2, *idx)
+            np.testing.assert_allclose(Sp, S[idx], atol=1e-13)
+            np.testing.assert_allclose(Cp, C[idx], atol=1e-13)
+
     def test_one_sided_offsite_declaration_gets_the_mean(self):
         # a single-direction declaration means (jab + jba)/2 in this codebase:
         # half the weight at e^{-iq}, half at e^{+iq} on the transposed slot
@@ -293,6 +336,61 @@ class TestLegacyFlexFileGuard(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             self._load(inp, {"Ising": self.HUND})
         self.assertIn("different", str(cm.exception))
+
+    def test_fractional_version_is_rejected_not_truncated(self):
+        # int() would truncate 2.9 to 2 and accept it
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        v = {"sc_vertex_version": 2.9}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        with self.assertRaises(ValueError) as cm:
+            self._load(inp, {"Hund": self.HUND})
+        self.assertIn("malformed", str(cm.exception))
+
+    def test_nonfinite_version_is_rejected_as_valueerror(self):
+        # int(inf) raises OverflowError, which must not escape undocumented
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        v = {"sc_vertex_version": np.inf}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        with self.assertRaises(ValueError) as cm:
+            self._load(inp, {"Hund": self.HUND})
+        self.assertIn("malformed", str(cm.exception))
+
+    def test_nonscalar_version_is_rejected(self):
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        v = {"sc_vertex_version": np.array([2, 2])}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        with self.assertRaises(ValueError) as cm:
+            self._load(inp, {"Hund": self.HUND})
+        self.assertIn("malformed", str(cm.exception))
+
+    def test_integral_float_version_is_accepted(self):
+        # 2.0 decodes to exactly 2; only truncation is forbidden
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        v = {"sc_vertex_version": 2.0}
+        inp = self._write(d, extra_s=v, extra_c=v)
+        self._load(inp, {"Hund": self.HUND})
+
+    def test_full_frequency_loader_activates_the_same_guard(self):
+        # the dynamic-Eliashberg path loads through
+        # _load_flex_susceptibilities_full, which must forward the interaction
+        # content into the same version guard as the static loader
+        import tempfile
+        import hwave.sc as sc
+
+        d = tempfile.mkdtemp()
+        inp = self._write(d)               # untagged
+        with self.assertRaises(ValueError) as cm:
+            sc._load_flex_susceptibilities_full(
+                inp, 2, 2, 2, 1, interactions={"Hund": self.HUND})
+        self.assertIn("sc_vertex_version", str(cm.exception))
 
     def test_malformed_version_is_rejected(self):
         import tempfile

--- a/tests/test_vertex_orientation.py
+++ b/tests/test_vertex_orientation.py
@@ -433,10 +433,21 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
                 got = ik[itype][:, :, 0, 0, 0]    # on-site: q-independent
                 np.testing.assert_allclose(got, want, rtol=0.0, atol=1e-12)
 
-    def test_asymmetric_on_site_input_reaches_the_sc_builders(self):
-        """Guard the reachability claim rather than assuming it: an asymmetric
-        ON-SITE inter-orbital entry survives into the S/C matrices, and makes
-        the charge matrix non-symmetric under the orbital-pair transpose."""
+    def test_asymmetric_on_site_input_is_symmetrised_by_the_sc_builders(self):
+        """An asymmetric ON-SITE inter-orbital entry reaches the S/C builders
+        and is reduced there to its physical symmetric coefficient, the MEAN
+        of the two declarations.
+
+        HISTORY: this test used to assert the opposite -- that asymmetric
+        input produced a pair-ASYMMETRIC charge matrix -- which guarded the
+        reachability claim while the builders read the raw per-slot values.
+        Since the #113 corrections the builders symmetrise declarations at
+        entry (matching UHFk's reading of the files and the transverse
+        channel, #105/#106), so the observable is now the mean. The
+        orientation of `_build_interaction_k` itself stays pinned by
+        `test_every_type_is_stored_pair_transposed`, which inspects the
+        builder's input directly.
+        """
         import hwave.sc as sc
         from hwave.solver._sc_matrices_myo import build_sc_matrices_myo
 
@@ -456,10 +467,13 @@ class TestAllInteractionTypesTransposed(unittest.TestCase):
                 self.assertTrue(
                     np.allclose(c_sym, np.swapaxes(c_sym, -1, -2)),
                     "symmetric input must give a pair-symmetric charge matrix")
-                self.assertFalse(
+                self.assertTrue(
                     np.allclose(c_asym, np.swapaxes(c_asym, -1, -2)),
-                    "asymmetric on-site input does reach the S/C builders, so "
-                    "the orientation is observable there")
+                    "asymmetric input must be symmetrised to the mean")
+                # and the mean is what lands: (1.0 + 0.4)/2 at the (ab,ab)
+                # charge slots carries -mean (density-density C = -V there)
+                self.assertAlmostEqual(
+                    c_asym[0, 0, 0, 1, 1].real, -0.7, places=12)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #113. Methodology and the full three-way (ED / RPA-ring / FLEX) adjudication table are in #107.

## The defects

Exact diagonalization of H-wave's documented file operators showed the S/C interaction matrices were wrong for the exchange-family types, each differently (`chi_s = [1 - chi0 S]^-1 chi0`, `chi_c = [1 + chi0 C]^-1 chi0`):

| type | defect |
|---|---|
| Hund | the spin contribution `S -= J` at (ab,ab) was **missing entirely** |
| Exchange | its ±J sat on the pair-antidiagonal Case-4 slots; the exact vertex puts it on the pair-diagonal Case-2 slots (`S += J'`, `C += J'`) |
| Ising | the spin sign at (ab,ab) was **inverted** (`S += I`, not `S -= I`) |

## The "MYO vs Kuroki convention difference" dissolves

`build_sc_matrices_myo` carried `-U'+2J` at the charge (ab,ab) slot against `sc.py`'s `-U'+J`, documented as a literature-convention choice. The exact per-type attribution is **Hund +J and Exchange +J'**: for the SU(2) Kanamori combination (J = J') their sum reproduces the standard `-U'+2J` exactly, while the spin channel gets `-J + J' = 0` — the standard "no J in S(ab,ab)". So MYO's value was right for the combination but wrong as a per-type split, and Kuroki's was wrong for the combination. Neither was a convention; one was a bookkeeping error and the other an omission.

With the per-type values fixed, the two builders are identical — `build_sc_matrices_myo` now **delegates** to `_build_sc_matrices_all_q` (the first concrete step of #108), and the per-q `_build_sc_matrices` delegates too, retiring two hand-maintained copies (one of which had already drifted once).

## Verification

- Three-way table after the fix: **|ED − FLEX| = 0.000 in all eight cells** (CoulombInter / Hund / Exchange / Ising × both channels), against 0.700 for the RPA ring in every cell — that side is #104, to be resolved by the #107 unification.
- Internal consistency: the SU(2) combination reproduces the standard Kanamori matrices, and the transverse table from #105 is consistent through the SU(2) identity for the same combination.
- The adjudicated table is pinned per type in `tests/test_sc_vertex_adjudicated.py`, including the SU(2)-combination check. Eight existing tests that pinned the old values (including two that asserted the myo–kuroki *divergence*) are updated, with the adjudication recorded at each changed assertion.

## Affected results

Any calculation whose interaction includes Hund, Exchange or Ising file entries — susceptibilities and Eliashberg kernels both. **U/V-only calculations are unchanged** (which covers the extended-Hubbard charge-fluctuation work).

952 tests pass.