### PR TITLE
Single-source the reduced/squashed density projections

### DIFF
--- a/src/hwave/solver/density_projection.py
+++ b/src/hwave/solver/density_projection.py
@@ -1,0 +1,41 @@
+"""Density-diagonal projections of the rank-4 interaction tensor.
+
+The ``reduced`` and ``squashed`` calculation schemes solve with the
+density-density diagonal of the interaction: exchange-, spin-flip- and
+pair-type off-diagonal vertices are dropped (a deliberate, documented
+approximation -- the callers warn about it). The two solvers used to
+carry their own copies of these einsum reductions; per issue #107 the
+projections live here once.
+
+Layout conventions:
+
+* ``project_density_pairs``: combined-index form. The tensor is read as
+  ``(nvol, nd, nd, nd, nd)`` with ``nd`` the (spin-)orbital dimension of
+  the run, and the pair diagonal ``[a, a, b, b]`` is extracted --
+  ``'kaabb->kab'``. Used by the plain reduced/spinful branches of both
+  solvers; FLEX's spin-resolved reduced branch is the same extraction
+  through a ``(ns, norb)`` factorized view (``'ksasatbtb->ksatb'``), so
+  it routes here after reshaping.
+* ``project_density_squashed``: spin-factorized form. The tensor is
+  read as ``(nvol, (ns, norb) * 4)`` and the orbital pair diagonal is
+  extracted while both spin indices per pair are kept --
+  ``'ksauatbvb->ksuatvb'`` -- yielding
+  ``(nvol, ns, ns, norb, ns, ns, norb)``. Used by the squashed scheme.
+
+``xp`` is the array backend (NumPy or CuPy); einsum dispatches on it.
+"""
+
+
+def project_density_pairs(ham_q, nvol, nd, xp):
+    """Pair-diagonal 'kaabb->kab' of a combined-index rank-4 tensor."""
+    return xp.einsum(
+        'kaabb->kab',
+        ham_q.reshape(nvol, *(nd,) * 4)).reshape(nvol, nd, nd)
+
+
+def project_density_squashed(ham_q, nvol, ns, norb, xp):
+    """Orbital pair-diagonal with per-pair spin structure kept."""
+    return xp.einsum(
+        'ksauatbvb->ksuatvb',
+        ham_q.reshape(nvol, *(ns, norb) * 4)).reshape(
+            nvol, *(ns, ns, norb) * 2)

--- a/src/hwave/solver/density_projection.py
+++ b/src/hwave/solver/density_projection.py
@@ -20,7 +20,11 @@ Layout conventions:
   read as ``(nvol, (ns, norb) * 4)`` and the orbital pair diagonal is
   extracted while both spin indices per pair are kept --
   ``'ksauatbvb->ksuatvb'`` -- yielding
