### PR TITLE
Single-source the adjudicated vertex content

### DIFF
--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -17,6 +17,8 @@ import sys
 import logging
 
 import numpy as np
+
+from hwave.solver.vertex_table import sc_coefficients
 from numpy.fft import fftn, ifftn
 from scipy.optimize import bisect
 from scipy.sparse.linalg import LinearOperator, eigs, bicgstab, gmres, lgmres
@@ -906,45 +908,32 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
     # CoulombInter contributes 2 V_aa(q) to the charge channel.
     mask1 = (l1f == l2f) & (l2f == l3f) & (l3f == l4f)
     if U_mat is not None and np.any(mask1):
+        sU, cU = sc_coefficients("CoulombIntra", "diag")
         for i in np.where(mask1)[0]:
             _l = l1f[i]
-            S_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
-            C_all[:, :, :, idx12[i], idx34[i]] += U_mat[_l, _l]
+            S_all[:, :, :, idx12[i], idx34[i]] += sU * U_mat[_l, _l]
+            C_all[:, :, :, idx12[i], idx34[i]] += cU * U_mat[_l, _l]
 
     # Case 2: l1==l3, l2==l4, l1!=l2
+    # Coefficients come from the single adjudicated table
+    # (hwave.solver.vertex_table). Signs, slots and per-type factors were
+    # established against exact diagonalization in #113 (Ising sign, the
+    # previously missing Hund S term, Exchange moved here from the
+    # pair-antidiagonal Case 4); the SU(2) Kanamori consistency check --
+    # Hund + Exchange at equal J giving S(ab,ab) without J and
+    # C(ab,ab) = -U' + 2J -- is pinned in the tests.
     mask2 = (l1f == l3f) & (l2f == l4f) & (l1f != l2f)
+    cross_terms = [(Up_mat, "CoulombInter"), (I_mat, "Ising"),
+                   (J_mat, "Hund"), (Jp_mat, "Exchange")]
     for i in np.where(mask2)[0]:
         s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         _l1, _l2 = l1f[i], l2f[i]
-        if Up_mat is not None:
-            s_q += Up_mat[_l1, _l2]
-            c_q -= Up_mat[_l1, _l2]
-        if I_mat is not None:
-            # SIGN adjudicated by exact diagonalization (issue #113): the
-            # exact spin vertex carries -I at this slot in the
-            # [I + chi0 W]^-1 convention, i.e. +I here (S enters as -S).
-            # The previous -I produced the wrong sign end to end.
-            s_q += I_mat[_l1, _l2]
-            c_q -= I_mat[_l1, _l2]
-        if J_mat is not None:
-            # Hund contributes to BOTH channels at this slot (issue #113):
-            # the exact vertices are W_zz = +J and W_cc = +J, i.e. S -= J and
-            # C += J. The S term was missing entirely.
-            s_q -= J_mat[_l1, _l2]
-            c_q += J_mat[_l1, _l2]
-        if Jp_mat is not None:
-            # Exchange lives HERE, not in the pair-antidiagonal Case 4 where
-            # it sat before (issue #113): exact diagonalization puts its
-            # vertex at this slot family in both channels, W_zz = -J and
-            # W_cc = +J, i.e. S += J and C += J. Consistency check that this
-            # split is right: for the SU(2) Kanamori combination
-            # (Hund + Exchange at equal J) the channel matrices become
-            # S(ab,ab) with no J at all and C(ab,ab) = -U' + 2J -- exactly
-            # the standard literature result, which the previous bookkeeping
-            # reproduced in neither channel per type.
-            s_q += Jp_mat[_l1, _l2]
-            c_q += Jp_mat[_l1, _l2]
+        for mat, itype in cross_terms:
+            if mat is not None:
+                sco, cco = sc_coefficients(itype, "cross")
+                s_q += sco * mat[_l1, _l2]
+                c_q += cco * mat[_l1, _l2]
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
@@ -963,13 +952,15 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
         c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         _l1, _l3 = l1f[i], l3f[i]
         if _l1 != _l3:
-            if J_mat is not None:
-                s_q += J_mat[_l1, _l3]
-                c_q -= J_mat[_l1, _l3]
-            if I_mat is not None:
-                s_q -= 2.0 * I_mat[_l1, _l3]
+            for mat, itype in ((J_mat, "Hund"), (I_mat, "Ising")):
+                if mat is not None:
+                    sco, cco = sc_coefficients(itype, "density")
+                    s_q += sco * mat[_l1, _l3]
+                    c_q += cco * mat[_l1, _l3]
         if Up_mat is not None:
-            c_q += 2.0 * Up_mat[_l1, _l3]
+            sco, cco = sc_coefficients("CoulombInter", "density")
+            s_q += sco * Up_mat[_l1, _l3]
+            c_q += cco * Up_mat[_l1, _l3]
         S_all[:, :, :, idx12[i], idx34[i]] += s_q
         C_all[:, :, :, idx12[i], idx34[i]] += c_q
 
@@ -977,15 +968,18 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
     mask4 = (l1f == l4f) & (l2f == l3f) & (l1f != l2f)
     for i in np.where(mask4)[0]:
         s_q = np.zeros((Nx, Ny, Nz), dtype=complex)
+        c_q = np.zeros((Nx, Ny, Nz), dtype=complex)
         _l1, _l2 = l1f[i], l2f[i]
         # Exchange used to sit here; exact diagonalization (issue #113) puts
         # its vertex on the pair-DIAGONAL slot family (Case 2), and end to end
         # the antidiagonal placement produced the right magnitude at the wrong
         # slots in both channels. Only PairHop belongs here (#100/#102).
         if PH_mat is not None:
-            s_q += PH_mat[_l1, _l2]
+            sco, cco = sc_coefficients("PairHop", "antidiag")
+            s_q += sco * PH_mat[_l1, _l2]
+            c_q += cco * PH_mat[_l1, _l2]
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
-        C_all[:, :, :, idx12[i], idx34[i]] = s_q  # S = C for this channel
+        C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
     return S_all, C_all
 

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -846,6 +846,26 @@ def _symmetrise_interactions_k(inter_k):
     return out
 
 
