### PR TITLE
Make pytest read pytest.ini, and make the CI coverage gate actually gate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+# Report precision for the coverage gate (PR #126, round-3 review).
+# coverage compares --cov-fail-under against the ROUNDED total: at the
+# default zero-decimal precision, 79.50% rounds to 80 and PASSES an
+# 80-percent floor. Two decimals shrink that rounding leeway to 0.005
+# points. Kept in .coveragerc (not pyproject.toml) deliberately: reading
+# coverage config from pyproject requires the coverage[toml] extra on
+# Python < 3.11, and a missing extra would silently drop this setting.
+[report]
+precision = 2

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,10 @@
-# Report precision for the coverage gate (PR #126, round-3 review).
-# coverage compares --cov-fail-under against the ROUNDED total: at the
-# default zero-decimal precision, 79.50% rounds to 80 and PASSES an
-# 80-percent floor. Two decimals shrink that rounding leeway to 0.005
-# points. Kept in .coveragerc (not pyproject.toml) deliberately: reading
-# coverage config from pyproject requires the coverage[toml] extra on
-# Python < 3.11, and a missing extra would silently drop this setting.
+# Report precision (PR #126). Two decimals make the DISPLAYED totals and
+# the --cov-fail-under comparison finer-grained, but any finite precision
+# still rounds: the HARD floor is enforced separately by
+# tests/_coverage_floor.py, which compares the integer line counts from
+# coverage.xml exactly. Kept in .coveragerc (ini format, read
+# unconditionally) rather than pyproject.toml so the setting does not
+# depend on how coverage's TOML support is provided in a given
+# environment.
 [report]
 precision = 2

--- a/.github/workflows/ci-python39.yml
+++ b/.github/workflows/ci-python39.yml
@@ -67,6 +67,7 @@ jobs:
       # tests nor the gate could actually fail CI).
       run: |
         poetry run pytest tests/ -v --cov=src/hwave --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+        poetry run python tests/_coverage_floor.py coverage.xml 80
 
     - name: Verify the test suite left the tracked tree clean
       # !cancelled(): report isolation defects even when the gating test

--- a/.github/workflows/ci-python39.yml
+++ b/.github/workflows/ci-python39.yml
@@ -60,9 +60,13 @@ jobs:
         poetry run python -m unittest discover tests/ -v
 
     - name: Run tests with pytest and coverage
+      # This step GATES: it runs the pytest-only tests unittest discovery
+      # cannot see, and enforces the coverage floor (issue #84 -- the
+      # floor configured in pytest.ini was silently ignored for a long
+      # time, and this step used to be continue-on-error, so neither the
+      # tests nor the gate could actually fail CI).
       run: |
-        poetry run pytest tests/ -v --cov=src/hwave --cov-report=term-missing --cov-report=xml
-      continue-on-error: true
+        poetry run pytest tests/ -v --cov=src/hwave --cov-report=term-missing --cov-report=xml --cov-fail-under=80
 
     - name: Verify the test suite left the tracked tree clean
       run: |

--- a/.github/workflows/ci-python39.yml
+++ b/.github/workflows/ci-python39.yml
@@ -69,6 +69,9 @@ jobs:
         poetry run pytest tests/ -v --cov=src/hwave --cov-report=term-missing --cov-report=xml --cov-fail-under=80
 
     - name: Verify the test suite left the tracked tree clean
