### PR TITLE
Add the adjudicated inter-orbital content to the RPA ring's spin vertex

### DIFF
--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -1004,15 +1004,13 @@ class RPA:
             # input (see _make_ham_inter). The correction's (a,b,a,b) slots
             # sit off the 'kaabb' diagonal, so the reduced/squashed reads
             # below are unaffected by construction.
-            ham_long_q = ham_inter_q
-            if getattr(self.ham_info, "ham_fierz_q", None) is not None:
-                ham_long_q = ham_inter_q + self.ham_info.ham_fierz_q
+            fierz_q = getattr(self.ham_info, "ham_fierz_q", None)
+            ham_long_q = (ham_inter_q if fierz_q is None
+                          else ham_inter_q + fierz_q)
             if gpu_active:
                 ham_inter_q = xp.asarray(ham_inter_q)
-                if ham_long_q is not ham_inter_q:
-                    ham_long_q = xp.asarray(ham_long_q)
-                else:
-                    ham_long_q = ham_inter_q
+                ham_long_q = (ham_inter_q if fierz_q is None
+                              else xp.asarray(ham_long_q))
 
             if self.spin_mode == "spinful":
                 chi0q_orig = chi0q

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -547,10 +547,30 @@ class Interaction:
             # with a != b: that is the adjudicated domain -- off-site
             # cross-orbital content is not representable by a q-only vertex
             # (#105 measurement) and stays as it was.
+            # `tbl`, when given, must be a PRE-fold table. Locality is
+            # judged BEFORE sublattice folding: folding maps an off-site
+            # bond to (0,0,0) between supercell orbitals, which would
+            # smuggle unadjudicated off-site content into the correction
+            # (measured: a one-orbital +-x bond folded with SubShape=[2,1,1]
+            # produced a spurious Fierz tensor of magnitude V). The pre-fold
+            # table is filtered to its on-site a != b entries, and only the
+            # filtered table is folded.
+            has_sub = getattr(self.lattice, "has_sublattice", False)
             if tbl is None:
-                tbl = self.param_ham[type]
-            tbl = _symmetrised(type, tbl)
+                if has_sub:
+                    tbl = self.param_ham_orig.get(type, {})
+                else:
+                    tbl = self.param_ham.get(type, {})
+            filtered = {}
             for (irvec, orbvec), v in tbl.items():
+                if tuple(irvec) == (0, 0, 0) and orbvec[0] != orbvec[1]:
+                    filtered[(irvec, orbvec)] = v
+            if not filtered:
+                return
+            if has_sub:
+                filtered = self._reshape_interaction(filtered, False)
+            filtered = _symmetrised(type, filtered)
+            for (irvec, orbvec), v in filtered.items():
                 if tuple(irvec) != (0, 0, 0):
                     continue
                 a, b = orbvec
@@ -583,7 +603,12 @@ class Interaction:
 
             _append_inter('CoulombIntra', coulomb_intra)
             _append_inter('CoulombInter', coulomb_inter)
-            _append_inter_cross('CoulombInter', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 }, tbl=coulomb_inter)
+            _append_inter_cross(
+                'CoulombInter', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 },
+                tbl=(wan90.split_coulomb(
+                        self.param_ham_orig['Coulomb'])[1]
+                     if getattr(self.lattice, "has_sublattice", False)
+                     else coulomb_inter))
             self._has_interaction = True
             self._has_interaction_coulomb = True
 

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -442,6 +442,17 @@ class Interaction:
         #   H = W(r)^{\beta\beta^\prime\alpha\alpah^\prime}
         #        * c_{i\alpha}^\dagger c_{i\alpha^\prime} c_{j\beta^\prime}^\dagger c_{j\beta}
         ham_r = np.zeros((nx,ny,nz,*(ns,norb)*4), dtype=np.complex128)
+        # Longitudinal Fierz (cross-slot) corrections live in a SEPARATE
+        # tensor: the ring's longitudinal solve consumes ham_inter_q +
+        # ham_fierz_q, while the transverse (ladder) assembly reads
+        # ham_inter_q alone. The two channels were adjudicated against exact
+        # diagonalization independently (#105 transverse, #113 longitudinal),
+        # and the cross-spin Exchange correction would otherwise land in the
+        # very tensor block the transverse assembly reads via the crossing
+        # relation, doubling the adjudicated ladder vertex (measured: the
+        # extracted Exchange coupling went -0.7 -> -1.4 when the correction
+        # shared the tensor).
+        fierz_r = np.zeros_like(ham_r)
 
         # spin(a,ap,bp,b)  0: up, 1: down
         spin_table = {
@@ -525,6 +536,36 @@ class Interaction:
                         orb = (s4, b, s3, a, s1, a, s2, b)
                         ham_r[(*irvec, *orb)] += v * w
 
+        def _append_inter_cross(type, coeff, spins, tbl=None):
+            # Longitudinal cross-slot (Fierz) content, adjudicated against
+            # exact diagonalization in #113: the ring's W carried the
+            # density (aa,bb) slots of each type but not the (ab,ab)
+            # pair-cross slots, which is why its effective spin vertex was
+            # diag(U0, 0, 0, U1) where the adjudicated table (and the
+            # spin/charge builders in hwave.sc) have diag(U0, U', U', U1)
+            # (#104; measured 1e-2 in chiq). Restricted to ON-SITE entries
+            # with a != b: that is the adjudicated domain -- off-site
+            # cross-orbital content is not representable by a q-only vertex
+            # (#105 measurement) and stays as it was.
+            if tbl is None:
+                tbl = self.param_ham[type]
+            tbl = _symmetrised(type, tbl)
+            for (irvec, orbvec), v in tbl.items():
+                if tuple(irvec) != (0, 0, 0):
+                    continue
+                a, b = orbvec
+                if a == b:
+                    continue
+                for spinvec, w in spins.items():
+                    s1, s2, s3, s4 = spinvec
+                    # pair-diagonal placement -- bilinear (a,b) coupled to
+                    # bilinear (a,b) -- selected by measurement: it makes
+                    # the ring's chiq equal the FLEX channel solve to 3e-16
+                    # in every adjudicated cell, while the pair-antidiagonal
+                    # placement reproduces the old 1e-2 deficiency
+                    orb = (s4, a, s3, b, s1, a, s2, b)
+                    fierz_r[(*irvec, *orb)] += coeff * v * w
+
         if 'Coulomb' in self.param_ham.keys():
             # The aggregate 'Coulomb' input provides both the intra and inter
             # parts (shared decomposition, see wan90.split_coulomb).
@@ -542,6 +583,7 @@ class Interaction:
 
             _append_inter('CoulombIntra', coulomb_intra)
             _append_inter('CoulombInter', coulomb_inter)
+            _append_inter_cross('CoulombInter', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 }, tbl=coulomb_inter)
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
@@ -552,16 +594,19 @@ class Interaction:
 
         if 'CoulombInter' in self.param_ham.keys():
             _append_inter('CoulombInter')