+def _accumulate_coeff(dst, coeff, value):
+    """dst += coeff * value with IEEE-preserving forms.
+
+    NumPy evaluates ``1.0 * (Inf+0j)`` as ``Inf+NaNj`` (a full complex
+    multiply), while a direct add preserves the zero imaginary part, so
+    the +-1 coefficients of the vertex table must use direct add/subtract
+    to keep the pre-table behavior for non-finite couplings. Zero
+    coefficients suppress the contribution entirely (0.0 * Inf is NaN).
+    ``dst`` must be an ndarray or writeable view; the update is in place.
+    """
+    if coeff == 0.0:
+        return
+    if coeff == 1.0:
+        dst += value
+    elif coeff == -1.0:
+        dst -= value
+    else:
+        dst += coeff * value
+
+
 def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
                              _presymmetrised=False):
     """Build spin (S) and charge (C) interaction matrices for all q-points at once.
@@ -911,8 +931,10 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
         sU, cU = sc_coefficients("CoulombIntra", "diag")
         for i in np.where(mask1)[0]:
             _l = l1f[i]
-            S_all[:, :, :, idx12[i], idx34[i]] += sU * U_mat[_l, _l]
-            C_all[:, :, :, idx12[i], idx34[i]] += cU * U_mat[_l, _l]
+            _accumulate_coeff(S_all[:, :, :, idx12[i], idx34[i]],
+                              sU, U_mat[_l, _l])
+            _accumulate_coeff(C_all[:, :, :, idx12[i], idx34[i]],
+                              cU, U_mat[_l, _l])
 
     # Case 2: l1==l3, l2==l4, l1!=l2
     # Coefficients come from the single adjudicated table
@@ -932,13 +954,8 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
         for mat, itype in cross_terms:
             if mat is not None:
                 sco, cco = sc_coefficients(itype, "cross")
-                # explicit zero suppression: 0.0 * Inf is NaN, and a
-                # channel with no content for a type must stay untouched
-                # even for non-finite input
-                if sco != 0.0:
-                    s_q += sco * mat[_l1, _l2]
-                if cco != 0.0:
-                    c_q += cco * mat[_l1, _l2]
+                _accumulate_coeff(s_q, sco, mat[_l1, _l2])
+                _accumulate_coeff(c_q, cco, mat[_l1, _l2])
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
@@ -960,16 +977,12 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
             for mat, itype in ((J_mat, "Hund"), (I_mat, "Ising")):
                 if mat is not None:
                     sco, cco = sc_coefficients(itype, "density")
-                    if sco != 0.0:
-                        s_q += sco * mat[_l1, _l3]
-                    if cco != 0.0:
-                        c_q += cco * mat[_l1, _l3]
+                    _accumulate_coeff(s_q, sco, mat[_l1, _l3])
+                    _accumulate_coeff(c_q, cco, mat[_l1, _l3])
         if Up_mat is not None:
             sco, cco = sc_coefficients("CoulombInter", "density")
-            if sco != 0.0:
-                s_q += sco * Up_mat[_l1, _l3]
-            if cco != 0.0:
-                c_q += cco * Up_mat[_l1, _l3]
+            _accumulate_coeff(s_q, sco, Up_mat[_l1, _l3])
+            _accumulate_coeff(c_q, cco, Up_mat[_l1, _l3])
         S_all[:, :, :, idx12[i], idx34[i]] += s_q
         C_all[:, :, :, idx12[i], idx34[i]] += c_q
 
@@ -985,10 +998,8 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
         # slots in both channels. Only PairHop belongs here (#100/#102).
         if PH_mat is not None:
             sco, cco = sc_coefficients("PairHop", "antidiag")
-            if sco != 0.0:
-                s_q += sco * PH_mat[_l1, _l2]
-            if cco != 0.0:
-                c_q += cco * PH_mat[_l1, _l2]
+            _accumulate_coeff(s_q, sco, PH_mat[_l1, _l2])
+            _accumulate_coeff(c_q, cco, PH_mat[_l1, _l2])
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 

--- a/src/hwave/sc.py
+++ b/src/hwave/sc.py
@@ -932,8 +932,13 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
         for mat, itype in cross_terms:
             if mat is not None:
                 sco, cco = sc_coefficients(itype, "cross")
-                s_q += sco * mat[_l1, _l2]
-                c_q += cco * mat[_l1, _l2]
+                # explicit zero suppression: 0.0 * Inf is NaN, and a
+                # channel with no content for a type must stay untouched
+                # even for non-finite input
+                if sco != 0.0:
+                    s_q += sco * mat[_l1, _l2]
+                if cco != 0.0:
+                    c_q += cco * mat[_l1, _l2]
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 
@@ -955,12 +960,16 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
             for mat, itype in ((J_mat, "Hund"), (I_mat, "Ising")):
                 if mat is not None:
                     sco, cco = sc_coefficients(itype, "density")
-                    s_q += sco * mat[_l1, _l3]
-                    c_q += cco * mat[_l1, _l3]
+                    if sco != 0.0:
+                        s_q += sco * mat[_l1, _l3]
+                    if cco != 0.0:
+                        c_q += cco * mat[_l1, _l3]
         if Up_mat is not None:
             sco, cco = sc_coefficients("CoulombInter", "density")
-            s_q += sco * Up_mat[_l1, _l3]
-            c_q += cco * Up_mat[_l1, _l3]
+            if sco != 0.0:
+                s_q += sco * Up_mat[_l1, _l3]
+            if cco != 0.0:
+                c_q += cco * Up_mat[_l1, _l3]
         S_all[:, :, :, idx12[i], idx34[i]] += s_q
         C_all[:, :, :, idx12[i], idx34[i]] += c_q
 
@@ -976,8 +985,10 @@ def _build_sc_matrices_all_q(inter_k, norb, Nx, Ny, Nz,
         # slots in both channels. Only PairHop belongs here (#100/#102).
         if PH_mat is not None:
             sco, cco = sc_coefficients("PairHop", "antidiag")
-            s_q += sco * PH_mat[_l1, _l2]
-            c_q += cco * PH_mat[_l1, _l2]
+            if sco != 0.0:
+                s_q += sco * PH_mat[_l1, _l2]
+            if cco != 0.0:
+                c_q += cco * PH_mat[_l1, _l2]
         S_all[:, :, :, idx12[i], idx34[i]] = s_q
         C_all[:, :, :, idx12[i], idx34[i]] = c_q
 

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 #import read_input_k
 import hwave.qlmsio.read_input_k as read_input_k
 import hwave.qlmsio.wan90 as wan90
+from hwave.solver.vertex_table import fierz_coefficients
 from . import backend as _bk
 from . import fold
 from . import matsubara as _ms
@@ -639,7 +640,7 @@ class Interaction:
                         orb = (s4, b, s3, a, s1, a, s2, b)
                         ham_r[(*irvec, *orb)] += v * w
 
-        def _append_inter_cross(type, coeff, spins, tbl=None):
+        def _append_inter_cross(type, tbl=None):
             # Longitudinal cross-slot (Fierz) content, adjudicated against
             # exact diagonalization in #113: the ring's W carried the
             # density (aa,bb) slots of each type but not the (ab,ab)
@@ -673,6 +674,20 @@ class Interaction:
             if has_sub:
                 filtered = self._reshape_interaction(filtered, False)
             filtered = _symmetrised(type, filtered)
+            # spin-resolved coefficients DERIVED from the adjudicated S/C
+            # table via the channel decomposition W_same = (C - S)/2,
+            # W_cross = (C + S)/2 (hwave.solver.vertex_table) -- the values
+            # previously hand-coded here per type now have one source
+            w_same, w_cross = fierz_coefficients(type)
+            spins = {}
+            if w_same != 0.0:
+                spins[(0, 0, 0, 0)] = w_same
+                spins[(1, 1, 1, 1)] = w_same
+            if w_cross != 0.0:
+                spins[(0, 0, 1, 1)] = w_cross
+                spins[(1, 1, 0, 0)] = w_cross
+            if not spins:
+                return
             for (irvec, orbvec), v in filtered.items():
                 if tuple(irvec) != (0, 0, 0):
                     continue
@@ -687,7 +702,7 @@ class Interaction:
                     # in every adjudicated cell, while the pair-antidiagonal
                     # placement reproduces the old 1e-2 deficiency
                     orb = (s4, a, s3, b, s1, a, s2, b)
-                    fierz_r[(*irvec, *orb)] += coeff * v * w
+                    fierz_r[(*irvec, *orb)] += v * w
 
         if 'Coulomb' in self.param_ham.keys():
             # The aggregate 'Coulomb' input provides both the intra and inter
@@ -707,7 +722,7 @@ class Interaction:
             _append_inter('CoulombIntra', coulomb_intra)
             _append_inter('CoulombInter', coulomb_inter)
             _append_inter_cross(
-                'CoulombInter', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 },
+                'CoulombInter',
                 tbl=(wan90.split_coulomb(
                         self.param_ham_orig['Coulomb'])[1]
                      if getattr(self.lattice, "has_sublattice", False)
@@ -722,19 +737,19 @@ class Interaction:
 
         if 'CoulombInter' in self.param_ham.keys():
             _append_inter('CoulombInter')
-            _append_inter_cross('CoulombInter', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 })
+            _append_inter_cross('CoulombInter')
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
         if 'Hund' in self.param_ham.keys():
             _append_inter('Hund')
-            _append_inter_cross('Hund', +1.0, { (0,0,0,0): 1, (1,1,1,1): 1 })
+            _append_inter_cross('Hund')
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
         if 'Ising' in self.param_ham.keys():
             _append_inter('Ising')
-            _append_inter_cross('Ising', -1.0, { (0,0,0,0): 1, (1,1,1,1): 1 })
+            _append_inter_cross('Ising')
             self._has_interaction = True
             self._has_interaction_coulomb = True
 
@@ -745,7 +760,7 @@ class Interaction:
 
         if 'Exchange' in self.param_ham.keys():
             _append_inter('Exchange')
-            _append_inter_cross('Exchange', +1.0, { (0,0,1,1): 1, (1,1,0,0): 1 })
+            _append_inter_cross('Exchange')
             self._has_interaction = True
             self._has_interaction_exchange = True
 

--- a/src/hwave/solver/vertex_table.py
+++ b/src/hwave/solver/vertex_table.py
@@ -47,10 +47,14 @@ decomposition in code -- rather than recording it in a commit message --
 is the point of this module.
 """
 