-  ``(nvol, ns, ns, norb, ns, ns, norb)``. Used by the squashed scheme.
+  ``(nvol, ns, ns, norb, ns, ns, norb)``. Used by RPA's spin-free and
+  spin-diag squashed branches only: FLEX routes BOTH its reduced and
+  squashed modes through ``project_density_pairs`` (its channel solver
+  consumes the pair-diagonal form for either scheme; squashed there is
+  an output-layout distinction, not a different vertex).
 
 ``xp`` is the array backend (NumPy or CuPy); einsum dispatches on it.
 """

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -33,6 +33,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from .rpa import RPA, Lattice, Interaction
+from .density_projection import project_density_pairs
 from . import backend as _bk
 from . import matsubara as _ms
 
@@ -1818,9 +1819,11 @@ class FLEX(RPA):
                 sl = slice(s * norb, (s + 1) * norb)
                 chi0q[..., sl, sl] = chi0q_src
 
-            ham = xp.einsum('ksasatbtb->ksatb',
-                            ham_orig.reshape(nvol, *(ns, norb) * 4)
-                            ).reshape(nvol, nd, nd)
+            # 'ksasatbtb->ksatb' through the (ns, norb) factorized view
+            # picks the same entries as the combined-index pair diagonal
+            # and lands them in the same spin-major (nd, nd) layout, so it
+            # routes through the shared projection
+            ham = project_density_pairs(ham_orig, nvol, nd, xp)
 
         elif self.spin_mode == "spin-diag":
             # chi0q_raw shape: (nblock=2, nmat, nvol, norb, norb) for reduced
@@ -1835,17 +1838,17 @@ class FLEX(RPA):
                 sl = slice(s * norb, (s + 1) * norb)
                 chi0q[..., sl, sl] = chi0q_raw[s]
 
-            ham = xp.einsum('ksasatbtb->ksatb',
-                            ham_orig.reshape(nvol, *(ns, norb) * 4)
-                            ).reshape(nvol, nd, nd)
+            # 'ksasatbtb->ksatb' through the (ns, norb) factorized view
+            # picks the same entries as the combined-index pair diagonal
+            # and lands them in the same spin-major (nd, nd) layout, so it
+            # routes through the shared projection
+            ham = project_density_pairs(ham_orig, nvol, nd, xp)
 
         elif self.spin_mode == "spinful":
             # chi0q_raw shape: (nmat, nvol, nd, nd) for reduced
             chi0q = chi0q_raw
 
-            ham = xp.einsum('kaabb->kab',
-                            ham_orig.reshape(nvol, *(nd,) * 4)
-                            ).reshape(nvol, nd, nd)
+            ham = project_density_pairs(ham_orig, nvol, nd, xp)
 
         return chi0q, ham
 

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -1401,8 +1401,9 @@ class RPA:
                                       chi0q_orig.reshape(nfreq,nvol,norb,norb),
                                       spin_tensor).reshape(nfreq,nvol,nd,nd)
 
-                    ham = xp.einsum('ksasatbtb->ksatb',
-                                    ham_long.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(nd,)*2)
+                    # same spin-major extraction as the combined-index
+                    # pair diagonal (verified bitwise); shared projection
+                    ham = project_density_pairs(ham_long, nvol, nd, xp)
 
                 elif self.calc_scheme == "squashed":
                     # norb**2 squash

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 import hwave.qlmsio.read_input_k as read_input_k
 import hwave.qlmsio.wan90 as wan90
 from hwave.solver.vertex_table import fierz_coefficients
+from hwave.solver.density_projection import (
+    project_density_pairs, project_density_squashed)
 from . import backend as _bk
 from . import fold
 from . import matsubara as _ms
@@ -1323,8 +1325,7 @@ class RPA:
                     # exploited by _find_block_diagonal inside _solve_rpa.
                     nvol = self.lattice.nvol
                     nd = self.nd
-                    ham = xp.einsum('kaabb->kab',
-                                    ham_long.reshape(nvol,*(nd,)*4)).reshape(nvol,*(nd,)*2)
+                    ham = project_density_pairs(ham_long, nvol, nd, xp)
                 else:
                     ham = ham_long
 
@@ -1345,8 +1346,7 @@ class RPA:
                                       chi0q_orig,
                                       spin_tensor).reshape(nfreq,nvol,nd,nd)
 
-                    ham = xp.einsum('kaabb->kab',
-                                    ham_long.reshape(nvol,*(nd,)*4)).reshape(nvol,*(nd,)*2)
+                    ham = project_density_pairs(ham_long, nvol, nd, xp)
 
                 elif self.calc_scheme == "squashed":
                     nblock,nfreq,nvol,norb1,norb2 = chi0q_orig.shape
@@ -1363,8 +1363,8 @@ class RPA:
                                       chi0q_orig,
                                       spin_tensor).reshape(nfreq,nvol,ns,ns,norb,ns,ns,norb)
 
-                    ham = xp.einsum('ksauatbvb->ksuatvb',
-                                    ham_long.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(ns,ns,norb)*2)
+                    ham = project_density_squashed(ham_long, nvol, ns,
+                                                   norb, xp)
 
                 else:
                     nblock,nfreq,nvol,norb1,norb2,norb3,norb4 = chi0q_orig.shape
@@ -1420,8 +1420,8 @@ class RPA:
                                       chi0q_orig.reshape(nfreq,nvol,norb,norb),
                                       spin_tensor).reshape(nfreq,nvol,ns,ns,norb,ns,ns,norb)
 
-                    ham = xp.einsum('ksauatbvb->ksuatvb',
-                                    ham_long.reshape(nvol,*(ns,norb)*4)).reshape(nvol,*(ns,ns,norb)*2)
+                    ham = project_density_squashed(ham_long, nvol, ns,
+                                                   norb, xp)
 
                 else:
                     # general nd**4 case

--- a/tests/test_density_projection.py
+++ b/tests/test_density_projection.py
@@ -53,5 +53,35 @@ class TestDensityProjections(unittest.TestCase):
         np.testing.assert_array_equal(got, want)
 
 
+class TestLayoutsAndDegenerateShapes(unittest.TestCase):
+    """The helpers are pure element selections and must be layout- and
+    shape-agnostic: Fortran order, non-contiguous views, and degenerate
+    dimensions all reduce to the same values as a fresh C-order copy."""
+
+    def _check(self, ns, norb, nvol):
+        rng = np.random.default_rng(ns * 100 + norb * 10 + nvol)
+        nd = ns * norb
+        shape = (nvol,) + (nd,) * 4
+        h = (rng.standard_normal(shape)
+             + 1j * rng.standard_normal(shape))
+        want_p = project_density_pairs(h.copy(), nvol, nd, np)
+        want_s = project_density_squashed(h.copy(), nvol, ns, norb, np)
+        for label, variant in (
+                ("fortran", np.asfortranarray(h)),
+                ("noncontig", np.ascontiguousarray(
+                    np.concatenate([h, h], axis=0))[:nvol]),
+        ):
+            with self.subTest(layout=label, ns=ns, norb=norb, nvol=nvol):
+                np.testing.assert_array_equal(
+                    project_density_pairs(variant, nvol, nd, np), want_p)
+                np.testing.assert_array_equal(
+                    project_density_squashed(variant, nvol, ns, norb, np),
+                    want_s)
+
+    def test_layout_and_shape_matrix(self):
+        for ns, norb, nvol in ((2, 1, 1), (2, 1, 4), (2, 3, 2), (1, 2, 3)):
+            self._check(ns, norb, nvol)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_density_projection.py
+++ b/tests/test_density_projection.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Unit pins for the shared density projections (#107 increment 2).
+
+These are pure element selections, so exact equality is asserted
+against the original einsum notations they replaced -- including the
+spin-major layout identity between the factorized and combined-index
+forms that lets every plain-reduced site share one function.
+"""
+
+import unittest
+
+import numpy as np
+
+from hwave.solver.density_projection import (
+    project_density_pairs, project_density_squashed)
+
+
+class TestDensityProjections(unittest.TestCase):
+
+    def setUp(self):
+        rng = np.random.default_rng(11)
+        self.ns, self.norb, self.nvol = 2, 3, 5
+        self.nd = self.ns * self.norb
+        shape = (self.nvol,) + (self.nd,) * 4
+        self.h = (rng.standard_normal(shape)
+                  + 1j * rng.standard_normal(shape))
+
+    def test_pairs_matches_the_combined_index_form(self):
+        want = np.einsum(
+            'kaabb->kab',
+            self.h.reshape(self.nvol, *(self.nd,) * 4)
+        ).reshape(self.nvol, self.nd, self.nd)
+        got = project_density_pairs(self.h, self.nvol, self.nd, np)
+        np.testing.assert_array_equal(got, want)
+
+    def test_pairs_matches_the_factorized_form(self):
+        """The spin-major layout identity: 'ksasatbtb->ksatb' through the
+        (ns, norb) view selects the same elements in the same order."""
+        want = np.einsum(
+            'ksasatbtb->ksatb',
+            self.h.reshape(self.nvol, *(self.ns, self.norb) * 4)
+        ).reshape(self.nvol, self.nd, self.nd)
+        got = project_density_pairs(self.h, self.nvol, self.nd, np)
+        np.testing.assert_array_equal(got, want)
+
+    def test_squashed_matches_its_original_form(self):
+        want = np.einsum(
+            'ksauatbvb->ksuatvb',
+            self.h.reshape(self.nvol, *(self.ns, self.norb) * 4)
+        ).reshape(self.nvol, *(self.ns, self.ns, self.norb) * 2)
+        got = project_density_squashed(self.h, self.nvol, self.ns,
+                                       self.norb, np)
+        np.testing.assert_array_equal(got, want)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Second increment of #107 phase 2 (plan in that issue; increment 1 was #118).

The density-diagonal reduction of the interaction tensor — the defining operation of the reduced and squashed schemes — existed as seven inline einsum expressions across the two solvers, in two index notations. They now live once in `hwave.solver.density_projection`. FLEX's spin-factorized `'ksasatbtb->ksatb'` is the same extraction as the combined-index `'kaabb->kab'` (verified bitwise on random complex tensors), so all plain-reduced sites share one function; the squashed form keeps its own.

Zero behavior change, pinned by the RPA==FLEX one-shot equivalence matrix, the SCF fixed-point matrix (18 cells), and the full suite: 1037 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCUFFn4bpcC6yLt3TLYgBC