+      # !cancelled(): report isolation defects even when the gating test
+      # step failed -- the diagnostic is most useful exactly then
+      if: ${{ !cancelled() }}
       run: |
         # A test that modifies/deletes a TRACKED file -- or leaves a NEW stray
         # generated file in a committed input/output dir -- is a test-isolation

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,18 +1,22 @@
-[tool:pytest]
+; NOTE: a standalone pytest.ini must use the [pytest] header. This file
+; carried [tool:pytest] -- the setup.cfg header -- for a long time, so
+; pytest silently ignored EVERYTHING here (issue #84): addopts, markers,
+; and the coverage gate were never applied. When editing, keep two
+; constraints in mind:
+;   * no coverage flags in addopts: .github/workflows/run_tests.yml runs
+;     bare pytest without pytest-cov, and --cov here would break it. The
+;     coverage run (and its --cov-fail-under gate) lives in the CI
+;     workflow step that installs pytest-cov.
+;   * --strict-markers is active: register any new marker below or its
+;     first use fails loudly.
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
-    -v
+addopts =
     --tb=short
     --strict-markers
-    --disable-warnings
-    --cov=src/hwave
-    --cov-report=term-missing
-    --cov-report=html:htmlcov
-    --cov-report=xml
-    --cov-fail-under=80
 markers =
     unit: Unit tests
     integration: Integration tests

--- a/tests/_coverage_floor.py
+++ b/tests/_coverage_floor.py
@@ -1,0 +1,52 @@
+"""Exact coverage-floor check for CI (issue #84 / PR #126).
+
+``--cov-fail-under`` compares the floor against the ROUNDED total, so at
+any finite precision some band below the floor still passes (at the
+default zero decimals, 79.50% passed an 80 floor; at two decimals,
+79.995% still would -- and the review showed that value is attainable
+in this tree). This checker instead compares the integer line counts
+from coverage's XML report exactly: covered/valid >= floor/100 with no
+floating point and no rounding.
+
+CI invokes it right after the pytest+coverage step:
+
+    python tests/_coverage_floor.py coverage.xml 80
+
+The pure predicate is unit-tested in test_pytest_config.py. The file is
+named with a leading underscore so neither pytest (test_*.py) nor
+unittest discovery (test*.py) collects it as a test module.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+
+
+def passes(covered, valid, floor_percent):
+    """True iff covered/valid >= floor_percent/100, exactly.
+
+    Integer arithmetic only: covered * 100 >= valid * floor_percent is
+    the cross-multiplied form, exact for any int inputs. A report with
+    no valid lines fails (nothing was measured -- that is never a pass).
+    """
+    covered = int(covered)
+    valid = int(valid)
+    floor_percent = int(floor_percent)
+    if valid <= 0:
+        return False
+    return covered * 100 >= valid * floor_percent
+
+
+def main(argv):
+    xml_path, floor_percent = argv[1], int(argv[2])
+    root = ET.parse(xml_path).getroot()
+    covered = int(root.get("lines-covered"))
+    valid = int(root.get("lines-valid"))
+    ok = passes(covered, valid, floor_percent)
+    pct = 100.0 * covered / valid if valid else 0.0
+    print("exact coverage floor: {}/{} lines = {:.4f}% vs {}%: {}".format(
+        covered, valid, pct, floor_percent, "OK" if ok else "FAIL"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -6,9 +6,10 @@ still succeeded, so nothing noticed. This test fails if that ever
 happens again, by asserting the configuration the file declares was
 actually APPLIED, not merely that collection worked.
 
-pytest-style on purpose: it needs the pytest config object, and since
-the CI pytest step gates (issue #84 follow-through), a failure here
-fails CI even though unittest discovery cannot see this module.
+pytest-style on purpose: it needs the pytest config object. unittest
+discovery imports this module but collects no function-style tests;
+since the CI pytest step gates (issue #84 follow-through), a failure
+here still fails CI.
 """
 
 
@@ -37,24 +38,37 @@ def test_pytest_ini_is_actually_loaded(request):
         "pytest.ini addopts were not applied (issue #84 header regression)")
 
 