+from types import MappingProxyType
+
 # (S, C) per unit coupling, per slot family. Types absent from a family
 # contribute nothing there. PairLift has no particle-hole S/C content
-# (adjudicated zero).
-ADJUDICATED_SC = {
+# (adjudicated zero). Read-only: a consumer mutating the table would
+# silently poison BOTH builders at once, which is worse than the drift
+# this module exists to prevent.
+_ADJUDICATED_SC_RAW = {
     "CoulombIntra": {"diag": (+1.0, +1.0)},
     "CoulombInter": {"cross": (+1.0, -1.0), "density": (0.0, +2.0)},
     "Hund":         {"cross": (-1.0, +1.0), "density": (+1.0, -1.0)},
@@ -59,6 +63,13 @@ ADJUDICATED_SC = {
     "PairLift":     {},
     "PairHop":      {"antidiag": (+1.0, +1.0)},
 }
+
+ADJUDICATED_SC = MappingProxyType(
+    {k: MappingProxyType(v) for k, v in _ADJUDICATED_SC_RAW.items()})
+# no mutable backing name is retained: the proxies above hold the only
+# references to the inner dicts, and the module namespace exposes only
+# the read-only view
+del _ADJUDICATED_SC_RAW
 
 
 def sc_coefficients(itype, family):

--- a/src/hwave/solver/vertex_table.py
+++ b/src/hwave/solver/vertex_table.py
@@ -1,0 +1,66 @@
+"""The adjudicated spin/charge vertex content, single-sourced.
+
+Every value here was established by exact diagonalization of H-wave's
+documented file operators (issues #105/#113; methodology in #107): the
+O(lambda) self-energy is removed exactly via the Hartree-Fock response,
+the extraction is validated by q-independence for on-site input, and the
+per-channel scale is calibrated on the CoulombIntra control. This module
+is the ONE place that content lives; the two consumers -- the pair-space
+S/C builders in :mod:`hwave.sc` (FLEX general and Eliashberg) and the
+spin-resolved rank-4 ring vertex in :mod:`hwave.solver.rpa` (#104) --
+derive their coefficients from it, so they cannot drift apart again
+(they did, repeatedly: #96, #104, #113).
+
+Slot families of the pair-space matrices (slots are (l1*norb+l2,
+l3*norb+l4); ``a != b`` throughout):
+
+    ``diag``      (aa, aa)   same orbital on both pairs
+    ``cross``     (ab, ab)   pair-diagonal, orbital off-diagonal (Fierz)
+    ``density``   (aa, bb)   two densities
+    ``antidiag``  (ab, ba)   pair-antidiagonal
+
+``S`` enters the spin channel as ``[1 - chi0 S]^-1 chi0`` and ``C`` the
+charge channel as ``[1 + chi0 C]^-1 chi0``. Entries are per unit
+coupling of the interaction file.
+
+The ring's rank-4 vertex is spin-resolved instead of channel-resolved;
+for a slot with content (S, C) the same-spin / cross-spin coefficients
+in the solver's repulsion-positive convention are the channel
+decomposition
+
+    W_same  = (C - S) / 2
+    W_cross = (C + S) / 2
+
+anchored on the two families the ring always had right (CoulombIntra
+diag and CoulombInter density; see the #104 fix). Executing this
+decomposition in code -- rather than recording it in a commit message --
+is the point of this module.
+"""
+
+# (S, C) per unit coupling, per slot family. Types absent from a family
+# contribute nothing there. PairLift has no particle-hole S/C content
+# (adjudicated zero).
+ADJUDICATED_SC = {
+    "CoulombIntra": {"diag": (+1.0, +1.0)},
+    "CoulombInter": {"cross": (+1.0, -1.0), "density": (0.0, +2.0)},
+    "Hund":         {"cross": (-1.0, +1.0), "density": (+1.0, -1.0)},
+    "Exchange":     {"cross": (+1.0, +1.0)},
+    "Ising":        {"cross": (+1.0, -1.0), "density": (-2.0, 0.0)},
+    "PairLift":     {},
+    "PairHop":      {"antidiag": (+1.0, +1.0)},
+}
+
+
+def sc_coefficients(itype, family):
+    """(S, C) coefficients of ``itype`` at ``family``, or (0, 0)."""
+    return ADJUDICATED_SC.get(itype, {}).get(family, (0.0, 0.0))
+
+
+def fierz_coefficients(itype):
+    """(W_same, W_cross) of the ring's cross-slot correction for ``itype``.
+
+    The channel decomposition of the ``cross`` family content; zero for
+    types without cross-slot content.
+    """
+    s, c = sc_coefficients(itype, "cross")
+    return ((c - s) / 2.0, (c + s) / 2.0)

--- a/src/hwave/solver/vertex_table.py
+++ b/src/hwave/solver/vertex_table.py
@@ -12,12 +12,18 @@ derive their coefficients from it, so they cannot drift apart again
 (they did, repeatedly: #96, #104, #113).
 
 Slot families of the pair-space matrices (slots are (l1*norb+l2,
-l3*norb+l4); ``a != b`` throughout):
+l3*norb+l4)):
 
     ``diag``      (aa, aa)   same orbital on both pairs
     ``cross``     (ab, ab)   pair-diagonal, orbital off-diagonal (Fierz)
     ``density``   (aa, bb)   two densities
     ``antidiag``  (ab, ba)   pair-antidiagonal
+
+``a != b`` throughout, with ONE exception: CoulombInter's ``density``
+entry also applies at a == b, where an inter-site same-orbital V
+contributes 2 V_aa(q) to the charge diagonal (issue #95); Hund and
+Ising stay restricted to a != b there (an orbital has no Hund or Ising
+coupling with itself).
 
 ``S`` enters the spin channel as ``[1 - chi0 S]^-1 chi0`` and ``C`` the
 charge channel as ``[1 + chi0 C]^-1 chi0``. Entries are per unit

--- a/src/hwave/solver/vertex_table.py
+++ b/src/hwave/solver/vertex_table.py
@@ -7,9 +7,13 @@ the extraction is validated by q-independence for on-site input, and the
 per-channel scale is calibrated on the CoulombIntra control. This module
 is the ONE place that content lives; the two consumers -- the pair-space
 S/C builders in :mod:`hwave.sc` (FLEX general and Eliashberg) and the
-spin-resolved rank-4 ring vertex in :mod:`hwave.solver.rpa` (#104) --
-derive their coefficients from it, so they cannot drift apart again
-(they did, repeatedly: #96, #104, #113).
+Fierz CROSS-SLOT correction of the ring vertex in
+:mod:`hwave.solver.rpa` (#104) -- derive their coefficients from it, so
+those pieces cannot drift apart again (they did, repeatedly: #96, #104,
+#113). The ring's long-standing base content (the density slots and the
+transverse spin-flip slots, adjudicated in #105 and never drifted) is
+still encoded in rpa.py's spin tables; folding those into this table is
+a later increment.
 
 Slot families of the pair-space matrices (slots are (l1*norb+l2,
 l3*norb+l4)):

--- a/tests/test_vertex_table_single_source.py
+++ b/tests/test_vertex_table_single_source.py
@@ -115,7 +115,12 @@ class TestZeroCoefficientSuppression(unittest.TestCase):
         stay exactly zero even for non-finite couplings. Diagonal
         CoulombInter has no S content; density-slot Ising has no C
         content."""
+        import warnings
+
         import hwave.sc as sc
+
+        warnings.simplefilter("ignore", RuntimeWarning)
+        self.addCleanup(warnings.resetwarnings)
 
         k = np.array([0.0])
         ik = sc._build_interaction_k(
@@ -132,6 +137,54 @@ class TestZeroCoefficientSuppression(unittest.TestCase):
         # the density slots (aa, bb) of Ising carry S only
         self.assertEqual(complex(C[0, 0, 0, 0, 3]), 0.0,
                          "density-slot Ising must not touch C")
+
+
+class TestIEEEParity(unittest.TestCase):
+
+    def test_plus_minus_one_coefficients_preserve_complex_infinities(self):
+        """numpy's 1.0 * (Inf+0j) is Inf+NaNj (full complex multiply);
+        the +-1 coefficients must use direct add/subtract so non-finite
+        values keep the pre-refactor component structure. The interaction
+        arrays are built by hand and passed pre-symmetrised: the public
+        Fourier builder itself multiplies by complex phases and turns Inf
+        into Inf+NaNj before the S/C builder is reached (identically in
+        the old and new code), which would mask the accumulator
+        semantics under test."""
+        import warnings
+
+        import hwave.sc as sc
+
+        warnings.simplefilter("ignore", RuntimeWarning)
+        self.addCleanup(warnings.resetwarnings)
+
+        def mat(entries):
+            m = np.zeros((2, 2, 1, 1, 1), dtype=complex)
+            for (a, b), v in entries.items():
+                m[a, b, 0, 0, 0] = v
+            return m
+
+        inf = complex(np.inf, 0.0)
+        cases = [
+            ("CoulombIntra", {(0, 0): inf, (1, 1): inf},
+             [("S", (0, 0), np.inf), ("C", (0, 0), np.inf)]),
+            ("CoulombInter", {(0, 1): inf, (1, 0): inf},
+             [("S", (1, 1), np.inf), ("C", (1, 1), -np.inf)]),
+            ("PairHop", {(0, 1): inf, (1, 0): inf},
+             [("S", (1, 2), np.inf), ("C", (1, 2), np.inf)]),
+        ]
+        for itype, entries, expected in cases:
+            with self.subTest(interaction=itype):
+                ik = {itype: mat(entries)}
+                S, C = sc._build_sc_matrices_all_q(
+                    ik, 2, 1, 1, 1, _presymmetrised=True)
+                M = {"S": S[0, 0, 0], "C": C[0, 0, 0]}
+                for ch, (i, j), want in expected:
+                    got = M[ch][i, j]
+                    self.assertEqual(got.real, want,
+                                     "%s %s[%d,%d] real" % (itype, ch, i, j))
+                    self.assertEqual(got.imag, 0.0,
+                                     "%s %s[%d,%d] imag must stay exactly "
+                                     "zero, not NaN" % (itype, ch, i, j))
 
 
 if __name__ == "__main__":

--- a/tests/test_vertex_table_single_source.py
+++ b/tests/test_vertex_table_single_source.py
@@ -91,5 +91,48 @@ class TestAssembledConsistency(unittest.TestCase):
                 self.assertIsNone(sv.ham_info.ham_fierz_q)
 
 
+class TestTableContent(unittest.TestCase):
+
+    def test_table_matches_the_adjudicated_values(self):
+        """Pin the exported table itself, independent of the builders."""
+        from hwave.solver.vertex_table import ADJUDICATED_SC
+
+        self.assertEqual(ADJUDICATED_SC, {
+            "CoulombIntra": {"diag": (+1.0, +1.0)},
+            "CoulombInter": {"cross": (+1.0, -1.0), "density": (0.0, +2.0)},
+            "Hund":         {"cross": (-1.0, +1.0), "density": (+1.0, -1.0)},
+            "Exchange":     {"cross": (+1.0, +1.0)},
+            "Ising":        {"cross": (+1.0, -1.0), "density": (-2.0, 0.0)},
+            "PairLift":     {},
+            "PairHop":      {"antidiag": (+1.0, +1.0)},
+        })
+
+
+class TestZeroCoefficientSuppression(unittest.TestCase):
+
+    def test_nonfinite_input_does_not_leak_into_absent_channels(self):
+        """0.0 * Inf is NaN: a channel with no content for a type must
+        stay exactly zero even for non-finite couplings. Diagonal
+        CoulombInter has no S content; density-slot Ising has no C
+        content."""
+        import hwave.sc as sc
+
+        k = np.array([0.0])
+        ik = sc._build_interaction_k(
+            k, k, k, {"CoulombInter": {((0, 0, 0), (0, 0)): np.inf,
+                                       ((0, 0, 0), (1, 1)): np.inf}}, 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 1, 1, 1)
+        self.assertTrue(np.all(S[0, 0, 0] == 0.0),
+                        "diagonal CoulombInter must not touch S")
+
+        ik = sc._build_interaction_k(
+            k, k, k, {"Ising": {((0, 0, 0), (0, 1)): np.inf,
+                                ((0, 0, 0), (1, 0)): np.inf}}, 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 1, 1, 1)
+        # the density slots (aa, bb) of Ising carry S only
+        self.assertEqual(complex(C[0, 0, 0, 0, 3]), 0.0,
+                         "density-slot Ising must not touch C")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vertex_table_single_source.py
+++ b/tests/test_vertex_table_single_source.py
@@ -119,8 +119,10 @@ class TestZeroCoefficientSuppression(unittest.TestCase):
 
         import hwave.sc as sc
 
+        ctx = warnings.catch_warnings()
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
         warnings.simplefilter("ignore", RuntimeWarning)
-        self.addCleanup(warnings.resetwarnings)
 
         k = np.array([0.0])
         ik = sc._build_interaction_k(
@@ -141,6 +143,17 @@ class TestZeroCoefficientSuppression(unittest.TestCase):
 
 class TestIEEEParity(unittest.TestCase):
 
+    def test_plus_two_coefficient_keeps_the_multiply_form(self):
+        """The +-2 coefficients (CoulombInter density) intentionally keep
+        the multiplication, matching the pre-refactor 2.0 * V form."""
+        import hwave.sc as sc
+
+        m = np.zeros((2, 2, 1, 1, 1), dtype=complex)
+        m[0, 1] = m[1, 0] = 0.7
+        S, C = sc._build_sc_matrices_all_q(
+            {"CoulombInter": m}, 2, 1, 1, 1, _presymmetrised=True)
+        self.assertAlmostEqual(complex(C[0, 0, 0, 0, 3]), 1.4, places=13)
+
     def test_plus_minus_one_coefficients_preserve_complex_infinities(self):
         """numpy's 1.0 * (Inf+0j) is Inf+NaNj (full complex multiply);
         the +-1 coefficients must use direct add/subtract so non-finite
@@ -154,8 +167,10 @@ class TestIEEEParity(unittest.TestCase):
 
         import hwave.sc as sc
 
+        ctx = warnings.catch_warnings()
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
         warnings.simplefilter("ignore", RuntimeWarning)
-        self.addCleanup(warnings.resetwarnings)
 
         def mat(entries):
             m = np.zeros((2, 2, 1, 1, 1), dtype=complex)
@@ -171,6 +186,9 @@ class TestIEEEParity(unittest.TestCase):
              [("S", (1, 1), np.inf), ("C", (1, 1), -np.inf)]),
             ("PairHop", {(0, 1): inf, (1, 0): inf},
              [("S", (1, 2), np.inf), ("C", (1, 2), np.inf)]),
+            # Case 3's +-1 density coefficients (Hund): S at (aa, bb)
+            ("Hund", {(0, 1): inf, (1, 0): inf},
+             [("S", (0, 3), np.inf), ("C", (0, 3), -np.inf)]),
         ]
         for itype, entries, expected in cases:
             with self.subTest(interaction=itype):

--- a/tests/test_vertex_table_single_source.py
+++ b/tests/test_vertex_table_single_source.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Both vertex builders derive from the one adjudicated table.
+
+The pair-space S/C matrices (hwave.sc) and the ring's spin-resolved
+cross-slot correction (hwave.solver.rpa) encode the same physics in two
+representations, tied by the channel decomposition W_same = (C - S)/2,
+W_cross = (C + S)/2. Historically the two drifted (#96, #104, #113);
+they now read one table (hwave.solver.vertex_table). These tests measure
+the consistency from the ASSEMBLED objects, not the table -- so a future
+edit that bypasses the table on either side still fails here.
+"""
+
+import unittest
+
+import numpy as np
+
+
+class TestAssembledConsistency(unittest.TestCase):
+
+    def _sc_cross(self, itype, J=0.7):
+        """S and C at the (01, 01) cross slot from the sc builders."""
+        import hwave.sc as sc
+
+        k = np.array([0.0])
+        entries = {((0, 0, 0), (0, 1)): J, ((0, 0, 0), (1, 0)): J}
+        ik = sc._build_interaction_k(k, k, k, {itype: entries}, 2)
+        S, C = sc._build_sc_matrices_all_q(ik, 2, 1, 1, 1)
+        return S[0, 0, 0, 1, 1], C[0, 0, 0, 1, 1]
+
+    def _rpa_fierz(self, itype, J=0.7):
+        """Same-spin and cross-spin cross-slot entries of the ring's
+        Fierz tensor, read from the assembled solver."""
+        import hwave.solver.rpa as rpa_mod
+
+        param_ham = {'Geometry': {'norb': 2, 'rvec': np.eye(3),
+                                  'center': [[0, 0, 0]] * 2},
+                     'Transfer': {((0, 0, 0), (0, 0)): 1.0},
+                     itype: {((0, 0, 0), (0, 1)): J,
+                             ((0, 0, 0), (1, 0)): J}}
+        info = {'mode': 'RPA', 'param': {'T': 2.0, 'filling': 0.5,
+                'CellShape': [1, 1, 1], 'SubShape': [1, 1, 1], 'Nmat': 4},
+                'enable_spin_orbital': False, 'calc_scheme': 'general',
+                'calc_type': 'ring'}
+        sv = rpa_mod.RPA(param_ham, {}, info)
+        f = sv.ham_info.ham_fierz_q
+        if f is None:
+            return 0.0, 0.0
+        f = np.asarray(f).reshape(-1, 4, 4, 4, 4)[0]
+        # spin-major nd = 4: up = {0: 0, 1: 1}, down = {0: 2, 1: 3};
+        # entries sit at (a, b, a, b) per spin block (see the appender)
+        same = f[0, 1, 0, 1]          # (up a, up b, up a, up b)
+        cross = f[2, 3, 0, 1]         # (dn a, dn b, up a, up b)
+        return same, cross
+
+    def test_ring_fierz_is_the_channel_decomposition_of_sc(self):
+        """For every type with cross-slot content: measure S/C from the
+        sc builders and the same-spin/cross-spin entries from the ring,
+        and require W_same == (C - S)/2, W_cross == (C + S)/2."""
+        for itype in ("CoulombInter", "Hund", "Ising", "Exchange"):
+            with self.subTest(interaction=itype):
+                S, C = self._sc_cross(itype)
+                same, cross = self._rpa_fierz(itype)
+                self.assertAlmostEqual(
+                    complex(same), complex((C - S) / 2.0), places=12,
+                    msg="%s same-spin" % itype)
+                self.assertAlmostEqual(
+                    complex(cross), complex((C + S) / 2.0), places=12,
+                    msg="%s cross-spin" % itype)
+
+    def test_types_without_cross_content_have_no_fierz(self):
+        for itype in ("PairHop", "PairLift", "CoulombIntra"):
+            with self.subTest(interaction=itype):
+                entries = ({((0, 0, 0), (0, 0)): 0.7,
+                            ((0, 0, 0), (1, 1)): 0.7}
+                           if itype == "CoulombIntra" else
+                           {((0, 0, 0), (0, 1)): 0.7,
+                            ((0, 0, 0), (1, 0)): 0.7})
+                import hwave.solver.rpa as rpa_mod
+
+                param_ham = {'Geometry': {'norb': 2, 'rvec': np.eye(3),
+                                          'center': [[0, 0, 0]] * 2},
+                             'Transfer': {((0, 0, 0), (0, 0)): 1.0},
+                             itype: entries}
+                info = {'mode': 'RPA',
+                        'param': {'T': 2.0, 'filling': 0.5,
+                                  'CellShape': [1, 1, 1],
+                                  'SubShape': [1, 1, 1], 'Nmat': 4},
+                        'enable_spin_orbital': False,
+                        'calc_scheme': 'general', 'calc_type': 'ring'}
+                sv = rpa_mod.RPA(param_ham, {}, info)
+                self.assertIsNone(sv.ham_info.ham_fierz_q)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vertex_table_single_source.py
+++ b/tests/test_vertex_table_single_source.py
@@ -56,10 +56,21 @@ class TestAssembledConsistency(unittest.TestCase):
         """For every type with cross-slot content: measure S/C from the
         sc builders and the same-spin/cross-spin entries from the ring,
         and require W_same == (C - S)/2, W_cross == (C + S)/2."""
+        J = 0.7
+        expected_sc = {"CoulombInter": (+J, -J), "Hund": (-J, +J),
+                       "Ising": (+J, -J), "Exchange": (+J, +J)}
         for itype in ("CoulombInter", "Hund", "Ising", "Exchange"):
             with self.subTest(interaction=itype):
-                S, C = self._sc_cross(itype)
-                same, cross = self._rpa_fierz(itype)
+                S, C = self._sc_cross(itype, J=J)
+                # guard against a vacuous pass: if both builders dropped
+                # the cross content entirely, the identity below would
+                # hold on zeros -- pin the expected NONZERO values first
+                want_s, want_c = expected_sc[itype]
+                self.assertAlmostEqual(complex(S), complex(want_s),
+                                       places=12, msg="%s S" % itype)
+                self.assertAlmostEqual(complex(C), complex(want_c),
+                                       places=12, msg="%s C" % itype)
+                same, cross = self._rpa_fierz(itype, J=J)
                 self.assertAlmostEqual(
                     complex(same), complex((C - S) / 2.0), places=12,
                     msg="%s same-spin" % itype)
@@ -143,16 +154,44 @@ class TestZeroCoefficientSuppression(unittest.TestCase):
 
 class TestIEEEParity(unittest.TestCase):
 
-    def test_plus_two_coefficient_keeps_the_multiply_form(self):
-        """The +-2 coefficients (CoulombInter density) intentionally keep
-        the multiplication, matching the pre-refactor 2.0 * V form."""
+    def test_plus_minus_two_coefficients_preserve_structure(self):
+        """The +-2 coefficients: value doubled for finite input, and the
+        component structure of Inf+0j preserved (a real scalar multiply
+        scales componentwise, matching the pre-refactor 2.0 * V form; a
+        finite-only check could not distinguish the forms)."""
+        import warnings
+
         import hwave.sc as sc
+
+        ctx = warnings.catch_warnings()
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
+        warnings.simplefilter("ignore", RuntimeWarning)
 
         m = np.zeros((2, 2, 1, 1, 1), dtype=complex)
         m[0, 1] = m[1, 0] = 0.7
         S, C = sc._build_sc_matrices_all_q(
             {"CoulombInter": m}, 2, 1, 1, 1, _presymmetrised=True)
         self.assertAlmostEqual(complex(C[0, 0, 0, 0, 3]), 1.4, places=13)
+
+        # numpy promotes scalar * complex array to a complex multiply, so
+        # 2.0 * (Inf+0j) is Inf+NaNj -- IDENTICAL to the pre-refactor
+        # 2.0 * V form, and distinguishable from a replace-by-two-adds
+        # implementation (which would give Inf+0j)
+        m = np.zeros((2, 2, 1, 1, 1), dtype=complex)
+        m[0, 1] = m[1, 0] = complex(np.inf, 0.0)
+        S, C = sc._build_sc_matrices_all_q(
+            {"CoulombInter": m}, 2, 1, 1, 1, _presymmetrised=True)
+        got = C[0, 0, 0, 0, 3]          # +2 slot
+        self.assertEqual(got.real, np.inf)
+        self.assertTrue(np.isnan(got.imag),
+                        "the legacy multiply form yields Inf+NaNj here")
+        S, C = sc._build_sc_matrices_all_q(
+            {"Ising": m}, 2, 1, 1, 1, _presymmetrised=True)
+        got = S[0, 0, 0, 0, 3]          # -2 slot
+        self.assertEqual(got.real, -np.inf)
+        self.assertTrue(np.isnan(got.imag),
+                        "the legacy multiply form yields -Inf+NaNj here")
 
     def test_plus_minus_one_coefficients_preserve_complex_infinities(self):
         """numpy's 1.0 * (Inf+0j) is Inf+NaNj (full complex multiply);
@@ -203,6 +242,67 @@ class TestIEEEParity(unittest.TestCase):
                     self.assertEqual(got.imag, 0.0,
                                      "%s %s[%d,%d] imag must stay exactly "
                                      "zero, not NaN" % (itype, ch, i, j))
+
+
+class TestMixedTypeGolden(unittest.TestCase):
+
+    def test_mixed_types_norb3_complex_slots(self):
+        """Permanent legacy-parity protection: a mixed-type norb=3 complex
+        input, with selected slots of every type and family pinned (the
+        pre-refactor and refactored builders were verified bit-for-bit
+        equal on this class of input during review; these values freeze
+        that behavior)."""
+        import hwave.sc as sc
+
+        norb = 3
+
+        def mat(entries):
+            m = np.zeros((norb, norb, 1, 1, 1), dtype=complex)
+            for (a, b), v in entries.items():
+                m[a, b, 0, 0, 0] = v
+            return m
+
+        ik = {
+            "CoulombIntra": mat({(a, a): 2.0 + 0.1 * a for a in range(3)}),
+            "CoulombInter": mat({(0, 1): 0.7, (1, 0): 0.7,
+                                 (0, 2): 0.4, (2, 0): 0.4}),
+            "Hund": mat({(0, 1): 0.3, (1, 0): 0.3}),
+            "Ising": mat({(1, 2): 0.2, (2, 1): 0.2}),
+            "Exchange": mat({(0, 2): 0.25, (2, 0): 0.25}),
+            "PairHop": mat({(0, 1): 0.15 + 0.05j, (1, 0): 0.15 - 0.05j}),
+        }
+        S, C = sc._build_sc_matrices_all_q(
+            ik, norb, 1, 1, 1, _presymmetrised=True)
+        S = S[0, 0, 0]
+        C = C[0, 0, 0]
+        p = lambda a, b: a * norb + b
+        checks = [
+            # diag: U_a at (aa, aa); CoulombInter aa density adds nothing here
+            ("S", p(0, 0), p(0, 0), 2.0), ("C", p(0, 0), p(0, 0), 2.0),
+            ("S", p(1, 1), p(1, 1), 2.1),
+            # density (aa, bb): C = 2 V; Hund S = +J, C = -J; Ising S = -2 I
+            ("C", p(0, 0), p(1, 1), 2 * 0.7 - 0.3),
+            ("S", p(0, 0), p(1, 1), 0.3),
+            ("S", p(1, 1), p(2, 2), -2 * 0.2),
+            ("C", p(1, 1), p(2, 2), 0.0),
+            ("C", p(0, 0), p(2, 2), 2 * 0.4),
+            # cross (ab, ab): V (+, -), Hund (-, +), Ising (+, -), Exch (+, +)
+            ("S", p(0, 1), p(0, 1), 0.7 - 0.3),
+            ("C", p(0, 1), p(0, 1), -0.7 + 0.3),
+            ("S", p(1, 2), p(1, 2), 0.2),
+            ("C", p(1, 2), p(1, 2), -0.2),
+            ("S", p(0, 2), p(0, 2), 0.4 + 0.25),
+            ("C", p(0, 2), p(0, 2), -0.4 + 0.25),
+            # antidiag (ab, ba): PairHop, complex phase preserved, S = C
+            ("S", p(0, 1), p(1, 0), 0.15 + 0.05j),
+            ("C", p(0, 1), p(1, 0), 0.15 + 0.05j),
+            ("S", p(1, 0), p(0, 1), 0.15 - 0.05j),
+        ]
+        M = {"S": S, "C": C}
+        for ch, i, j, want in checks:
+            self.assertAlmostEqual(
+                complex(M[ch][i, j]), complex(want), places=12,
+                msg="%s[%d,%d]" % (ch, i, j))
 
 
 if __name__ == "__main__":

--- a/tests/test_vertex_table_single_source.py
+++ b/tests/test_vertex_table_single_source.py
@@ -119,6 +119,23 @@ class TestTableContent(unittest.TestCase):
         })
 
 
+class TestTableImmutability(unittest.TestCase):
+
+    def test_both_mapping_levels_are_frozen(self):
+        """The table-equality test would still pass if the proxies were
+        removed; pin the freeze itself."""
+        import hwave.solver.vertex_table as vt
+
+        with self.assertRaises(TypeError):
+            vt.ADJUDICATED_SC["Hund"] = {}
+        with self.assertRaises(TypeError):
+            vt.ADJUDICATED_SC["Hund"]["cross"] = (0.0, 0.0)
+        self.assertFalse(hasattr(vt, "_ADJUDICATED_SC_RAW"),
+                         "no mutable backing name may be retained")
+        self.assertIsInstance(vt.sc_coefficients("Hund", "cross"), tuple)
+        self.assertIsInstance(vt.sc_coefficients("Hund", "nope"), tuple)
+
+
 class TestZeroCoefficientSuppression(unittest.TestCase):
 
     def test_nonfinite_input_does_not_leak_into_absent_channels(self):
@@ -156,9 +173,10 @@ class TestIEEEParity(unittest.TestCase):
 
     def test_plus_minus_two_coefficients_preserve_structure(self):
         """The +-2 coefficients: value doubled for finite input, and the
-        component structure of Inf+0j preserved (a real scalar multiply
-        scales componentwise, matching the pre-refactor 2.0 * V form; a
-        finite-only check could not distinguish the forms)."""
+        legacy component structure preserved (numpy promotes the scalar
+        multiply to a COMPLEX multiply, matching the pre-refactor
+        2.0 * V form; a finite-only check could not distinguish the
+        forms)."""
         import warnings
 
         import hwave.sc as sc


### PR DESCRIPTION
First increment of #107 phase 2 (design recorded in that issue).

The adjudicated per-type S/C vertex values existed in two implementations — the pair-space case placements in `hwave.sc` and the spin-resolved Fierz coefficients in `rpa.py` — tied only by a derivation recorded in a commit message. That duplication pattern is exactly how #96, #104 and #113 happened.

One module (`hwave.solver.vertex_table`) now holds the table with its exact-diagonalization provenance, and both builders derive from it; the channel decomposition `W_same = (C−S)/2`, `W_cross = (C+S)/2` is executed in code.

Zero behavior change, verified by the full net built this week: adjudicated-table tests, the RPA==FLEX one-shot equivalence matrix, the SCF fixed-point matrix (18 cells), the transverse suite, and the independent two-orbital reference. A new test measures the decomposition identity from the assembled objects, so an edit bypassing the table on either side fails regardless.

Full suite: 1031 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCUFFn4bpcC6yLt3TLYgBC