+            _append_inter_cross('CoulombInter', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 })
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
         if 'Hund' in self.param_ham.keys():
             _append_inter('Hund')
+            _append_inter_cross('Hund', +1.0, { (0,0,0,0): 1, (1,1,1,1): 1 })
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
         if 'Ising' in self.param_ham.keys():
             _append_inter('Ising')
+            _append_inter_cross('Ising', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 })
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
@@ -572,6 +617,7 @@ class Interaction:
 
         if 'Exchange' in self.param_ham.keys():
             _append_inter('Exchange')
+            _append_inter_cross('Exchange', +1.0, { (0,0,1,1): 1, (1,1,0,0): 1 })
             self._has_interaction = True
             self._has_interaction_exchange = True
 
@@ -594,6 +640,12 @@ class Interaction:
 
         self.ham_inter_r = ham_r
         self.ham_inter_q = ham_q
+
+        fierz_r = fierz_r.reshape(nx,ny,nz,*(nd,)*4)
+        if np.any(fierz_r):
+            self.ham_fierz_q = FFT.fftn(fierz_r, axes=(0,1,2))
+        else:
+            self.ham_fierz_q = None
 
 class RPA:
     """
@@ -947,12 +999,25 @@ class RPA:
             # ham_inter_q is built on the host at init; mirror it to chi0q's
             # backend so the inflation einsums and the solve stay on one device.
             ham_inter_q = self.ham_info.ham_inter_q
+            # The longitudinal channels solve with the Fierz-corrected
+            # tensor; ham_inter_q itself stays as the transverse assembly's
+            # input (see _make_ham_inter). The correction's (a,b,a,b) slots
+            # sit off the 'kaabb' diagonal, so the reduced/squashed reads
+            # below are unaffected by construction.
+            ham_long_q = ham_inter_q
+            if getattr(self.ham_info, "ham_fierz_q", None) is not None:
+                ham_long_q = ham_inter_q + self.ham_info.ham_fierz_q
             if gpu_active:
                 ham_inter_q = xp.asarray(ham_inter_q)
+                if ham_long_q is not ham_inter_q:
+                    ham_long_q = xp.asarray(ham_long_q)
+                else:
+                    ham_long_q = ham_inter_q
 
             if self.spin_mode == "spinful":
                 chi0q_orig = chi0q
                 ham_orig = ham_inter_q
+                ham_long = ham_long_q
 
                 if self.calc_scheme == "reduced" or self.calc_scheme == "squashed":
                     # Treat combined spin-orbital indices as general orbitals.
@@ -961,13 +1026,14 @@ class RPA:
                     nvol = self.lattice.nvol
                     nd = self.nd
                     ham = xp.einsum('kaabb->kab',
-                                    ham_orig.reshape(nvol,*(nd,)*4)).reshape(nvol,*(nd,)*2)
+                                    ham_long.reshape(nvol,*(nd,)*4)).reshape(nvol,*(nd,)*2)
                 else:
-                    ham = ham_orig
+                    ham = ham_long
 
             elif self.spin_mode == "spin-diag":
                 chi0q_orig = chi0q
                 ham_orig = ham_inter_q
+                ham_long = ham_long_q
 
                 if self.calc_scheme == "reduced":
                     nblock,nfreq,nvol,norb1,norb2 = chi0q_orig.shape
@@ -982,7 +1048,7 @@ class RPA:
                                       spin_tensor).reshape(nfreq,nvol,nd,nd)
 
                     ham = xp.einsum('kaabb->kab',
-                                    ham_orig.reshape(nvol,*(nd,)*4)).reshape(nvol,*(nd,)*2)
+                                    ham_long.reshape(nvol,*(nd,)*4)).reshape(nvol,*(nd,)*2)
 
                 elif self.calc_scheme == "squashed":
                     nblock,nfreq,nvol,norb1,norb2 = chi0q_orig.shape
@@ -1000,7 +1066,7 @@ class RPA:
                                       spin_tensor).reshape(nfreq,nvol,ns,ns,norb,ns,ns,norb)
 
                     ham = xp.einsum('ksauatbvb->ksuatvb',
-                                    ham_orig.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(ns,ns,norb)*2)
+                                    ham_long.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(ns,ns,norb)*2)
 
                 else:
                     nblock,nfreq,nvol,norb1,norb2,norb3,norb4 = chi0q_orig.shape
@@ -1016,12 +1082,13 @@ class RPA:
                     chi0q = xp.einsum('glkabcd,gtuv->lkgatbucvd',
                                       chi0q_orig,
                                       spin_tensor).reshape(nfreq,nvol,nd,nd,nd,nd)
-                    ham = ham_orig
+                    ham = ham_long
 
             elif self.spin_mode == "spin-free":
                 # introduce spin degree of freedom
                 chi0q_orig = chi0q
                 ham_orig = ham_inter_q
+                ham_long = ham_long_q
 
                 if self.calc_scheme == "reduced":
                     # alpha=alpha', beta=beta' case
@@ -1037,7 +1104,7 @@ class RPA:
                                       spin_tensor).reshape(nfreq,nvol,nd,nd)
 
                     ham = xp.einsum('ksasatbtb->ksatb',
-                                    ham_orig.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(nd,)*2)
+                                    ham_long.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(nd,)*2)
 
                 elif self.calc_scheme == "squashed":
                     # norb**2 squash
@@ -1056,7 +1123,7 @@ class RPA:
                                       spin_tensor).reshape(nfreq,nvol,ns,ns,norb,ns,ns,norb)
 
                     ham = xp.einsum('ksauatbvb->ksuatvb',
-                                    ham_orig.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(ns,ns,norb)*2)
+                                    ham_long.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(ns,ns,norb)*2)
 
                 else:
                     # general nd**4 case
@@ -1073,7 +1140,7 @@ class RPA:
                     chi0q = xp.einsum('lkabcd,stuv->lksatbucvd',
                                       chi0q_orig.reshape(nfreq,nvol,norb,norb,norb,norb),
                                       spin_tensor).reshape(nfreq,nvol,nd,nd,nd,nd)
-                    ham = ham_orig
+                    ham = ham_long
 
             # A reused green_info must not carry results from a previous
             # solve: if this run fails validation, or computes ring-only after

--- a/tests/test_rpa_2orb.py
+++ b/tests/test_rpa_2orb.py
@@ -163,14 +163,21 @@ class RPATwoOrbital:
                 chi0 = chi0q[:,:,:,:, idqx, idqy,Nmat//2]
                 Vxq = V*(1.0+np.exp(-1J*kx))
                 Vyq = 2.0*V*np.cos(ky)
-                X0 = np.array(([chi0[0][0][0][0], 0, 0, chi0[0][0][1][1], 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0],
-                                [chi0[1][1][0][0], 0, 0, chi0[1][1][1][1], 0, 0, 0, 0],
-                                [0, 0, 0, 0, chi0[0][0][0][0], 0, 0, chi0[0][0][1][1]],
-                                [0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, chi0[1][1][0][0], 0, 0, chi0[1][1][1][1]]), dtype=np.complex128)
+                # FULL pair-space bubble per spin block. The historical
+                # truncation to the palindromic slots ((aa), (bb)) was exact
+                # as long as W had support only there: with column support
+                # restricted to those slots, [I + X0 W]^{-1} X0 restricted to
+                # them never reads the other X0 entries. The #104 fix adds
+                # vertex content on the (ab), (ba) slots, which couples the
+                # sectors, so the bubble must carry its full pair structure.
+                X0 = np.zeros((8, 8), dtype=np.complex128)
+                for sblk in (0, 4):
+                    for a in range(2):
+                        for c in range(2):
+                            for b in range(2):
+                                for d in range(2):
+                                    X0[sblk + 2*a + c, sblk + 2*b + d] = \
+                                        chi0[a][c][b][d]
                 W =  np.array([[Vyq, 0, 0, np.conj(Vxq), U+Vyq, 0, 0, np.conj(Vxq)],
                                 [0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0],
@@ -179,7 +186,23 @@ class RPATwoOrbital:
                                 [0, 0, 0, 0, 0, 0, 0, 0],
                                 [0, 0, 0, 0, 0, 0, 0, 0],
                                 [Vxq, 0, 0, U+Vyq, Vxq, 0, 0, Vyq]], dtype=np.complex128)
-                X = np.linalg.inv(I + X0 @ W.T) @ X0
+                # Adjudicated longitudinal cross-slot (Fierz) content
+                # (#104/#113): the ON-SITE part of the inter-orbital V
+                # carries a same-spin coupling -V on the (ab), (ba) pair
+                # slots -- the spin/charge decomposition of these entries is
+                # S(ab,ab) = +V, C(ab,ab) = -V, the exact-diagonalization
+                # values. The off-site parts (Vxq phase, Vyq) stay as they
+                # were: off-site cross-orbital content is not representable
+                # by a q-only vertex and remains outside the adjudication.
+                # solved with W + Fierz; ham keeps the base tensor, which
+                # is what the solver stores in ham_inter_q (its Fierz part
+                # lives in the separate ham_fierz_q, exactly so that the
+                # transverse assembly keeps reading the base tensor)
+                W_solve = W.copy()
+                V_on = V
+                for slot in (1, 2, 5, 6):
+                    W_solve[slot, slot] += -V_on
+                X = np.linalg.inv(I + X0 @ W_solve.T) @ X0
 
                 ham[idqx,idqy,:,:] = W
                 chi[idqx,idqy,:,:] = X

--- a/tests/test_rpa_coulomb_keyword.py
+++ b/tests/test_rpa_coulomb_keyword.py
@@ -60,6 +60,13 @@ class TestRPACoulombKeyword(unittest.TestCase):
         np.testing.assert_allclose(
             obj_c.ham_inter_q, obj_ref.ham_inter_q, rtol=0.0, atol=1e-12,
             err_msg="'Coulomb' must equal CoulombIntra + CoulombInter")
+        # the Fierz correction (#104) must also agree between the two routes:
+        # the fixture has an on-site inter-orbital entry, so it is nonempty
+        self.assertIsNotNone(obj_c.ham_fierz_q)
+        self.assertIsNotNone(obj_ref.ham_fierz_q)
+        np.testing.assert_allclose(
+            obj_c.ham_fierz_q, obj_ref.ham_fierz_q, rtol=0.0, atol=1e-12,
+            err_msg="aggregate and explicit Fierz tensors must agree")
 
     def test_coulomb_conflicts_with_explicit_terms(self):
         norb = 1

--- a/tests/test_rpa_flex_oneshot_equivalence.py
+++ b/tests/test_rpa_flex_oneshot_equivalence.py
@@ -190,19 +190,37 @@ class TestFierzDomain(unittest.TestCase):
         self.assertIsNone(hi.ham_fierz_q)
 
     def test_fierz_support_sits_on_the_cross_slots_only(self):
-        # exact support: on-site inter-orbital V at 2 orbitals, no folding.
-        # nd = 4 (spin-major: 0=(up,0), 1=(up,1), 2=(dn,0), 3=(dn,1)); the
-        # same-spin pair-diagonal entries (a,b,a,b) carry -V and nothing
-        # else is populated
-        hi = self._ham_info(2, {((0, 0, 0), (0, 1)): 0.7,
-                                ((0, 0, 0), (1, 0)): 0.7}, [1, 1, 1])
-        f = np.asarray(hi.ham_fierz_q).reshape(4, 4, 4, 4, 4)[0]
-        want = np.zeros((4, 4, 4, 4), dtype=complex)
-        for up_a, up_b, dn_a, dn_b in ((0, 1, 2, 3),):
-            for a, b in ((up_a, up_b), (up_b, up_a),
-                         (dn_a, dn_b), (dn_b, dn_a)):
-                want[a, b, a, b] = -0.7
-        np.testing.assert_allclose(f, want, atol=1e-13)
+        # exact support per type: on-site inter-orbital entries at 2
+        # orbitals, no folding. nd = 4 (spin-major: 0=(up,0), 1=(up,1),
+        # 2=(dn,0), 3=(dn,1)); the pair-diagonal entries (a,b,a,b) carry
+        # the adjudicated coefficient -- same-spin for CoulombInter (-V),
+        # Hund (+J) and Ising (-I), cross-spin for Exchange (+J') -- and
+        # nothing else is populated
+        J = 0.7
+        up = {0: 0, 1: 1}
+        dn = {0: 2, 1: 3}
+        same = [(up, up), (dn, dn)]
+        cross = [(up, dn), (dn, up)]
+        table = {
+            'CoulombInter': (-J, same),
+            'Hund': (+J, same),
+            'Ising': (-J, same),
+            'Exchange': (+J, cross),
+        }
+        for key, (coeff, blocks) in table.items():
+            with self.subTest(interaction=key):
+                hi = self._ham_info(2, {((0, 0, 0), (0, 1)): J,
+                                        ((0, 0, 0), (1, 0)): J},
+                                    [1, 1, 1], key=key)
+                f = np.asarray(hi.ham_fierz_q).reshape(4, 4, 4, 4, 4)[0]
+                want = np.zeros((4, 4, 4, 4), dtype=complex)
+                for s_bra, s_ket in blocks:
+                    for a, b in ((0, 1), (1, 0)):
+                        want[s_bra[a], s_bra[b],
+                             s_ket[a], s_ket[b]] = coeff
+                np.testing.assert_allclose(
+                    f, want, atol=1e-13,
+                    err_msg="%s Fierz support" % key)
 
     def test_aggregate_coulomb_fierz_equals_explicit(self):
         # under folding the aggregate path must split the PRE-fold table

--- a/tests/test_rpa_flex_oneshot_equivalence.py
+++ b/tests/test_rpa_flex_oneshot_equivalence.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""RPA == FLEX at one shot, across calc_schemes (#107 phase 1, #104 fix).
+
+RPA is the one-shot limit of FLEX (one iteration, no self-energy feedback,
+bare Green function). These tests pin the measured equivalence matrix:
+
+* reduced / squashed: equal to ~1e-13 in every interaction cell (measured
+  before the #104 fix and unchanged by it -- the Fierz slots sit off the
+  density diagonal those schemes read).
+* general: the multi-orbital on-site cells (inter-orbital CoulombInter,
+  Hund, combined U+V+J) disagreed by up to 1.2e-2 while #104 was open --
+  the ring's longitudinal W lacked the adjudicated Fierz cross-slot
+  content -- and must now be element-complete equal.
+* spin modes: the corrected W is shared by every spin mode, so a
+  spin-symmetric system solved in spin-diag mode (two identical bubble
+  blocks) must reproduce the spin-free result bit for bit.
+
+The spin/charge mapping (chi_s = chi_uu - chi_ud, chi_c = chi_uu + chi_ud on
+the spin blocks of RPA's chiq) was verified on the CoulombIntra control,
+where the two solvers agreed both before and after the fix.
+"""
+
+import os
+import unittest
+
+import numpy as np
+
+
+def _read(path, interactions):
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    idict = {'path_to_input': path, 'Geometry': 'geom.dat',
+             'Transfer': 'transfer.dat'}
+    idict.update(interactions)
+    return read_input_k.QLMSkInput({'path_to_input': path,
+                                    'interaction': idict})
+
+
+def _run(scheme, solver, path, interactions, filling):
+    import hwave.solver.rpa as rpa_mod
+    import hwave.solver.flex as flex_mod
+
+    r = _read(path, interactions)
+    ham = r.get_param("ham")
+    par = {'T': 2.0, 'filling': filling, 'CellShape': [4, 4, 1],
+           'SubShape': [1, 1, 1], 'Nmat': 32}
+    if solver == 'rpa':
+        sv = rpa_mod.RPA(ham, {}, {'mode': 'RPA', 'param': par,
+                                   'enable_spin_orbital': False,
+                                   'calc_scheme': scheme,
+                                   'calc_type': 'ring'})
+    else:
+        pf = dict(par)
+        pf.update({'IterationMax': 1, 'Mix': 1.0, 'EPS': 1})
+        sv = flex_mod.FLEX(ham, {}, {'mode': 'FLEX', 'param': pf,
+                                     'enable_spin_orbital': False,
+                                     'calc_scheme': scheme})
+    g = r.get_param("green")
+    os.makedirs('tests/rpa/output', exist_ok=True)
+    sv.solve(g, 'tests/rpa/output')
+    return g
+
+
+class TestGeneralSchemeOneShot(unittest.TestCase):
+    """The cells that carried the #104 deficiency, element-complete."""
+
+    CASES = [
+        ("inter-orbital V", {'CoulombInter': 'onsite_inter.dat'}),
+        ("Hund", {'Hund': 'hund_onsite.dat'}),
+        ("U+V+J", {'CoulombIntra': 'coulombintra.dat',
+                   'CoulombInter': 'onsite_inter.dat',
+                   'Hund': 'hund_onsite.dat'}),
+    ]
+
+    def test_multiorbital_onsite_cells_match_flex(self):
+        norb = 2
+        for name, inter in self.CASES:
+            with self.subTest(interaction=name):
+                gr = _run('general', 'rpa', 'tests/rpa/input_2orb',
+                          inter, 0.5)
+                gf = _run('general', 'flex', 'tests/rpa/input_2orb',
+                          inter, 0.5)
+                np.testing.assert_allclose(
+                    np.asarray(gf['chi0q']), np.asarray(gr['chi0q']),
+                    rtol=0.0, atol=1e-12)
+                chiq = np.asarray(gr['chiq'])
+                cs = np.asarray(gf['chiq_s'])
+                cc = np.asarray(gf['chiq_c'])
+                recon = np.zeros_like(chiq)
+                same = 0.5 * (cc + cs)
+                diff = 0.5 * (cc - cs)
+                for s1 in (0, 1):
+                    for s2 in (0, 1):
+                        blk = same if s1 == s2 else diff
+                        recon[:, :,
+                              s1*norb:(s1+1)*norb, s1*norb:(s1+1)*norb,
+                              s2*norb:(s2+1)*norb, s2*norb:(s2+1)*norb] = blk
+                np.testing.assert_allclose(
+                    chiq, recon, rtol=0.0, atol=1e-12,
+                    err_msg="%s: the ring must reproduce the FLEX channel "
+                            "solve element-complete (this cell was 1e-2 off "
+                            "while #104 was open)" % name)
+
+
+class TestReducedSquashedOneShot(unittest.TestCase):
+    """reduced/squashed were equal before the #104 fix and must stay equal:
+    the Fierz slots sit off the density diagonal these schemes read."""
+
+    def _blocks(self, cq, norb):
+        if cq.ndim == 8:
+            # squashed layout: chiq[w, k, s1, s1', a, s2, s2', b]
+            uu = cq[:, :, 0, 0, :, 0, 0, :]
+            ud = cq[:, :, 0, 0, :, 1, 1, :]
+        else:
+            uu = cq[:, :, :norb, :norb]
+            ud = cq[:, :, :norb, norb:]
+        return uu, ud
+
+    def test_matrix_cells(self):
+        cases = [
+            ('tests/rpa/input', {'CoulombInter': 'coulombinter.dat'},
+             0.75, 1),
+            ('tests/rpa/input_2orb', {'CoulombIntra': 'coulombintra.dat',
+                                      'CoulombInter': 'onsite_inter.dat',
+                                      'Hund': 'hund_onsite.dat'},
+             0.5, 2),
+        ]
+        for scheme in ('reduced', 'squashed'):
+            for path, inter, filling, norb in cases:
+                with self.subTest(scheme=scheme, path=path):
+                    gr = _run(scheme, 'rpa', path, inter, filling)
+                    gf = _run(scheme, 'flex', path, inter, filling)
+                    uu, ud = self._blocks(np.asarray(gr['chiq']), norb)
+                    cs = np.asarray(gf['chiq_s'])[:, :, :norb, :norb]
+                    cc = np.asarray(gf['chiq_c'])[:, :, :norb, :norb]
+                    np.testing.assert_allclose(uu - ud, cs,
+                                               rtol=0.0, atol=1e-12)
+                    np.testing.assert_allclose(uu + ud, cc,
+                                               rtol=0.0, atol=1e-12)
+
+
+class TestSpinModeConsistency(unittest.TestCase):
+
+    def test_spin_diag_matches_spin_free_on_symmetric_input(self):
+        """A spin-symmetric system solved in spin-diag mode (two identical
+        bubble blocks through the chi0q_init route) must reproduce the
+        spin-free chiq bit for bit. The corrected longitudinal W is one
+        tensor shared by every spin mode, so the #104 fix applies to
+        spin-resolved runs identically -- this is what a channel-level
+        patch of the spin-free path alone could not have guaranteed."""
+        import hwave.solver.rpa as rpa_mod
+
+        inter = {'CoulombInter': 'onsite_inter.dat'}
+        gr = _run('general', 'rpa', 'tests/rpa/input_2orb', inter, 0.5)
+        chi0q_free = np.asarray(gr['chi0q'])
+        chiq_free = np.asarray(gr['chiq'])
+
+        out = 'tests/rpa/output'
+        np.savez(os.path.join(out, 'chi0q_diag_su2test.npz'),
+                 chi0q=np.stack([chi0q_free, chi0q_free], axis=0))
+        try:
+            r = _read('tests/rpa/input_2orb', inter)
+            par = {'T': 2.0, 'filling': 0.5, 'CellShape': [4, 4, 1],
+                   'SubShape': [1, 1, 1], 'Nmat': 32}
+            rpa = rpa_mod.RPA(r.get_param("ham"), {},
+                              {'mode': 'RPA', 'param': par,
+                               'enable_spin_orbital': False,
+                               'calc_scheme': 'general',
+                               'calc_type': 'ring'})
+            g = r.get_param("green")
+            g.update(rpa.read_init({'path_to_input': out,
+                                    'chi0q_init': 'chi0q_diag_su2test.npz'}))
+            rpa.solve(g, out)
+            self.assertEqual(rpa.spin_mode, "spin-diag")
+            np.testing.assert_array_equal(np.asarray(g['chiq']), chiq_free)
+        finally:
+            os.remove(os.path.join(out, 'chi0q_diag_su2test.npz'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_flex_oneshot_equivalence.py
+++ b/tests/test_rpa_flex_oneshot_equivalence.py
@@ -139,6 +139,59 @@ class TestReducedSquashedOneShot(unittest.TestCase):
                                                rtol=0.0, atol=1e-12)
 
 
+class TestFierzDomain(unittest.TestCase):
+    """The correction applies exactly on the adjudicated domain: on-site
+    inter-orbital entries of the PRE-fold table. Folding maps an off-site
+    bond to (0,0,0) between supercell orbitals, so judging locality on the
+    folded table smuggled unadjudicated off-site content into the
+    correction (a one-orbital +-x bond folded with SubShape=[2,1,1]
+    produced a spurious Fierz tensor of magnitude V)."""
+
+    def _ham_info(self, norb, entries, sub, key='CoulombInter'):
+        import hwave.solver.rpa as rpa_mod
+
+        param_ham = {'Geometry': {'norb': norb, 'rvec': np.eye(3),
+                                  'center': [[0, 0, 0]] * norb},
+                     'Transfer': {((0, 0, 0), (0, 0)): 1.0},
+                     key: entries}
+        info = {'mode': 'RPA', 'param': {'T': 2.0, 'filling': 0.5,
+                'CellShape': [4, 1, 1], 'SubShape': list(sub), 'Nmat': 4},
+                'enable_spin_orbital': False, 'calc_scheme': 'general',
+                'calc_type': 'ring'}
+        return rpa_mod.RPA(param_ham, {}, info).ham_info
+
+    def test_folded_offsite_bond_is_a_fierz_noop(self):
+        hi = self._ham_info(1, {((1, 0, 0), (0, 0)): 0.7,
+                                ((-1, 0, 0), (0, 0)): 0.7}, [2, 1, 1])
+        self.assertIsNone(hi.ham_fierz_q)
+
+    def test_folded_onsite_interorbital_keeps_the_correction(self):
+        hi = self._ham_info(2, {((0, 0, 0), (0, 1)): 0.7,
+                                ((0, 0, 0), (1, 0)): 0.7}, [2, 1, 1])
+        self.assertIsNotNone(hi.ham_fierz_q)
+        self.assertAlmostEqual(float(np.max(np.abs(hi.ham_fierz_q))),
+                               0.7, places=12)
+
+    def test_intra_only_and_one_orbital_have_no_fierz(self):
+        hi = self._ham_info(1, {((0, 0, 0), (0, 0)): 4.0}, [1, 1, 1],
+                            key='CoulombIntra')
+        self.assertIsNone(hi.ham_fierz_q)
+        hi = self._ham_info(1, {((1, 0, 0), (0, 0)): 0.7,
+                                ((-1, 0, 0), (0, 0)): 0.7}, [1, 1, 1])
+        self.assertIsNone(hi.ham_fierz_q)
+
+    def test_aggregate_coulomb_fierz_equals_explicit(self):
+        # under folding the aggregate path must split the PRE-fold table
+        explicit = self._ham_info(2, {((0, 0, 0), (0, 1)): 0.7,
+                                      ((0, 0, 0), (1, 0)): 0.7}, [2, 1, 1])
+        aggregate = self._ham_info(
+            2, {((0, 0, 0), (0, 1)): 0.7, ((0, 0, 0), (1, 0)): 0.7,
+                ((0, 0, 0), (0, 0)): 2.0, ((0, 0, 0), (1, 1)): 2.0},
+            [2, 1, 1], key='Coulomb')
+        np.testing.assert_allclose(aggregate.ham_fierz_q,
+                                   explicit.ham_fierz_q, atol=1e-13)
+
+
 class TestSpinModeConsistency(unittest.TestCase):
 
     def test_spin_diag_matches_spin_free_on_symmetric_input(self):
@@ -155,7 +208,9 @@ class TestSpinModeConsistency(unittest.TestCase):
         chi0q_free = np.asarray(gr['chi0q'])
         chiq_free = np.asarray(gr['chiq'])
 
-        out = 'tests/rpa/output'
+        import tempfile
+
+        out = tempfile.mkdtemp()
         np.savez(os.path.join(out, 'chi0q_diag_su2test.npz'),
                  chi0q=np.stack([chi0q_free, chi0q_free], axis=0))
         try:
@@ -174,7 +229,9 @@ class TestSpinModeConsistency(unittest.TestCase):
             self.assertEqual(rpa.spin_mode, "spin-diag")
             np.testing.assert_array_equal(np.asarray(g['chiq']), chiq_free)
         finally:
-            os.remove(os.path.join(out, 'chi0q_diag_su2test.npz'))
+            import shutil
+
+            shutil.rmtree(out, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_rpa_flex_oneshot_equivalence.py
+++ b/tests/test_rpa_flex_oneshot_equivalence.py
@@ -180,6 +180,30 @@ class TestFierzDomain(unittest.TestCase):
                                 ((-1, 0, 0), (0, 0)): 0.7}, [1, 1, 1])
         self.assertIsNone(hi.ham_fierz_q)
 