-def test_coverage_gate_boundary_semantics():
-    """The CI coverage floor compares the ROUNDED total (PR #126 round-3
-    review measured 79.50% passing an 80 floor at coverage's default
-    zero-decimal precision). Pin the boundary at the two-decimal
-    precision .coveragerc sets, and that the config is actually loaded."""
+def test_coverage_floor_is_exact():
+    """The CI floor is enforced by tests/_coverage_floor.py on the
+    integer line counts from coverage.xml -- NOT by the rounded
+    --cov-fail-under comparison, which at any finite precision passes a
+    band just below the floor (79.50% passed at zero decimals; 79.995%
+    would at two, and the round-5 review showed 6151/7689 = 79.9974% is
+    three added statements away in this tree). Pin the exact predicate
+    on those boundary cases."""
+    from tests._coverage_floor import passes
+
+    assert passes(4, 5, 80)             # exactly 80.00%
+    assert passes(80, 100, 80)
+    assert not passes(7999, 10000, 80)  # 79.99%
+    assert not passes(6151, 7689, 80)   # 79.9974% -- rounds to 80.00
+    assert not passes(0, 0, 80)         # nothing measured is not a pass
+
+
+def test_coverage_report_precision_is_two_decimals():
+    """.coveragerc sets two-decimal report precision (display and the
+    soft --cov-fail-under comparison). Asserted through coverage's
+    PUBLIC get_option API only -- a round-5 review found the earlier
+    version of this test bound to undocumented internals, which a
+    coverage upgrade could rename (silently skipping the test under the
+    broad ImportError guard)."""
     try:
         from coverage import Coverage
-        from coverage.results import should_fail_under
     except ImportError:
         import pytest
         pytest.skip("coverage not installed (bare-pytest environments)")
 
-    assert should_fail_under(79.99, 80, 2)
-    assert not should_fail_under(80.00, 80, 2)
-    # at the DEFAULT precision the leak this guards against reappears
-    assert not should_fail_under(79.50, 80, 0)
-
-    cov = Coverage()
-    assert cov.config.precision == 2, (
+    cov = Coverage(data_file=None)
+    assert cov.get_option("report:precision") == 2, (
         ".coveragerc precision=2 was not loaded (cwd must be the repo "
-        "root; got precision={})".format(cov.config.precision))
+        "root)")

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -1,0 +1,35 @@
+"""Detect the pytest.ini header regression (issue #84).
+
+pytest.ini carried the [tool:pytest] header -- valid only in setup.cfg --
+for a long time, and pytest silently ignored the whole file: collection
+still succeeded, so nothing noticed. This test fails if that ever
+happens again, by asserting the configuration the file declares was
+actually APPLIED, not merely that collection worked.
+
+pytest-style on purpose: it needs the pytest config object, and since
+the CI pytest step gates (issue #84 follow-through), a failure here
+fails CI even though unittest discovery cannot see this module.
+"""
+
+
+def test_pytest_ini_is_actually_loaded(request):
+    config = request.config
+
+    # the config file pytest resolved must be our pytest.ini
+    assert config.inipath is not None, (
+        "pytest resolved NO ini file: pytest.ini is missing or unreadable")
+    assert config.inipath.name == "pytest.ini", str(config.inipath)
+
+    # the marker registry from the ini must be present (a wrong header
+    # silently drops it; --strict-markers would then fail elsewhere, but
+    # only if a marked test is collected -- assert it directly)
+    markers = config.getini("markers")
+    assert any(str(m).startswith("slow:") for m in markers), (
+        "pytest.ini's marker registry was not applied -- most likely the "
+        "section header regressed from [pytest] to [tool:pytest], which "
+        "pytest ignores in a standalone pytest.ini (issue #84): {}".format(
+            markers))
+
+    # addopts must have been applied too
+    assert config.getoption("--strict-markers"), (
+        "pytest.ini addopts were not applied (issue #84 header regression)")

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -18,7 +18,9 @@ def test_pytest_ini_is_actually_loaded(request):
     # the config file pytest resolved must be our pytest.ini
     assert config.inipath is not None, (
         "pytest resolved NO ini file: pytest.ini is missing or unreadable")
-    assert config.inipath.name == "pytest.ini", str(config.inipath)
+    assert config.inipath == config.rootpath / "pytest.ini", (
+        "resolved ini is not the repository's own pytest.ini: {}".format(
+            config.inipath))
 
     # the marker registry from the ini must be present (a wrong header
     # silently drops it; --strict-markers would then fail elsewhere, but
@@ -33,3 +35,26 @@ def test_pytest_ini_is_actually_loaded(request):
     # addopts must have been applied too
     assert config.getoption("--strict-markers"), (
         "pytest.ini addopts were not applied (issue #84 header regression)")
+
+
+def test_coverage_gate_boundary_semantics():
+    """The CI coverage floor compares the ROUNDED total (PR #126 round-3
+    review measured 79.50% passing an 80 floor at coverage's default
+    zero-decimal precision). Pin the boundary at the two-decimal
+    precision .coveragerc sets, and that the config is actually loaded."""
+    try:
+        from coverage import Coverage
+        from coverage.results import should_fail_under
+    except ImportError:
+        import pytest
+        pytest.skip("coverage not installed (bare-pytest environments)")
+
+    assert should_fail_under(79.99, 80, 2)
+    assert not should_fail_under(80.00, 80, 2)
+    # at the DEFAULT precision the leak this guards against reappears
+    assert not should_fail_under(79.50, 80, 0)
+
+    cov = Coverage()
+    assert cov.config.precision == 2, (
+        ".coveragerc precision=2 was not loaded (cwd must be the repo "
+        "root; got precision={})".format(cov.config.precision))

--- a/tests/test_pytest_config.py
+++ b/tests/test_pytest_config.py
@@ -72,3 +72,32 @@ def test_coverage_report_precision_is_two_decimals():
     assert cov.get_option("report:precision") == 2, (
         ".coveragerc precision=2 was not loaded (cwd must be the repo "
         "root)")
+
+
+def test_coverage_floor_cli(tmp_path):
+    """CLI-level pin of the exact-floor checker: passing, failing,
+    malformed and missing XML must produce the right exit codes, and
+    the failure modes must be loud (nonzero), never a silent pass."""
+    import subprocess
+    import sys
+
+    script = "tests/_coverage_floor.py"
+
+    def run(*args):
+        return subprocess.run([sys.executable, script, *args],
+                              capture_output=True, text=True)
+
+    def xml(covered, valid):
+        p = tmp_path / "cov_{}_{}.xml".format(covered, valid)
+        p.write_text('<coverage lines-covered="{}" lines-valid="{}">'
+                     '</coverage>'.format(covered, valid))
+        return str(p)
+
+    assert run(xml(4, 5), "80").returncode == 0
+    assert run(xml(7999, 10000), "80").returncode == 1
+    assert run(xml(6151, 7689), "80").returncode == 1
+
+    bad = tmp_path / "bad.xml"
+    bad.write_text("<coverage")
+    assert run(str(bad), "80").returncode != 0
+    assert run(str(tmp_path / "missing.xml"), "80").returncode != 0


### PR DESCRIPTION
## Summary

Closes #84. \`pytest.ini\` used the \`[tool:pytest]\` header -- the one pytest reads only from \`setup.cfg\` -- so in a standalone \`pytest.ini\` **every setting in the file was silently ignored**: \`addopts\`, the marker registry, and the \`--cov-fail-under=80\` floor the CI appeared to enforce.

Per the issue's request this lands deliberately, not as a drive-by header flip:

- **Header corrected** to \`[pytest]\`; the file documents its own failure mode and its two constraints.
- **addopts slimmed** to \`--tb=short --strict-markers\`. The coverage flags are removed from the ini: \`run_tests.yml\` runs bare \`pytest\` without \`pytest-cov\` installed, and activating \`--cov\` from the ini would break that workflow. \`-v\` (noise at 1100+ tests) and \`--disable-warnings\` (hides real signals) are dropped.
- **Markers genuinely register** now, with \`--strict-markers\` making any unregistered marker fail loudly.
- **The coverage floor moves to where coverage actually runs**: the \`ci-python39.yml\` pytest step gains \`--cov-fail-under=80\` and loses \`continue-on-error\`, so it now gates. This also closes a known gap: module-level pytest-style tests are invisible to unittest discovery and previously ran only in a step whose failures could not fail CI.

## Verification

Measured before the flip: coverage 84.6% (floor 80, margin ~4.6 points). Full suite green under the new options with both runners: pytest 1135 passed / 25 skipped, unittest discovery OK. The exact gated CI command (cov + fail-under) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCUFFn4bpcC6yLt3TLYgBC