+    def test_folded_offsite_aggregate_is_a_fierz_noop(self):
+        # the aggregate path must also judge locality pre-fold: an off-site
+        # same-orbital bond arriving through 'Coulomb' folds to (0,0,0)
+        # between supercell orbitals just like the explicit table
+        hi = self._ham_info(1, {((1, 0, 0), (0, 0)): 0.7,
+                                ((-1, 0, 0), (0, 0)): 0.7}, [2, 1, 1],
+                            key='Coulomb')
+        self.assertIsNone(hi.ham_fierz_q)
+
+    def test_fierz_support_sits_on_the_cross_slots_only(self):
+        # exact support: on-site inter-orbital V at 2 orbitals, no folding.
+        # nd = 4 (spin-major: 0=(up,0), 1=(up,1), 2=(dn,0), 3=(dn,1)); the
+        # same-spin pair-diagonal entries (a,b,a,b) carry -V and nothing
+        # else is populated
+        hi = self._ham_info(2, {((0, 0, 0), (0, 1)): 0.7,
+                                ((0, 0, 0), (1, 0)): 0.7}, [1, 1, 1])
+        f = np.asarray(hi.ham_fierz_q).reshape(4, 4, 4, 4, 4)[0]
+        want = np.zeros((4, 4, 4, 4), dtype=complex)
+        for up_a, up_b, dn_a, dn_b in ((0, 1, 2, 3),):
+            for a, b in ((up_a, up_b), (up_b, up_a),
+                         (dn_a, dn_b), (dn_b, dn_a)):
+                want[a, b, a, b] = -0.7
+        np.testing.assert_allclose(f, want, atol=1e-13)
+
     def test_aggregate_coulomb_fierz_equals_explicit(self):
         # under folding the aggregate path must split the PRE-fold table
         explicit = self._ham_info(2, {((0, 0, 0), (0, 1)): 0.7,

--- a/tests/test_rpa_ladder.py
+++ b/tests/test_rpa_ladder.py
@@ -805,15 +805,13 @@ class TestRPALadder(unittest.TestCase):
                 self.assertLess(
                     float(np.max(np.abs(captured["ham_pm"]))), 1e-12)
 
-    @unittest.expectedFailure
     def test_su2_onsite_coulombinter_2orb_equality(self):
-        """The CORRECT physics, stated as such: SU(2) holds exactly for
-        on-site CoulombInter, so chi_zz must equal chi_pm.
-
-        Expected to fail while #104 is open (the longitudinal ring drops the
-        inter-orbital spin vertex). When #104 is fixed this flips to an
-        unexpected success, which unittest reports as a failure -- remove the
-        decorator then, and retire the signature test below.
+        """SU(2) holds exactly for on-site CoulombInter, so chi_zz must
+        equal chi_pm. This failed while #104 was open (the longitudinal ring
+        dropped the inter-orbital spin vertex, measured at 1e-2 in chiq); the
+        adjudicated Fierz cross-slot content restored the identity -- the
+        residual dropped from 3e-3 to 4e-34 with the transverse side
+        untouched.
         """
         solver, green_info = self._run_rpa(
             calc_type="ring+ladder", calc_scheme="general",
@@ -882,21 +880,12 @@ class TestRPALadder(unittest.TestCase):
                     Lx=4, Ly=4, Nmat=32, interactions=inter)
                 self.assertIn("chiq_pm", green_info)
 
-    def test_su2_onsite_coulombinter_2orb(self):
-        """On-site CoulombInter at two orbitals: SU(2) must hold, and does not.
-
-        `U' n_a n_b` is built from total densities, which are SU(2) scalars, so
-        the Hamiltonian stays SU(2) symmetric and `chi^{+-} = 2 chi^{zz}` is an
-        exact identity -- verified by diagonalization to 1e-15, including at
-        three times the coupling. The check is therefore valid.
-
-        It fails because the LONGITUDINAL ring is the deficient side: its
-        effective spin vertex is `diag(U_0, 0, 0, U_1)` where `sc.py` and exact
-        diagonalization both give `diag(U_0, U', U', U_1)`. That is issue #104.
-        This test is the detector for it and should start passing when #104 is
-        fixed; it must NOT be made to pass by removing U' from the transverse
-        side as well.
-        """
+    def test_su2_onsite_coulombinter_2orb_no_residual_anywhere(self):
+        """Retired #104 signature test, inverted: while the issue was open,
+        the chi_zz / chi_pm mismatch sat exactly on the U' pair slots (0,1)
+        and (1,0) at 3e-3 and nowhere else. With the adjudicated cross-slot
+        content in the longitudinal W, the mismatch must be gone EVERYWHERE
+        -- including those slots -- not merely reduced."""
         solver, green_info = self._run_rpa(
             calc_type="ring+ladder", calc_scheme="general",
             input_path='tests/rpa/input_2orb', Lx=4, Ly=4, Nmat=32,
@@ -918,22 +907,8 @@ class TestRPALadder(unittest.TestCase):
                         zz[:, i, j] = (chiq[iw0, :, a, c, b, d]
                                        - chiq[iw0, :, a, c, norb + b, norb + d])
                         pm[:, i, j] = chiq_pm[iw0, :, a, c, b, d]
-        # The mismatch must sit where the U' vertex acts -- the off-orbital
-        # pair slots (0,1) and (1,0) -- with the measured magnitude, and
-        # NOWHERE else. A generic assertRaises would also pass for unrelated
-        # regressions; this pins the specific #104 signature.
-        offs = [0 * norb + 1, 1 * norb + 0]
-        diff = np.abs(zz - pm)
-        mask = np.zeros((npair, npair), dtype=bool)
-        for i in offs:
-            for j in offs:
-                mask[i, j] = True
-        off_max = float(np.max(diff[:, mask]))
-        self.assertGreater(off_max, 3e-3,
-                           "the U' slots must disagree while #104 is open")
-        # and NOWHERE else: every element outside the expected slots agrees
-        self.assertLess(float(np.max(diff[:, ~mask])), 1e-10,
-                        "the mismatch must be confined to the U' slots")
+        self.assertLess(float(np.max(np.abs(zz - pm))), 1e-10,
+                        "chi_zz and chi_pm must agree in every pair slot")
 
     def test_su2_onsite_coulombintra_2orb(self):
         """CoulombIntra at two orbitals: SU(2) holds and the ring is correct


### PR DESCRIPTION
Fixes #104. Second deliverable of #107 phase 1 (the one-shot equivalence matrix, recorded in that issue).

## Problem

The ring's rank-4 interaction tensor carried the density `(aa,bb)` slots of each interaction type but not the `(ab,ab)` pair-cross slots. Its effective spin vertex for on-site inter-orbital input was `diag(U0, 0, 0, U1)` where exact diagonalization and the pairing-vertex builders both give `diag(U0, U', U', U1)` (#104). Measured against the FLEX channel solve at one shot: inter-orbital V off by 1.0e-2, Hund 1.2e-2, U+V+J 3.9e-3 in chiq.

## Fix

The missing spin-resolved content follows from the adjudicated spin/charge table via `W_same = (C−S)/2`, `W_cross = (C+S)/2` per slot, anchored on the slot families the ring already had right. Additions (on-site a≠b only — the adjudicated domain): CoulombInter −U′ same-spin, Hund +J same-spin, Ising −I same-spin, Exchange +J′ cross-spin, at the (ab,ab) slots. The orientation was selected by measurement (element-complete agreement at 3e-16 vs exact reproduction of the old deficiency).

The corrections live in a **separate tensor** added to the longitudinal solve only: the transverse (ladder) assembly keeps reading the base tensor, because the cross-spin Exchange correction would otherwise land in the very block the ladder assembly reads via the crossing relation and double its adjudicated vertex (measured −0.7 → −1.4). reduced/squashed schemes read the density diagonal and are untouched.

## Verified consequences

- RPA general == FLEX one-shot, element-complete, in every adjudicated cell (was 1e-2 off)
- SU(2) restored: chi_zz == chi_pm for on-site CoulombInter under ring+ladder (3e-3 → 4e-34); the expectedFailure sentinel retired per its own instructions
- spin-diag == spin-free bit-for-bit on a spin-symmetric system — one shared W fixes every spin mode
- The independent two-orbital reference model updated with the same content (and its full pair-space bubble; the old palindromic truncation was exact only for the old W support) and agrees with the solver
- reduced/squashed equivalence with FLEX re-verified at 1e-13

## Behavior change

RPA chiq for multi-orbital systems with on-site inter-orbital interactions changes by up to ~1e-2. This is the #104 bug fix; single-orbital and U-only results are unchanged.

Full suite: 987 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCUFFn4bpcC6yLt3TLYgBC