### PR TITLE
RPA: bond-resolved transverse (spin-flip) channel with off-site interactions (experimental)

### DIFF
--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2926,14 +2926,21 @@ def W_pm_bond(topo, ham_pm_onsite, *, spatial_shape):
        to every CALLER per the spec's "Construction domain"). Each
        representative ``(m, a, b)`` with coefficient
        ``C = topo.coeffs[type][m][a, b]`` emits the SAME real value into
-       BOTH mirrored diagonal target cells:
-       ``W[q, (reverse[m], a, b), (reverse[m], a, b)] += s_type * Re(C)``
-       and ``W[q, (m, b, a), (m, b, a)] += s_type * Re(C)`` -- bond-
-       diagonal, q-INDEPENDENT. The per-slot ``Re(.)`` placement (never
-       the raw complex value) is deliberate: a Hermitian-closed ``+-i*eps``
-       null-direction pair must leave the diagonal exactly real (the
-       structural Hermiticity test with a complex ``CoulombInter``
-       coefficient pins this).
+       BOTH mirrored diagonal target cells, DIRECT placement (AMENDED
+       2026-08-16, Task-6 granule adjudication -- the channel carrying
+       the declared coefficient is the target, matching the longitudinal
+       ``bare_bond_vertices`` Fock-diagonal rule exactly; the PREVIOUS
+       ``m <-> reverse[m]`` swap FAILED the multi-orbital off-site
+       CoulombInter granule at O(1), invisible at ``a == b`` which is why
+       Gate W0's norb=1 fixtures never caught it -- see the spec's "Cross
+       family" section for the full derivation):
+       ``W[q, (m, a, b), (m, a, b)] += s_type * Re(C)``
+       and ``W[q, (reverse[m], b, a), (reverse[m], b, a)] += s_type * Re(C)``
+       -- bond-diagonal, q-INDEPENDENT. The per-slot ``Re(.)`` placement
+       (never the raw complex value) is deliberate: a Hermitian-closed
+       ``+-i*eps`` null-direction pair must leave the diagonal exactly
+       real (the structural Hermiticity test with a complex
+       ``CoulombInter`` coefficient pins this).
     3. **Flip family** (``Exchange``, ``f_J = -1``), the SAME off-site
        representatives. Each representative ``(m, a, b)`` with
        ``J = topo.coeffs["Exchange"][m][a, b]`` at ``R = topo.delta_r[m]``
@@ -3057,6 +3064,18 @@ def W_pm_bond(topo, ham_pm_onsite, *, spatial_shape):
 
     # Step 2: cross family (CoulombInter, Ising) -- bond-diagonal,
     # q-independent, both mirrored diagonal target cells per representative.
+    # AMENDED (2026-08-16, Task-6 granule adjudication): DIRECT placement
+    # -- content lands at I=(m,a,b), the channel m carrying the declared
+    # coefficient (delta_r[m] = +R_declared), matching the longitudinal
+    # bare_bond_vertices Fock-diagonal rule exactly (#151-validated
+    # precedent). The mirrored partner emits the same Re value at
+    # (reverse[m], b, a). The PREVIOUS m<->reverse[m] swap (target at
+    # reverse[m] with (a,b) unchanged, target at m with (b,a) swapped)
+    # FAILED the multi-orbital off-site CoulombInter granule (L=3, norb=2,
+    # a != b) at O(1) (0.12 vs tol 5.6e-4) -- invisible at a=b, which is
+    # why Gate W0's norb=1 cross-family fixtures could not catch it; see
+    # docs/superpowers/specs/2026-08-15-bond-transverse-design.md, "Cross
+    # family", the 2026-08-16 amendment.
     for type_name, s_type in (("CoulombInter", -1.0), ("Ising", 1.0)):
         block_arr = coeffs.get(type_name)
         if block_arr is None:
@@ -3065,10 +3084,10 @@ def W_pm_bond(topo, ham_pm_onsite, *, spatial_shape):
             val = s_type * float(np.real(block_arr[m, a, b]))
             if val == 0.0:
                 continue
-            target1 = int(reverse[m])
-            idx1 = target1 * nd + a * norb + b
+            idx1 = m * nd + a * norb + b
             W[:, idx1, idx1] += val
-            idx2 = m * nd + b * norb + a
+            target2 = int(reverse[m])
+            idx2 = target2 * nd + b * norb + a
             W[:, idx2, idx2] += val
 
     # Step 3: flip family (Exchange) -- the two AMENDED ordered records,

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2683,13 +2683,16 @@ def _require_transverse_integral(value, label):
     # arrays, None, complex, non-integral or non-finite floats -- is
     # rejected; numeric strings deliberately do NOT coerce.
     if isinstance(value, (float, np.floating)):
-        value_f = float(value)
-        if (not np.isfinite(value_f) or value_f != np.floor(value_f)
-                or abs(value_f) > 2.0**53):
+        # Validate at the value's NATIVE precision (no float() narrowing:
+        # a fractional np.longdouble could round to an integral float64,
+        # and a longdouble just above 2**53 could narrow onto the
+        # accepted boundary).
+        if (not np.isfinite(value) or value != np.floor(value)
+                or abs(value) > 2.0**53):
             raise ValueError(
                 "resolve_transverse_topology: {} must be an integral "
                 "value, got {!r}".format(label, value))
-        return int(value_f)
+        return int(value)
     raise ValueError(
         "resolve_transverse_topology: {} must be an integer, got "
         "{!r}".format(label, value))

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2872,3 +2872,218 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
         coeffs[type_name] = arr
 
     return TransverseTopology(delta_r=delta_r, reverse=reverse, coeffs=coeffs)
+
+
+# =============================================================================
+# Phase W, Task 3 -- the production bond-resolved transverse vertex W_pm_bond
+# =============================================================================
+#
+# APPEND-ONLY REGION (continued): nothing above this banner is touched by
+# this task -- `resolve_interactions`/`bare_bond_vertices` (templates) and
+# every Task-2 name (`TransverseTopology`, `resolve_transverse_topology`,
+# `iter_reversal_orbits`, `validate_topology_against_mesh`,
+# `transverse_effective_activity`) stay byte-for-byte identical.
+#
+# Implements docs/superpowers/specs/2026-08-15-bond-transverse-design.md,
+# "The vertex -- element equations" (steps 1-3, the AMENDED 2026-08-16 flip-
+# family assignment) -- the ORDERED-RECORD equations Gate W0
+# (tests/test_bond_transverse_ed.py, Task 1) numerically validated against
+# exact diagonalization BEFORE this function existed. This function is a
+# faithful production transcription of that gate's test-local reference,
+# `w_expected_from_records`: same representative-orbit iteration (via the
+# shared `iter_reversal_orbits`, filtered to the off-site R != 0 domain),
+# same coefficient table, same q-phase convention -- cross-pinned against
+# that reference at rel=0/abs=1e-13 on all three W0 ED granule fixtures in
+# tests/test_bond_transverse_w.py.
+
+def W_pm_bond(topo, ham_pm_onsite, *, spatial_shape):
+    """The bond-resolved transverse (spin-flip) vertex ``W_{+-}(q)``, built
+    from ``topo`` (a :class:`TransverseTopology`, spec "The master
+    transverse topology") and the CALLER-ASSEMBLED on-site vertex
+    ``ham_pm_onsite`` (spec "The vertex -- element equations", steps 1-3).
+
+    Construction (spec, verbatim; also see the module-level Task 1 gate
+    ``tests/test_bond_transverse_ed.py``'s ``w_expected_from_records``,
+    which encodes the IDENTICAL equations independently and is this
+    function's ED-validated oracle):
+
+    1. **Channel-0 (on-site) block** = ``ham_pm_onsite`` verbatim, placed
+       (never re-assembled -- ``W_pm_bond`` performs NO assembly of its
+       own) into ``W[:, 0:nd, 0:nd]``. ``ham_pm_onsite`` already carries
+       the mesh's ``nvol`` leading axis (the shape
+       ``_assemble_transverse_vertex`` returns): for genuinely on-site-only
+       declarations that tensor is q-INDEPENDENT (constant along the
+       leading axis) by construction elsewhere
+       (``_check_transverse_representable``), so this step is a placement,
+       not a broadcast, despite the shared leading axis -- the B=1
+       reduction test pins this: with ``B=1`` (on-site-only topology),
+       ``W_pm_bond`` IS ``ham_pm_onsite`` reshaped, bit for bit.
+    2. **Cross family** (``CoulombInter`` -> ``-Re(.)``, ``Ising`` ->
+       ``+Re(.)``), OFF-SITE (``R != 0``) reversal-orbit representatives
+       only (``iter_reversal_orbits(topo)``, filtered to ``m != 0`` --
+       that helper's own docstring: "the mandatory local channel 0" is
+       included in its general enumeration; the off-site filter belongs
+       to every CALLER per the spec's "Construction domain"). Each
+       representative ``(m, a, b)`` with coefficient
+       ``C = topo.coeffs[type][m][a, b]`` emits the SAME real value into
+       BOTH mirrored diagonal target cells:
+       ``W[q, (reverse[m], a, b), (reverse[m], a, b)] += s_type * Re(C)``
+       and ``W[q, (m, b, a), (m, b, a)] += s_type * Re(C)`` -- bond-
+       diagonal, q-INDEPENDENT. The per-slot ``Re(.)`` placement (never
+       the raw complex value) is deliberate: a Hermitian-closed ``+-i*eps``
+       null-direction pair must leave the diagonal exactly real (the
+       structural Hermiticity test with a complex ``CoulombInter``
+       coefficient pins this).
+    3. **Flip family** (``Exchange``, ``f_J = -1``), the SAME off-site
+       representatives. Each representative ``(m, a, b)`` with
+       ``J = topo.coeffs["Exchange"][m][a, b]`` at ``R = topo.delta_r[m]``
+       emits the AMENDED (2026-08-16, Gate W0 adjudication) two ordered
+       records, q-dependent ONLY here:
+       ``W[q, (0,a,a), (0,b,b)] += f_J * conj(J) * exp(-i q.R)`` and
+       ``W[q, (0,b,b), (0,a,a)] += f_J * J * exp(+i q.R)``. The PRE-
+       amendment draft form (``f_J*J*exp(+iqR)`` at ``(aa,bb)``) failed
+       Gate W0's multi-orbital off-site Exchange granule systematically
+       (residuals 0.18-0.33); this is the swapped, ED-adjudicated
+       assignment.
+
+    The q mesh is ``q = 2*pi*(n_x/N_x, n_y/N_y, n_z/N_z)`` (``spatial_shape
+    = (N_x, N_y, N_z)``), C-order flattened -- the SAME convention
+    ``sc._build_bond_m0_blocks``'s own phase composition uses (cross-pinned
+    by a dedicated test on a shared fixture); ``q.R = 2*pi*sum_d
+    n_d*R_d/N_d``. The ``(Nx, Ny, Nz, ...)`` frame used to build this mesh
+    is private to this function; the returned array is the canonical
+    flattened ``(nvol, ND, ND)`` shape every numerical object in the spec
+    uses.
+
+    Parameters
+    ----------
+    topo : TransverseTopology
+        The master transverse bond topology (``resolve_transverse_topology``
+        or an equivalent hand-built, invariant-satisfying instance).
+    ham_pm_onsite : array_like, shape (nvol, norb, norb, norb, norb),
+        complex
+        The ALREADY-ASSEMBLED on-site transverse vertex (e.g.
+        ``RPA._assemble_transverse_vertex`` applied to the on-site-only
+        tensor filtered from the ORIGINAL PRE-FOLD declarations at
+        ``irvec == (0, 0, 0)``) -- never re-derived here.
+    spatial_shape : sequence of 3 ints
+        ``(Nx, Ny, Nz)``; ``nvol = Nx*Ny*Nz`` must match both
+        ``ham_pm_onsite``'s leading axis and ``topo``'s own mesh-
+        injectivity requirement (``validate_topology_against_mesh``,
+        invoked here at entry).
+
+    Returns
+    -------
+    ndarray, complex128, shape (nvol, ND, ND)
+        ``ND = B * norb**2``, ``B = len(topo.delta_r)``.
+
+    Raises
+    ------
+    ValueError
+        Propagated from :func:`validate_topology_against_mesh` (mesh-
+        injectivity violation, malformed ``spatial_shape``, a
+        ``ham_pm_onsite`` whose leading axis disagrees with ``nvol``, or a
+        stale/corrupted ``topo``), or raised directly here if
+        ``ham_pm_onsite`` has the wrong ndim/shape or its orbital count
+        disagrees with ``topo.coeffs``'s.
+    """
+    try:
+        Nx, Ny, Nz = (int(x) for x in spatial_shape)
+    except (TypeError, ValueError):
+        raise ValueError(
+            "W_pm_bond: spatial_shape must be a length-3 sequence of "
+            "integers; got {!r}".format(spatial_shape))
+    nvol = Nx * Ny * Nz
+
+    ham_pm_onsite = np.array(ham_pm_onsite, dtype=complex, copy=False)
+    if ham_pm_onsite.ndim != 5:
+        raise ValueError(
+            "W_pm_bond: ham_pm_onsite must have ndim=5 (nvol, norb, norb, "
+            "norb, norb); got shape {}".format(ham_pm_onsite.shape))
+    norb = ham_pm_onsite.shape[1]
+    expected_onsite_shape = (nvol, norb, norb, norb, norb)
+    if ham_pm_onsite.shape != expected_onsite_shape:
+        raise ValueError(
+            "W_pm_bond: ham_pm_onsite must have shape (nvol, norb, norb, "
+            "norb, norb) = {} (nvol from spatial_shape={}, norb inferred "
+            "from ham_pm_onsite.shape[1]); got {}".format(
+                expected_onsite_shape, spatial_shape, ham_pm_onsite.shape))
+
+    # The ONE mesh-dependent validation lifecycle point (spec, "The master
+    # transverse topology"): mesh-injectivity of topo.delta_r AND that
+    # ham_pm_onsite's leading axis matches nvol.
+    validate_topology_against_mesh(
+        topo, spatial_shape, arrays={"ham_pm_onsite": ham_pm_onsite})
+    # Re-fetch a freshly-validated, alias-safe topology for local use (the
+    # same defensive re-construction validate_topology_against_mesh applies
+    # internally -- topo.coeffs is a plain dict a caller could have re-keyed
+    # between that call returning and this line).
+    topo = TransverseTopology(topo.delta_r, topo.reverse, topo.coeffs)
+
+    delta_r = np.asarray(topo.delta_r)
+    reverse = np.asarray(topo.reverse)
+    B = delta_r.shape[0]
+    coeffs = topo.coeffs
+    for type_name, arr in coeffs.items():
+        if arr.shape[1] != norb:
+            raise ValueError(
+                "W_pm_bond: topo.coeffs[{!r}] has norb={} but "
+                "ham_pm_onsite implies norb={}".format(
+                    type_name, arr.shape[1], norb))
+
+    nd = norb * norb
+    ND = B * nd
+    W = np.zeros((nvol, ND, ND), dtype=complex)
+
+    # Step 1: channel-0 block = the received on-site vertex, placed
+    # verbatim (no assembly, no broadcast beyond what ham_pm_onsite's own
+    # leading axis already carries).
+    W[:, 0:nd, 0:nd] = ham_pm_onsite.reshape(nvol, nd, nd)
+
+    # q mesh (private (Nx, Ny, Nz) frame, C-order flattened), spec's fixed
+    # convention -- the same one sc._build_bond_m0_blocks' phase uses.
+    kx = 2.0 * np.pi * np.arange(Nx) / Nx
+    ky = 2.0 * np.pi * np.arange(Ny) / Ny
+    kz = 2.0 * np.pi * np.arange(Nz) / Nz
+    KX, KY, KZ = np.meshgrid(kx, ky, kz, indexing='ij')
+    q_flat = np.stack([KX.ravel(), KY.ravel(), KZ.ravel()], axis=-1)
+
+    # Off-site (R != 0) reversal-orbit representatives -- the shared helper
+    # (spec, "Canonical orbit rule") ranges over EVERY channel including 0;
+    # steps 2-3 are binding to the off-site construction domain only (spec,
+    # "Construction domain (binding for steps 2-3)"), so channel 0 is
+    # filtered out here, not inside the shared helper.
+    reps = [rep for rep in iter_reversal_orbits(topo) if rep[0] != 0]
+
+    # Step 2: cross family (CoulombInter, Ising) -- bond-diagonal,
+    # q-independent, both mirrored diagonal target cells per representative.
+    for type_name, s_type in (("CoulombInter", -1.0), ("Ising", 1.0)):
+        block_arr = coeffs.get(type_name)
+        if block_arr is None:
+            continue
+        for (m, a, b) in reps:
+            val = s_type * float(np.real(block_arr[m, a, b]))
+            if val == 0.0:
+                continue
+            target1 = int(reverse[m])
+            idx1 = target1 * nd + a * norb + b
+            W[:, idx1, idx1] += val
+            idx2 = m * nd + b * norb + a
+            W[:, idx2, idx2] += val
+
+    # Step 3: flip family (Exchange) -- the two AMENDED ordered records,
+    # q-dependent ONLY through this local-channel phase.
+    exch_arr = coeffs.get("Exchange")
+    if exch_arr is not None:
+        for (m, a, b) in reps:
+            J = complex(exch_arr[m, a, b])
+            if J == 0.0:
+                continue
+            R = delta_r[m].astype(float)
+            phase = np.exp(1j * (q_flat @ R))
+            idx_aa = a * norb + a
+            idx_bb = b * norb + b
+            W[:, idx_aa, idx_bb] += -1.0 * np.conj(J) * np.conj(phase)
+            W[:, idx_bb, idx_aa] += -1.0 * J * phase
+
+    return W

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2668,21 +2668,31 @@ def _require_transverse_integral(value, label):
     ``irvec``/``orbvec`` component that is accidentally a truthiness
     flag) is never a legitimate integral coordinate here.
     """
-    if isinstance(value, bool):
+    if isinstance(value, (bool, np.bool_)):
         raise ValueError(
             "resolve_transverse_topology: {} must be an integer, not a "
             "bool, got {!r}".format(label, value))
-    try:
+    # Exact-integer types pass through unchanged (arbitrary precision:
+    # no float round-trip, which would silently round values above
+    # 2**53 and overflow on huge ints).
+    if isinstance(value, (int, np.integer)):
+        return int(value)
+    # Float types are accepted iff they carry an exact integral value
+    # small enough that the value is unambiguous (|v| <= 2**53, the
+    # float64 contiguous-integer bound). Everything else -- strings,
+    # arrays, None, complex, non-integral or non-finite floats -- is
+    # rejected; numeric strings deliberately do NOT coerce.
+    if isinstance(value, (float, np.floating)):
         value_f = float(value)
-    except (TypeError, ValueError):
-        raise ValueError(
-            "resolve_transverse_topology: {} must be an integer, got "
-            "{!r}".format(label, value))
-    if not np.isfinite(value_f) or value_f != np.floor(value_f):
-        raise ValueError(
-            "resolve_transverse_topology: {} must be an integral value, "
-            "got {!r}".format(label, value))
-    return int(value_f)
+        if (not np.isfinite(value_f) or value_f != np.floor(value_f)
+                or abs(value_f) > 2.0**53):
+            raise ValueError(
+                "resolve_transverse_topology: {} must be an integral "
+                "value, got {!r}".format(label, value))
+        return int(value_f)
+    raise ValueError(
+        "resolve_transverse_topology: {} must be an integer, got "
+        "{!r}".format(label, value))
 
 
 def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2095,3 +2095,730 @@ def track_subspace(points, *, seed=None, weight=None, deg_tol=1.0e-3,
         prev_basis = Q if Q.shape[0] > 0 else sub
 
     return records
+
+
+# =============================================================================
+# Phase W, Task 2 -- the master transverse bond topology
+# =============================================================================
+#
+# APPEND-ONLY REGION. Nothing above this banner is touched by this task (or
+# any later Phase W task): `resolve_interactions` and every pre-existing
+# function/class in this module stay byte-for-byte identical (the
+# append-only contract of
+# docs/superpowers/plans/2026-08-16-bond-transverse-phase-w.md, "Global
+# Constraints" -- `bare_bond_vertices`/`resolve_interactions` are templates,
+# never edited).
+#
+# Implements the "master transverse topology" of
+# docs/superpowers/specs/2026-08-15-bond-transverse-design.md ("The
+# enlarged transverse objects (contracts)" -> "The master transverse
+# topology", "Canonical orbit rule", "Construction domain (binding for
+# steps 2-3)"): `TransverseTopology`, `resolve_transverse_topology`,
+# `iter_reversal_orbits`, `validate_topology_against_mesh`,
+# `transverse_effective_activity`. This section stays general (topology and
+# coefficient bookkeeping only) -- vertex construction (`W_pm_bond`, Phase W
+# Task 3) and the bubble (`transverse_bond_bubble_static`, Task 4) are NOT
+# built here; they consume this section's objects.
+
+import collections as _collections  # local: keeps the append-only region
+                                     # self-contained without touching the
+                                     # module's top-of-file import block.
+
+_TRANSVERSE_ACTIVE_TYPES = ("CoulombInter", "Ising", "Exchange")
+
+
+def _as_readonly_int_array(value, name, *, ndim, last_dim=None):
+    """Validate/convert ``value`` into a read-only ``int64`` array for
+    :class:`TransverseTopology`'s ``delta_r``/``reverse`` fields.
+
+    Rejects (``ValueError``, never silently clamps/truncates -- the same
+    philosophy ``resolve_interactions``'s ``bond_max_shells`` validation
+    uses): wrong ``ndim``, a wrong trailing axis length (when ``last_dim``
+    is given), a complex dtype, a non-finite value, or a genuinely
+    fractional value. A float array whose entries are all exact integers
+    (e.g. ``np.array([[0, 0, 0]], dtype=float)``) is accepted and cast.
+    """
+    arr = np.asarray(value)
+    if arr.ndim != ndim:
+        raise ValueError(
+            "TransverseTopology: {} must have ndim={}; got shape {}".format(
+                name, ndim, arr.shape))
+    if last_dim is not None and arr.shape[-1] != last_dim:
+        raise ValueError(
+            "TransverseTopology: {} must have last axis of length {}; got "
+            "shape {}".format(name, last_dim, arr.shape))
+    if np.iscomplexobj(arr):
+        raise ValueError(
+            "TransverseTopology: {} must be real/integer-valued; got a "
+            "complex dtype ({})".format(name, arr.dtype))
+    if arr.size and not np.all(np.isfinite(arr)):
+        raise ValueError(
+            "TransverseTopology: {} must be finite; got {}".format(name, arr))
+    if not np.issubdtype(arr.dtype, np.integer):
+        if arr.size and not np.all(arr == np.round(arr)):
+            raise ValueError(
+                "TransverseTopology: {} must be integer-valued (no "
+                "fractional part); got {}".format(name, arr))
+    out = np.array(arr, dtype=np.int64, copy=True)
+    out.flags.writeable = False
+    return out
+
+
+_TransverseTopologyBase = _collections.namedtuple(
+    "_TransverseTopologyBase", ["delta_r", "reverse", "coeffs"])
+
+
+class TransverseTopology(_TransverseTopologyBase):
+    """Alias-safe, closure-validated bond-channel topology for the
+    transverse (spin-flip) channel (spec, "The master transverse
+    topology").
+
+    Fields
+    ------
+    delta_r : np.ndarray, shape (B, 3), int64, read-only
+        Bravais-cell displacement per channel. ``delta_r[0] == (0, 0, 0)``
+        ALWAYS -- the mandatory local channel every topology contains,
+        never removed by shell truncation.
+    reverse : np.ndarray, shape (B,), int64, read-only
+        ``reverse[m]`` is the channel index of ``-delta_r[m]``;
+        ``reverse[reverse[m]] == m`` for every ``m`` (an involution) and
+        ``reverse[0] == 0``.
+    coeffs : dict[str, np.ndarray]
+        Per-interaction-type ``(B, norb, norb)`` complex arrays (a plain,
+        NEW dict -- mutating the dict passed into the constructor does not
+        affect the stored one), all sharing the same ``B``/``norb``. Every
+        array's own arrays are read-only, ``coeffs[t][0]`` is EXACTLY zero
+        (on-site content is represented exclusively by the caller's
+        ``ham_pm_onsite``, never here), and the closure invariant
+        ``coeffs[t][reverse[m]] == conj(coeffs[t][m]).T`` holds EXACTLY
+        (to the last bit) for every ``m``.
+
+    ``B = len(delta_r)`` (channel count, including channel 0); the enlarged
+    dimension a consumer builds from this topology is ``ND = B * norb**2``.
+
+    "Alias-safe", not "immutable": array VALUES cannot be mutated in place
+    (``flags.writeable = False``), but ``coeffs`` is an ordinary dict a
+    caller could re-key or replace wholesale on an aliased reference --
+    every consumer boundary (:func:`validate_topology_against_mesh`)
+    therefore re-validates rather than trusting a previously-constructed
+    instance is still well-formed.
+
+    Raises
+    ------
+    ValueError
+        On any invariant violation, at construction time (never
+        assert -- this is a public constructor, not an internal
+        precondition).
+    """
+
+    __slots__ = ()
+
+    def __new__(cls, delta_r, reverse, coeffs):
+        delta_r = _as_readonly_int_array(delta_r, "delta_r", ndim=2, last_dim=3)
+        B = delta_r.shape[0]
+        if B < 1:
+            raise ValueError(
+                "TransverseTopology: delta_r must carry at least channel 0 "
+                "(the mandatory local R=(0,0,0) channel); got shape {}"
+                .format(delta_r.shape))
+        if not np.array_equal(delta_r[0], np.zeros(3, dtype=np.int64)):
+            raise ValueError(
+                "TransverseTopology: channel 0 must be R=(0,0,0) (the "
+                "mandatory local channel every topology contains); got "
+                "delta_r[0]={}".format(tuple(int(x) for x in delta_r[0])))
+
+        reverse = _as_readonly_int_array(reverse, "reverse", ndim=1)
+        if reverse.shape != (B,):
+            raise ValueError(
+                "TransverseTopology: reverse must have shape ({},), "
+                "matching delta_r's channel count B={}; got {}".format(
+                    B, B, reverse.shape))
+        if reverse.size and (np.any(reverse < 0) or np.any(reverse >= B)):
+            raise ValueError(
+                "TransverseTopology: reverse entries must all be valid "
+                "channel indices in [0, {}); got {}".format(
+                    B, reverse.tolist()))
+        if not np.array_equal(reverse[reverse], np.arange(B, dtype=np.int64)):
+            raise ValueError(
+                "TransverseTopology: reverse must be an involution "
+                "(reverse[reverse[m]] == m for every channel m); got "
+                "reverse={}".format(reverse.tolist()))
+        if int(reverse[0]) != 0:
+            raise ValueError(
+                "TransverseTopology: reverse[0] must be 0 -- channel 0 "
+                "(R=(0,0,0)) is its own reversal partner; got reverse[0]={}"
+                .format(int(reverse[0])))
+        # Geometric consistency: reverse[m] must genuinely be the channel of
+        # -delta_r[m]. This is not separately listed among the spec's
+        # constructor-time checks, but reverse's whole MEANING depends on
+        # it, and every downstream consumer (the closure check right below,
+        # iter_reversal_orbits, W_pm_bond's orbit iteration) silently
+        # produces wrong results if it is violated -- the same
+        # internal-interface guard bare_bond_vertices applies to
+        # ResolvedInteractionSet.reverse (see its "bond_set is not
+        # reversal-closed" ValueError above).
+        neg = -delta_r
+        if not np.array_equal(delta_r[reverse], neg):
+            mism = np.any(delta_r[reverse] != neg, axis=1)
+            bad = int(np.argmax(mism))
+            raise ValueError(
+                "TransverseTopology: reverse is not geometrically "
+                "consistent with delta_r -- delta_r[reverse[{0}]]={1} != "
+                "-delta_r[{0}]={2}".format(
+                    bad, tuple(int(x) for x in delta_r[reverse[bad]]),
+                    tuple(int(x) for x in neg[bad])))
+
+        new_coeffs = {}
+        common_norb = None
+        for type_name, raw_arr in dict(coeffs).items():
+            arr = np.array(raw_arr, dtype=complex, copy=True)
+            if arr.ndim != 3 or arr.shape[0] != B or arr.shape[1] != arr.shape[2]:
+                raise ValueError(
+                    "TransverseTopology: coeffs[{!r}] must have shape "
+                    "(B, norb, norb) with B={} (matching delta_r); got {}"
+                    .format(type_name, B, arr.shape))
+            if common_norb is None:
+                common_norb = arr.shape[1]
+            elif arr.shape[1] != common_norb:
+                raise ValueError(
+                    "TransverseTopology: coeffs arrays disagree on norb -- "
+                    "coeffs[{!r}] has norb={} but an earlier type has "
+                    "norb={}".format(type_name, arr.shape[1], common_norb))
+            if np.any(arr[0] != 0):
+                raise ValueError(
+                    "TransverseTopology: coeffs[{!r}][0] (channel 0, the "
+                    "on-site R=(0,0,0) channel) must be EXACTLY zero -- "
+                    "on-site content is represented exclusively by the "
+                    "caller's ham_pm_onsite, never by a topology coeffs "
+                    "array; got coeffs[{!r}][0]={}".format(
+                        type_name, type_name, arr[0]))
+            mism = arr[reverse] - np.conj(np.swapaxes(arr, 1, 2))
+            if np.any(mism != 0):
+                m_bad = int(np.argmax(np.any(mism != 0, axis=(1, 2))))
+                raise ValueError(
+                    "TransverseTopology: coeffs[{!r}] fails the Hermitian "
+                    "closure invariant coeffs[reverse[m]] == "
+                    "conj(coeffs[m]).T at channel m={} (reverse[m]={}): "
+                    "coeffs[{!r}][{}]={} but conj(coeffs[{!r}][{}]).T={}"
+                    .format(type_name, m_bad, int(reverse[m_bad]),
+                            type_name, m_bad, arr[reverse[m_bad]],
+                            type_name, m_bad, np.conj(arr[m_bad]).T))
+            arr.flags.writeable = False
+            new_coeffs[type_name] = arr
+
+        return super(TransverseTopology, cls).__new__(
+            cls, delta_r, reverse, new_coeffs)
+
+
+def iter_reversal_orbits(topo):
+    """Yield ONE representative ``(m, a, b)`` per reversal orbit
+    ``{(m, a, b), (reverse[m], b, a)}`` of ``topo`` (spec, "Canonical orbit
+    rule"): the representative is the LEXICOGRAPHIC TUPLE-MINIMUM of the
+    orbit's (at most two) elements.
+
+    This is the ONE shared helper both the topology layer (this module)
+    and the vertex construction (``W_pm_bond``, Phase W Task 3) use to
+    enumerate reversal orbits -- unit-tested standalone here, independent
+    of either caller, per the spec's "Canonical orbit rule".
+
+    Ranges over EVERY channel ``topo`` carries (``m`` in ``[0, B)``,
+    INCLUDING the mandatory on-site channel 0) and every orbital pair
+    ``(a, b)`` in ``[0, norb) x [0, norb)``; ``norb`` is read from
+    ``topo.coeffs`` (every array there shares one ``(B, norb, norb)``
+    shape by :class:`TransverseTopology`'s own constructor validation).
+    Callers that only want the OFF-SITE domain (spec, "Construction domain
+    (binding for steps 2-3)": steps 2-3 of ``W_pm_bond`` iterate ``R != 0``
+    content exclusively) filter this function's output to ``m != 0``
+    themselves -- this helper stays domain-agnostic, matching the general
+    "Canonical orbit rule" statement.
+
+    At ``m == reverse[m]`` (only possible at ``m == 0``, since a genuine
+    ``m != 0`` channel wrapping onto its own reversal on a finite mesh is
+    rejected by :func:`validate_topology_against_mesh`, never silently
+    produced here) and ``a == b``, the orbit is a SINGLETON (its own
+    partner); every other orbit has exactly two elements.
+
+    Parameters
+    ----------
+    topo : TransverseTopology
+
+    Returns
+    -------
+    list of (int, int, int)
+        One ``(m, a, b)`` representative per orbit, in the deterministic
+        order the ``(m, a, b)`` triple-loop first encounters each orbit
+        (which is already ascending in the representative itself, since
+        the representative is always whichever element of the pair is
+        visited first).
+
+    Raises
+    ------
+    ValueError
+        If ``topo.coeffs`` is empty (``norb`` cannot be inferred -- every
+        topology :func:`resolve_transverse_topology` returns carries the
+        ``CoulombInter``/``Ising``/``Exchange`` keys always, even when
+        zero-filled, so this is only reachable from a hand-built
+        ``TransverseTopology`` with an empty ``coeffs`` dict).
+    """
+    if not topo.coeffs:
+        raise ValueError(
+            "iter_reversal_orbits: topo.coeffs is empty, so norb cannot be "
+            "inferred (every TransverseTopology resolve_transverse_topology "
+            "returns carries at least the CoulombInter/Ising/Exchange "
+            "zero-filled arrays)")
+    norb = None
+    for type_name, arr in topo.coeffs.items():
+        if norb is None:
+            norb = arr.shape[1]
+        elif arr.shape[1] != norb:
+            raise ValueError(
+                "iter_reversal_orbits: topo.coeffs arrays disagree on norb "
+                "({} vs coeffs[{!r}]'s {})".format(norb, type_name, arr.shape[1]))
+
+    reverse = topo.reverse
+    B = len(reverse)
+    seen = set()
+    reps = []
+    for m in range(B):
+        mr = int(reverse[m])
+        for a in range(norb):
+            for b in range(norb):
+                key = (m, a, b)
+                if key in seen:
+                    continue
+                partner = (mr, b, a)
+                seen.add(key)
+                seen.add(partner)
+                reps.append(min(key, partner))
+    return reps
+
+
+def validate_topology_against_mesh(topo, spatial_shape, *, arrays=None):
+    """The ONE mesh-dependent validation lifecycle point for a
+    :class:`TransverseTopology` (spec, "The master transverse topology"):
+    invoked by BOTH ``transverse_bond_bubble_static`` (Phase W Task 4) and
+    ``W_pm_bond`` (Task 3) at entry, so the injectivity rule below is
+    enforced exactly once per call site.
+
+    Validates, in order:
+
+    1. ``spatial_shape``: a length-3 sequence of strictly positive
+       integers (``Nx, Ny, Nz``).
+    2. (optional) every array in ``arrays`` (a ``{label: ndarray}``
+       mapping) has a leading axis equal to ``nvol = prod(spatial_shape)``
+       -- the "any independently shaped numerical input's nvol must equal
+       prod(spatial_shape)" check the spec's "master transverse topology"
+       section requires this function to apply (e.g. a caller's Green
+       function or ``ham_pm_onsite`` tensor built on the wrong mesh).
+    3. ``topo``'s own invariants, by round-tripping it back through
+       :class:`TransverseTopology`'s validating constructor (alias-safe,
+       not immutable: ``coeffs`` -- though its ARRAYS are read-only -- is
+       itself a plain, mutable dict a caller could have re-keyed since
+       ``topo`` was built).
+    4. INJECTIVITY of ``delta_r mod spatial_shape`` over ALL channels: any
+       two DISTINCT channels whose displacement coincides after periodic
+       wrapping (``R`` vs ``R + k*L`` on any axis, e.g. ``R=1`` vs ``R=6``
+       on ``L=5``, INCLUDING the even-mesh self-reversal alias
+       ``+L/2 == -L/2``) are REJECTED, naming both channels (index and raw
+       ``delta_r``) and the mesh. A topology that passes this check can
+       never produce duplicate ED operators under
+       ``SectorED.bond_correlator_transverse``'s own post-wrap duplicate
+       detection (spec).
+
+    Parameters
+    ----------
+    topo : TransverseTopology
+    spatial_shape : sequence of 3 ints
+        ``(Nx, Ny, Nz)``.
+    arrays : dict[str, array_like], optional
+        Additional numerical inputs whose leading axis must equal
+        ``nvol = Nx*Ny*Nz``.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        On any of the above.
+    """
+    try:
+        shape_seq = tuple(spatial_shape)
+    except TypeError:
+        raise ValueError(
+            "validate_topology_against_mesh: spatial_shape must be a "
+            "length-3 sequence of strictly positive integers; got {!r}"
+            .format(spatial_shape))
+    if len(shape_seq) != 3:
+        raise ValueError(
+            "validate_topology_against_mesh: spatial_shape must have "
+            "length 3 (Nx, Ny, Nz); got {!r}".format(spatial_shape))
+    shape_i = []
+    for x in shape_seq:
+        try:
+            xf = float(x)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "validate_topology_against_mesh: spatial_shape entries "
+                "must be integers; got {!r}".format(spatial_shape))
+        if not np.isfinite(xf) or xf != np.floor(xf) or xf <= 0:
+            raise ValueError(
+                "validate_topology_against_mesh: spatial_shape entries "
+                "must be strictly positive integers; got {!r}".format(
+                    spatial_shape))
+        shape_i.append(int(xf))
+    Nx, Ny, Nz = shape_i
+    nvol = Nx * Ny * Nz
+
+    if arrays:
+        for label, value in dict(arrays).items():
+            value = np.asarray(value)
+            got = value.shape[0] if value.ndim else None
+            if value.ndim < 1 or got != nvol:
+                raise ValueError(
+                    "validate_topology_against_mesh: {} has leading axis "
+                    "{} but the mesh {} implies nvol={}".format(
+                        label, got, shape_i, nvol))
+
+    # Re-validate topo (alias-safe, not immutable -- see the class
+    # docstring); a hand-built or corrupted topology is caught here rather
+    # than silently producing wrong results downstream.
+    topo = TransverseTopology(topo.delta_r, topo.reverse, topo.coeffs)
+
+    shape_arr = np.array(shape_i, dtype=np.int64)
+    delta_r = np.asarray(topo.delta_r)
+    B = delta_r.shape[0]
+    wrapped = np.mod(delta_r, shape_arr)
+    seen = {}
+    for m in range(B):
+        key = tuple(int(x) for x in wrapped[m])
+        if key in seen:
+            other = seen[key]
+            raise ValueError(
+                "validate_topology_against_mesh: channels {} (delta_r={}) "
+                "and {} (delta_r={}) collide on the mesh {} -- both wrap to "
+                "the same displacement {} modulo the mesh (an alias such as "
+                "R vs R+k*L on some axis, or the even-mesh self-reversal "
+                "+L/2 == -L/2); a topology whose channels are not "
+                "INJECTIVE modulo the mesh cannot be used at this mesh "
+                "resolution.".format(
+                    other, tuple(int(v) for v in delta_r[other]),
+                    m, tuple(int(v) for v in delta_r[m]), shape_i, key))
+        seen[key] = m
+    return None
+
+
+def transverse_effective_activity(topo):
+    """The shared "is this topology doing anything transverse off-site"
+    predicate: EXACT nonzero after summation, Hermitian projection and
+    shell truncation -- i.e. after everything
+    :func:`resolve_transverse_topology` already did to ``topo.coeffs``.
+
+    A topology built entirely from PASS-ZERO declarations (only
+    Hund/PairLift, or no off-site transverse-active interaction at all)
+    has every ``coeffs`` array identically zero (channel 0 always is, by
+    :class:`TransverseTopology`'s own constructor invariant; channel 0 is
+    the ONLY channel when nothing off-site was ever declared) and this
+    returns ``False``; any genuinely nonzero off-site CoulombInter/
+    Ising/Exchange coefficient makes it ``True``.
+
+    This is the ONE shared place that answers the question -- callers
+    (``W_pm_bond``, ``transverse_bond_bubble_static``, and any future
+    gate/preflight code, Phase W Tasks 3+) use this rather than
+    re-deriving their own "is coeffs all zero" check.
+
+    Parameters
+    ----------
+    topo : TransverseTopology
+
+    Returns
+    -------
+    bool
+    """
+    for arr in topo.coeffs.values():
+        if np.any(arr != 0):
+            return True
+    return False
+
+
+def _close_offsite_hermitian(by_irvec, norb, reverse_atol, reverse_rtol,
+                              type_name):
+    """Off-site (``R != 0``) reverse-closure / Hermitian-projection for
+    ONE interaction type, per the SAME algorithm ``resolve_interactions``
+    (its "Step 2: reverse closure / Hermiticity synthesis", above in this
+    module) applies to its ``CoulombInter``-shaped input.
+
+    Deliberately RE-IMPLEMENTED here rather than shared with
+    ``resolve_interactions`` -- this task's append-only contract forbids
+    editing that function (or extracting a common helper out of it) -- but
+    the algorithm itself is the SAME normalization
+    :func:`resolve_transverse_topology` must reproduce (carried Task-1
+    review finding): for a density-density (commuting-operator) type,
+    declaring BOTH ``C`` at ``R`` and ``conj(C)`` at ``-R`` describes the
+    SAME physical operator sum TWICE (``bare_bond_vertices``'s Finding-1
+    derivation, above, reproduces the argument in full) -- so a
+    consistent mirrored pair is Hermitian-PROJECTED onto its exact
+    conjugate average (``0.5 * (declared + conj(synthesized))``), never
+    stored as either raw declared value, and an INCONSISTENT mirrored pair
+    (beyond the scale-aware tolerance) raises rather than silently picking
+    one side. A single-direction declaration is stored as declared, with
+    its reverse partner synthesized as the exact conjugate. Duplicate
+    declarations at the identical ``(type, R, a, b)`` key cannot occur
+    here (a plain Python dict already deduplicates that -- same note
+    ``resolve_interactions``'s own "Step 1" docstring makes); a caller
+    that pre-sums two logical contributions into one dict entry gets that
+    pre-summed value carried through this same closure unchanged.
+
+    Parameters
+    ----------
+    by_irvec : dict[tuple, dict[(int, int), complex]]
+        ``{irvec: {(a, b): value}}``, OFF-SITE (``irvec != (0, 0, 0)``)
+        entries only (the caller filters out the on-site point).
+    norb : int
+    reverse_atol, reverse_rtol : float
+        Same scale-aware tolerance semantics as ``resolve_interactions``.
+    type_name : str
+        Only used to make a ``ValueError`` message actionable.
+
+    Returns
+    -------
+    dict[tuple, np.ndarray]
+        ``{irvec: (norb, norb) complex}``, closed under
+        ``irvec -> -irvec`` (every key's negation is also a key).
+    """
+    declared_irvecs = set(by_irvec.keys())
+    all_irvecs = set(declared_irvecs)
+    for irvec in declared_irvecs:
+        all_irvecs.add(tuple(-x for x in irvec))
+
+    completed = {}
+    visited = set()
+    for irvec in all_irvecs:
+        if irvec in visited:
+            continue
+        neg = tuple(-x for x in irvec)
+        visited.add(irvec)
+        visited.add(neg)
+
+        fwd = by_irvec.get(irvec, {})
+        bwd = by_irvec.get(neg, {})
+
+        fwd_mat = np.zeros((norb, norb), dtype=complex)
+        bwd_mat = np.zeros((norb, norb), dtype=complex)
+
+        synth_fwd_from_bwd = {(a, b): np.conj(v) for (b, a), v in bwd.items()}
+        synth_bwd_from_fwd = {(b, a): np.conj(v) for (a, b), v in fwd.items()}
+
+        keys_fwd = set(fwd.keys()) | set(synth_fwd_from_bwd.keys())
+        for (a, b) in keys_fwd:
+            v_declared = fwd.get((a, b))
+            v_synth = synth_fwd_from_bwd.get((a, b))
+            if v_declared is not None and v_synth is not None:
+                tol = reverse_atol + reverse_rtol * abs(v_declared)
+                if abs(v_declared - v_synth) > tol:
+                    raise ValueError(
+                        "resolve_transverse_topology: {}_{}{}({}) = {} "
+                        "disagrees with conj({}_{}{}({})) = {} beyond "
+                        "tolerance (atol={}, rtol={})".format(
+                            type_name, a, b, irvec, v_declared,
+                            type_name, b, a, neg, v_synth,
+                            reverse_atol, reverse_rtol))
+                fwd_mat[a, b] = 0.5 * (v_declared + v_synth)
+            elif v_declared is not None:
+                fwd_mat[a, b] = v_declared
+            else:
+                fwd_mat[a, b] = v_synth
+
+        keys_bwd = set(bwd.keys()) | set(synth_bwd_from_fwd.keys())
+        for (a, b) in keys_bwd:
+            v_declared = bwd.get((a, b))
+            v_synth = synth_bwd_from_fwd.get((a, b))
+            if v_declared is not None and v_synth is not None:
+                tol = reverse_atol + reverse_rtol * abs(v_declared)
+                if abs(v_declared - v_synth) > tol:
+                    raise ValueError(
+                        "resolve_transverse_topology: {}_{}{}({}) = {} "
+                        "disagrees with conj({}_{}{}({})) = {} beyond "
+                        "tolerance (atol={}, rtol={})".format(
+                            type_name, a, b, neg, v_declared,
+                            type_name, b, a, irvec, v_synth,
+                            reverse_atol, reverse_rtol))
+                bwd_mat[a, b] = 0.5 * (v_declared + v_synth)
+            elif v_declared is not None:
+                bwd_mat[a, b] = v_declared
+            else:
+                bwd_mat[a, b] = v_synth
+
+        completed[irvec] = fwd_mat
+        if neg != irvec:
+            completed[neg] = bwd_mat
+        # neg == irvec is impossible here: irvec != (0, 0, 0) always (the
+        # caller filters out the on-site point before calling), and
+        # -irvec == irvec only at irvec == (0, 0, 0).
+
+    return completed
+
+
+def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
+    """Resolve the master transverse bond topology (spec, "The master
+    transverse topology") from the SAME raw, PRE-FOLD interaction
+    declarations ``resolve_interactions`` consumes -- the pre-fold
+    locality rule (judge locality on the ORIGINAL declarations, never a
+    folded table; ``rpa.py``'s own ``param_ham_orig``-reading builders,
+    e.g. ``_append_inter_cross``/``_append_onsite_direct`` above this
+    module in the pipeline, apply the identical rule for the same reason).
+    Callers pass ``interactions = self.param_ham_orig`` (or the equivalent
+    un-folded dict-of-dicts) -- NEVER the post-sublattice-folding
+    ``self.param_ham``.
+
+    Collects the UNION of declared off-site displacement vectors from
+    EVERY transverse-active type (``CoulombInter``, ``Ising``,
+    ``Exchange``; ``Hund``/``PairLift`` and anything else in
+    ``interactions`` contribute NO shells and are simply never read --
+    "tolerated" per the spec), closes each type's own declarations under
+    ``R -> -R`` with the SAME sum-then-Hermitian-project normalization
+    ``resolve_interactions`` uses (see :func:`_close_offsite_hermitian`),
+    orders channels the SAME way ``resolve_interactions`` does (``m=0``
+    first, then shells by ``(Euclidean length, lexicographic irvec)``),
+    and returns a :class:`TransverseTopology` whose ``coeffs`` are
+    zero-filled, per type, at every channel that type does not declare.
+
+    Parameters
+    ----------
+    interactions : dict
+        A dict-of-dicts container in the SAME shape as
+        ``self.param_ham_orig``/``self.param_ham``: keys are interaction
+        type names; each sub-dict has the SAME ``{(irvec, orbvec): value}``
+        shape ``resolve_interactions``'s own ``coulomb_inter`` parameter
+        documents (``irvec`` a length-3 int tuple, ``orbvec = (a, b)``
+        0-based orbital indices, ``value`` complex). A missing type key is
+        treated exactly like an empty sub-dict; on-site (``irvec ==
+        (0, 0, 0)``) entries of every type are ignored here -- on-site
+        content is represented exclusively through the caller's
+        ``ham_pm_onsite`` (Phase W Task 3's ``W_pm_bond``, spec step 1),
+        never through a topology ``coeffs`` channel.
+    cell : array_like, shape (3, 3)
+        Real-space lattice vectors (rows) -- the SAME quantity
+        ``resolve_interactions`` calls ``lattice_vectors``; used
+        identically, only for Euclidean shell length / ``max_shells``
+        ordering.
+    norb : int
+        Number of orbitals; every ``coeffs`` array is
+        ``(B, norb, norb)``.
+    max_shells : int or None, optional
+        Truncates the UNION of off-site shells (the ``bond_max_shells``
+        semantics ``resolve_interactions`` documents) by WHOLE ``|R|``-
+        shells; ``None`` (the default) keeps every declared off-site
+        shell. A negative, non-integral or non-finite value raises
+        ``ValueError`` (never clamped/truncated).
+
+    Returns
+    -------
+    TransverseTopology
+        Channel 0 is always ``R=(0,0,0)``; ``coeffs`` holds
+        ``"CoulombInter"``, ``"Ising"`` and ``"Exchange"`` keys ALWAYS
+        (zero-filled at every channel for a type that declares nothing at
+        all off-site), each ``(B, norb, norb)`` complex, Hermitian-closed
+        exactly like ``resolve_interactions``'s ``v_bond``.
+
+    Raises
+    ------
+    ValueError
+        If a mirrored declared pair disagrees beyond tolerance, if
+        ``max_shells`` is invalid, or (propagated from
+        :class:`TransverseTopology`'s constructor) if the resolved
+        topology somehow fails its own invariants.
+    """
+    norb = int(norb)
+    if norb <= 0:
+        raise ValueError(
+            "resolve_transverse_topology: norb must be a positive integer, "
+            "got {!r}".format(norb))
+    if not hasattr(interactions, "get"):
+        raise ValueError(
+            "resolve_transverse_topology: interactions must be a "
+            "dict-like container (mapping interaction type name -> "
+            "{(irvec, orbvec): value} sub-dict), got {!r}".format(
+                type(interactions)))
+
+    reverse_atol, reverse_rtol = 1e-10, 1e-8
+
+    per_type_completed = {}
+    union_irvecs = set()
+    for type_name in _TRANSVERSE_ACTIVE_TYPES:
+        tbl = interactions.get(type_name, {}) or {}
+        by_irvec = {}
+        for (irvec, orbvec), value in tbl.items():
+            irvec = tuple(int(x) for x in irvec)
+            if irvec == (0, 0, 0):
+                continue
+            a, b = int(orbvec[0]), int(orbvec[1])
+            by_irvec.setdefault(irvec, {})[(a, b)] = complex(value)
+        completed = _close_offsite_hermitian(
+            by_irvec, norb, reverse_atol, reverse_rtol, type_name)
+        per_type_completed[type_name] = completed
+        union_irvecs.update(completed.keys())
+
+    # --- shell sort: SAME ordering resolve_interactions uses (m=0 first,
+    # then shells by (Euclidean length, lexicographic irvec)) ---
+    def sort_key(irvec):
+        return (_shell_length(irvec, cell), irvec)
+
+    ordered_irvecs_all = sorted(union_irvecs, key=sort_key)
+    shells = []  # list of (length, [irvecs...])
+    for irvec in ordered_irvecs_all:
+        length = _shell_length(irvec, cell)
+        if shells and abs(length - shells[-1][0]) <= 1e-6 * max(
+                length, shells[-1][0], 1.0):
+            shells[-1][1].append(irvec)
+        else:
+            shells.append((length, [irvec]))
+
+    if max_shells is not None:
+        try:
+            shells_f = float(max_shells)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "resolve_transverse_topology: max_shells must be a "
+                "non-negative integer or None, got {!r}".format(max_shells))
+        if (not np.isfinite(shells_f) or shells_f < 0
+                or shells_f != np.floor(shells_f)):
+            raise ValueError(
+                "resolve_transverse_topology: max_shells must be a "
+                "non-negative integral value (shell 0 is the mandatory "
+                "on-site R=(0,0,0) channel, always kept regardless; "
+                "max_shells counts OFF-SITE shells beyond it) or None, "
+                "got {!r}".format(max_shells))
+        n_keep = int(shells_f)
+        shells = shells[:n_keep]
+
+    ordered_irvecs = [irvec for _, irvecs in shells for irvec in irvecs]
+
+    delta_r = [(0, 0, 0)] + ordered_irvecs
+    index_of = {dr: i for i, dr in enumerate(delta_r)}
+    B = len(delta_r)
+
+    reverse = [0]
+    for irvec in ordered_irvecs:
+        neg = tuple(-x for x in irvec)
+        if neg not in index_of:
+            raise ValueError(
+                "resolve_transverse_topology: internal error -- channel "
+                "{} has no reverse partner {} in the resolved union "
+                "(reversal closure invariant violated)".format(irvec, neg))
+        reverse.append(index_of[neg])
+
+    coeffs = {}
+    for type_name in _TRANSVERSE_ACTIVE_TYPES:
+        completed = per_type_completed[type_name]
+        arr = np.zeros((B, norb, norb), dtype=complex)
+        for m, irvec in enumerate(delta_r):
+            if m == 0:
+                continue
+            block = completed.get(irvec)
+            if block is not None:
+                arr[m] = block
+        coeffs[type_name] = arr
+
+    return TransverseTopology(delta_r=delta_r, reverse=reverse, coeffs=coeffs)

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2660,6 +2660,31 @@ def _close_offsite_hermitian(by_irvec, norb, reverse_atol, reverse_rtol,
     return completed
 
 
+def _require_transverse_integral(value, label):
+    """Coerce ``value`` to ``int`` iff it is an exact integral scalar;
+    otherwise raise a ``resolve_transverse_topology``-prefixed
+    ``ValueError`` naming ``label``. ``bool`` is rejected even though
+    ``isinstance(True, int)`` in Python, since a stray boolean (e.g. an
+    ``irvec``/``orbvec`` component that is accidentally a truthiness
+    flag) is never a legitimate integral coordinate here.
+    """
+    if isinstance(value, bool):
+        raise ValueError(
+            "resolve_transverse_topology: {} must be an integer, not a "
+            "bool, got {!r}".format(label, value))
+    try:
+        value_f = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            "resolve_transverse_topology: {} must be an integer, got "
+            "{!r}".format(label, value))
+    if not np.isfinite(value_f) or value_f != np.floor(value_f):
+        raise ValueError(
+            "resolve_transverse_topology: {} must be an integral value, "
+            "got {!r}".format(label, value))
+    return int(value_f)
+
+
 def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
     """Resolve the master transverse bond topology (spec, "The master
     transverse topology") from the SAME raw, PRE-FOLD interaction
@@ -2742,8 +2767,8 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
         :class:`TransverseTopology`'s constructor) if the resolved
         topology somehow fails its own invariants.
     """
-    norb = int(norb)
-    if norb <= 0:
+    norb = _require_transverse_integral(norb, "norb")
+    if norb < 1:
         raise ValueError(
             "resolve_transverse_topology: norb must be a positive integer, "
             "got {!r}".format(norb))
@@ -2763,10 +2788,48 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
         tbl = interactions.get(type_name, {}) or {}
         by_irvec = {}
         for (irvec, orbvec), value in tbl.items():
-            irvec = tuple(int(x) for x in irvec)
+            try:
+                irvec_len = len(irvec)
+            except TypeError:
+                raise ValueError(
+                    "resolve_transverse_topology: {} declares an irvec "
+                    "key that is not a 3-component vector, got "
+                    "{!r}".format(type_name, irvec))
+            if irvec_len != 3:
+                raise ValueError(
+                    "resolve_transverse_topology: {} declares an irvec "
+                    "key with {} component(s), expected exactly 3, got "
+                    "{!r}".format(type_name, irvec_len, irvec))
+            irvec = tuple(
+                _require_transverse_integral(
+                    x, "{} irvec component".format(type_name))
+                for x in irvec)
+
+            try:
+                orbvec_len = len(orbvec)
+            except TypeError:
+                raise ValueError(
+                    "resolve_transverse_topology: {} declares an orbvec "
+                    "key that is not a 2-component (a, b) pair, got "
+                    "{!r}".format(type_name, orbvec))
+            if orbvec_len != 2:
+                raise ValueError(
+                    "resolve_transverse_topology: {} declares an orbvec "
+                    "key with {} component(s), expected exactly 2 (a, "
+                    "b), got {!r}".format(type_name, orbvec_len, orbvec))
+            a = _require_transverse_integral(
+                orbvec[0], "{} orbvec[0]".format(type_name))
+            b = _require_transverse_integral(
+                orbvec[1], "{} orbvec[1]".format(type_name))
+            if not (0 <= a < norb and 0 <= b < norb):
+                raise ValueError(
+                    "resolve_transverse_topology: {} declares orbital "
+                    "index (a={}, b={}) at irvec={} out of range for "
+                    "norb={}; orbital indices must satisfy 0 <= a,b < "
+                    "norb".format(type_name, a, b, irvec, norb))
+
             if irvec == (0, 0, 0):
                 continue
-            a, b = int(orbvec[0]), int(orbvec[1])
             by_irvec.setdefault(irvec, {})[(a, b)] = complex(value)
         per_type_by_irvec[type_name] = by_irvec
         completed = _close_offsite_hermitian(

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -2711,7 +2711,18 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
         semantics ``resolve_interactions`` documents) by WHOLE ``|R|``-
         shells; ``None`` (the default) keeps every declared off-site
         shell. A negative, non-integral or non-finite value raises
-        ``ValueError`` (never clamped/truncated).
+        ``ValueError`` (never clamped/truncated). Dropping declared
+        content is ALWAYS an error, never silent: if the truncation would
+        remove a shell that carries any exactly-nonzero DECLARED
+        coefficient (from ``CoulombInter``, ``Ising`` or ``Exchange``),
+        this raises ``ValueError`` -- the same ambiguity guard
+        ``resolve_interactions``'s ``bond_max_shells=0`` case applies
+        (bond_channels.py's "Step 4" above), generalized here to any
+        truncation depth: ``max_shells=0`` with declared off-site content
+        is simply the ``n_keep=0`` instance of the same rule. A
+        truncation that only drops shells with no declared nonzero
+        coefficient (e.g. purely synthesized-negligible partners, or
+        shells nothing ever declared) remains fine.
 
     Returns
     -------
@@ -2726,7 +2737,8 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
     ------
     ValueError
         If a mirrored declared pair disagrees beyond tolerance, if
-        ``max_shells`` is invalid, or (propagated from
+        ``max_shells`` is invalid, if ``max_shells`` would drop a shell
+        carrying declared nonzero content, or (propagated from
         :class:`TransverseTopology`'s constructor) if the resolved
         topology somehow fails its own invariants.
     """
@@ -2744,6 +2756,7 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
 
     reverse_atol, reverse_rtol = 1e-10, 1e-8
 
+    per_type_by_irvec = {}
     per_type_completed = {}
     union_irvecs = set()
     for type_name in _TRANSVERSE_ACTIVE_TYPES:
@@ -2755,6 +2768,7 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
                 continue
             a, b = int(orbvec[0]), int(orbvec[1])
             by_irvec.setdefault(irvec, {})[(a, b)] = complex(value)
+        per_type_by_irvec[type_name] = by_irvec
         completed = _close_offsite_hermitian(
             by_irvec, norb, reverse_atol, reverse_rtol, type_name)
         per_type_completed[type_name] = completed
@@ -2791,6 +2805,42 @@ def resolve_transverse_topology(interactions, cell, norb, *, max_shells=None):
                 "max_shells counts OFF-SITE shells beyond it) or None, "
                 "got {!r}".format(max_shells))
         n_keep = int(shells_f)
+        dropped_shells = shells[n_keep:]
+
+        # Ambiguity guard (review fix, generalizing resolve_interactions's
+        # "Step 4" bond_max_shells=0 guard, bond_channels.py above, to
+        # every truncation depth): dropping a shell that carries any
+        # exactly-nonzero DECLARED coefficient (from CoulombInter, Ising
+        # or Exchange) is ALWAYS an error, never silent -- the docstring's
+        # "max_shells truncates the UNION of off-site shells" promise
+        # would otherwise silently discard content the caller explicitly
+        # asked for. Checked against per_type_by_irvec (the RAW declared
+        # entries, pre-closure), matching resolve_interactions's own
+        # has_nonzero_inter_site_v -- a synthesized-but-negligible
+        # reverse partner never triggers this on its own (it is not
+        # itself a declared entry), but its declared mirror at the SAME
+        # shell (same |R|, since |R| == |-R| always) does.
+        dropped_irvecs = {irvec for _, irvecs in dropped_shells
+                           for irvec in irvecs}
+        if dropped_irvecs:
+            offending = []
+            for type_name in _TRANSVERSE_ACTIVE_TYPES:
+                by_irvec = per_type_by_irvec[type_name]
+                for irvec in dropped_irvecs:
+                    entries = by_irvec.get(irvec)
+                    if entries and any(v != 0 for v in entries.values()):
+                        offending.append((type_name, irvec))
+            if offending:
+                offending.sort(key=lambda x: (x[0], x[1]))
+                raise ValueError(
+                    "resolve_transverse_topology: max_shells={} requested "
+                    "but this would drop shell(s) carrying declared "
+                    "nonzero off-site content: {}; this is ambiguous "
+                    "(asks to truncate away declared coefficients rather "
+                    "than merely unresolved/zero-valued shells). Use a "
+                    "larger max_shells, or omit the offending "
+                    "declarations, for the genuinely truncated model "
+                    "instead.".format(max_shells, offending))
         shells = shells[:n_keep]
 
     ordered_irvecs = [irvec for _, irvecs in shells for irvec in irvecs]

--- a/src/hwave/solver/bubble.py
+++ b/src/hwave/solver/bubble.py
@@ -23,9 +23,20 @@ deliberately imports neither ``sparse_ir`` nor ``flex.py`` -- the IR entry
 points receive already-constructed ``IRAxis`` objects and duck-type their
 attributes/methods (``statistics``, ``beta``, ``wmax``, ``eps``, ``tau``,
 ``n_tau``, ``n_freq``, ``freq_to_tau_points``, ``tau_to_freq``) -- so the
-plain dense path stays usable without the optional IR dependency; the bond
-entry point takes a ``bond_set`` (duck-typed ``delta_r``/``n_channels``)
-and never imports ``bond_channels`` either.
+plain dense path stays usable without the optional IR dependency; the
+LONGITUDINAL bond entry points (``bond_bubble_static``, ``_iter_bond_dynamic``)
+take a ``bond_set`` (duck-typed ``delta_r``/``n_channels``) and never import
+``bond_channels`` either.
+
+The one exception is ``transverse_bond_bubble_static`` (Phase W Task 4,
+``docs/superpowers/specs/2026-08-15-bond-transverse-design.md``): its
+``topo`` argument is a ``bond_channels.TransverseTopology``, and the
+spec requires ``validate_topology_against_mesh`` -- defined in
+``bond_channels.py`` -- to run at entry. Since ``bond_channels.py``
+imports THIS module at its own top level (``from . import bubble as
+_bubble``), a module-level ``from . import bond_channels`` here would
+cycle; ``transverse_bond_bubble_static`` therefore imports
+``bond_channels`` LOCALLY, inside the function, instead.
 """
 
 import numpy as np
@@ -1305,5 +1316,263 @@ def _ir_bond_static(green_kw, ax_fermi, ax_bose, bond_set, *,
             chi_bar[:, m * npair:(m + 1) * npair,
                     mp * npair:(mp + 1) * npair] = block[..., 0]
             del block
+
+    return chi_bar
+
+
+# ===========================================================================
+# bond-enlarged bubble  --  static cross-block (transverse) assembly
+# ===========================================================================
+#
+# transverse_bond_bubble_static computes the STATIC (Omega=0) bond-enlarged
+# transverse particle-hole bubble chi0_+-(q; Delta r_m, Delta r_m'), the
+# cross-block analogue of bond_bubble_static: instead of contracting one
+# propagator block against itself channel-pair by channel-pair (the
+# longitudinal bond path above), it contracts block 1 (DOWN, forward) against
+# block 0 (UP, reversed) -- the SAME per-pair roll-by-(Delta r_m - Delta r_m')
+# / contract_general / endpoint-mean / spatial-fftn / tau_to_boson pipeline
+# (_bond_pair_full_block, unmodified) driven by ONE new block-aware generator
+# (_iter_transverse_bond_channel_pairs) that plays the role
+# _iter_bond_channel_pairs plays for the nblock=1 longitudinal path.
+#
+# fwd = block 1 (DOWN), rev = block 0 (UP): the AMENDED 2026-08-15 Phase-H
+# H3 adjudication (spec, "The bond bubble (static)") -- the Wick contraction
+# of the campaign's observable <S+;S+dagger> factorizes as
+# -G_down(r,tau)*G_up(-r,-tau), so the forward propagator is the DOWN Green
+# function. This is NOT the same role assignment as 3a's
+# ``transverse_bubble(fwd=0, rev=1)`` (block 0 = up = forward there): that
+# earlier entry point computes the CONJUGATE object <S-;S-dagger>, which
+# coincides with <S+;S+dagger> only when G_up == G_down (spec's NOTE under
+# "The bond bubble (static)"). The role swap is not absorbable in the frame
+# map (a pure index permutation cannot express a spin-role swap): a naive
+# fwd=up/rev=down assignment here was measured (Phase-H H3, an Nmat-independent
+# effect) to leave an O(1) residual, not a finite-Nmat discretization error --
+# see ``transverse_bond_bubble_static``'s docstring for the recorded
+# mutation-check magnitude on THIS entry point.
+
+
+def _iter_transverse_bond_channel_pairs(prepped, delta_r, beta,
+                                        spatial_shape, workers):
+    """Shared per-pair generator for the transverse (cross-block) bond
+    bubble: yields ``((m, mp), block)`` in row-major channel order (``m``
+    outer, ``mp`` inner), ``block`` the FULL-frequency ``(nmat, nvol,
+    npair, npair)`` complex128 bond bubble for that channel pair, built by
+    :func:`_bond_pair_full_block` -- the SAME per-pair pipeline the
+    longitudinal path's :func:`_iter_bond_channel_pairs` uses, differing
+    only in WHICH block of ``prepped`` supplies the forward/reversed
+    factors: forward = block 1 (DOWN), reversed = block 0 (UP) (see the
+    module comment above and ``transverse_bond_bubble_static``'s
+    docstring). ``prepped`` is assumed built from a two-block
+    (``nblock == 2``) Green function; this function performs no
+    validation of its own -- callers (``transverse_bond_bubble_static``)
+    validate ``nblock == 2`` before building ``prepped``.
+
+    ``delta_r``: ``(B, 3)`` integer array (``topo.delta_r``, already
+    validated by the caller).
+
+    Mirrors :func:`_iter_bond_channel_pairs`'s del discipline: the
+    unused halves of ``prepped.green_rt``/``prepped.green_rev`` (block 0
+    of ``green_rt`` -- UP, never read as the forward factor here -- and
+    block 1 of ``green_rev`` -- DOWN, never read as the reversed factor
+    here) are released as soon as the needed block is extracted, rather
+    than staying bound in ``prepped`` for the whole ``(m, mp)`` loop; and
+    the generator clears its own ``block`` reference immediately after
+    each ``yield`` (see :func:`_iter_bond_channel_pairs`'s comment on why
+    a generator's suspended-frame locals need an explicit ``del`` beyond
+    whatever the consumer does with its own reference)."""
+    _, nmat, nvol, nd, _ = prepped.green_rt.shape
+    B = delta_r.shape[0]
+
+    sgn = prepped.sgn.reshape((nmat, 1, 1, 1))
+    # Forward = block 1 (DOWN). `* sgn` is an elementwise product -> a
+    # fresh array, decoupled from the two-block buffer underneath, so
+    # dropping prepped.green_rt right after this line is safe.
+    green_rt_full = prepped.green_rt
+    green_fwd_sgn = green_rt_full[1] * sgn
+    del green_rt_full
+    prepped.green_rt = None
+
+    # Reversed = block 0 (UP). Plain indexing is a VIEW into the two-block
+    # buffer, so this is copied explicitly before the full buffer (with
+    # its unused block 1) is released.
+    green_rev_full = prepped.green_rev
+    green_rev = green_rev_full[0].copy()
+    del green_rev_full
+    prepped.green_rev = None
+
+    tail_pack = None
+    if prepped.tail_on:
+        # Endpoint threading (spec: "The bond bubble (static)" / mirrors
+        # _assemble_cross_block's own threading): forward branch and its
+        # jump always read block 1 (down), reversed branch and its jump
+        # always read block 0 (up).
+        tail_pack = (prepped.fwd0_p[1], prepped.rev0_p[0],
+                     prepped.jump_f[1], prepped.jump_r_rev[0])
+
+    for m in range(B):
+        dm = delta_r[m]
+        for mp in range(B):
+            dmp = delta_r[mp]
+            shift = (int(dm[0]) - int(dmp[0]),
+                     int(dm[1]) - int(dmp[1]),
+                     int(dm[2]) - int(dmp[2]))
+
+            block = _bond_pair_full_block(
+                green_fwd_sgn, green_rev, tail_pack, beta, spatial_shape,
+                workers, shift)
+            yield (m, mp), block
+            # See _iter_bond_channel_pairs's identical comment: releases
+            # the previous pair's block from this generator's own
+            # suspended frame, keeping the per-pair working set bounded.
+            del block
+
+
+def transverse_bond_bubble_static(green_kw, green0_tail, beta, topo, *,
+                                  spatial_shape, workers=None):
+    """Bond-enlarged static (``Omega=0``) TRANSVERSE particle-hole bubble
+    ``chi0_+-(q; Delta r_m, Delta r_m')``, the cross-block analogue of
+    :func:`bond_bubble_static`.
+
+    **Block roles (AMENDED 2026-08-15, Phase-H H3 adjudication -- spec
+    "The bond bubble (static)"): fwd = block 1 (DOWN), rev = block 0
+    (UP).** The Wick contraction of the observable ``<S+;S+dagger>``
+    factorizes as ``-G_down(r,tau)*G_up(-r,-tau)``, i.e. the forward
+    propagator is the DOWN Green function -- independently derived by the
+    H3 reviewer and pinned by the V=0 gate (an un-swapped ``fwd=up,
+    rev=down`` choice leaves an Nmat-INDEPENDENT residual, not a
+    finite-Nmat discretization error; see the mutation-check note below).
+    This is NOT the same convention as :func:`transverse_bubble`'s own
+    ``fwd=block 0 (up), rev=block 1 (down)``: that entry point computes
+    the CONJUGATE object ``<S-;S-dagger>``, which coincides with
+    ``<S+;S+dagger>`` only when ``G_up == G_down`` (an open question this
+    spec explicitly leaves to a later granule, not settled by this
+    function). The role swap is NOT absorbable into the roll/frame-map
+    machinery (a pure index permutation cannot express a spin-role swap).
+
+    Parameters
+    ----------
+    green_kw : ndarray, complex, shape (2, nmat, nvol, p, p)
+        Canonical two-block Green's function, ``nblock == 2`` REQUIRED
+        (block 0 = G_up, block 1 = G_down -- ``ValueError`` naming both
+        the actual ``nblock`` and the required value otherwise). Same
+        deflated/full Green/tail semantics as :func:`dense_bubble`
+        (module docstring's "Green/tail contracts"; deflated pair when
+        ``green0_tail`` is given, ``None`` => full G and the tail
+        machinery off).
+    green0_tail : ndarray or None, same shape/dtype family as ``green_kw``
+        The paired tau-space tail add-back, or ``None`` to disable the
+        tail correction.
+    beta : float
+        Inverse temperature; must be > 0.
+    topo : bond_channels.TransverseTopology
+        The master transverse bond topology (``delta_r``/``reverse``/
+        ``coeffs`` -- only ``delta_r`` is read here; ``coeffs`` belongs to
+        the VERTEX, ``W_pm_bond``, not the bubble). Validated at entry via
+        ``bond_channels.validate_topology_against_mesh`` (the ONE
+        mesh-dependent lifecycle point shared with ``W_pm_bond`` -- spec,
+        "The master transverse topology").
+    spatial_shape : tuple of 3 positive ints (Nx, Ny, Nz)
+        The lattice shape; ``prod(spatial_shape)`` must equal
+        ``green_kw.shape[2]`` (``nvol``), and ``topo.delta_r`` must be
+        INJECTIVE modulo this mesh (``validate_topology_against_mesh``).
+    workers : int or None, optional
+        Forwarded to ``backend.spatial_ifftn``/``spatial_fftn``.
+
+    Returns
+    -------
+    ndarray, complex128, shape (nvol, ND, ND)
+        ``ND = npair * B`` with ``npair = p**2``, ``B = len(topo.delta_r)``;
+        the static (``Omega=0``) bond-enlarged transverse bubble,
+        bond-major/orbital-minor index ``I = m * npair + (a * p + c)`` --
+        the SAME index convention :func:`bond_bubble_static` uses. The
+        ``Omega=0`` element is bosonic Matsubara index ``nmat // 2`` (even
+        ``nmat`` REQUIRED, same as :func:`bond_bubble_static` -- see
+        :func:`_validate_even_nmat_for_bond`).
+
+    Raises
+    ------
+    ValueError
+        If ``green_kw``'s block axis is not exactly 2 (naming the actual
+        ``nblock`` and the required value 2); on any other shape/dtype
+        mismatch (see :func:`_validate_dense_inputs`); if ``nmat`` is odd
+        (see :func:`_validate_even_nmat_for_bond`); or if ``topo``/
+        ``spatial_shape`` fail mesh-injectivity or ``topo``'s own
+        constructor invariants (propagated from
+        ``bond_channels.validate_topology_against_mesh``). All failures
+        are ``ValueError`` (survives ``python -O``).
+
+    Notes
+    -----
+    Mutation check (fwd/rev swapped to block 0 (up) forward / block 1
+    (down) reversed, run manually during development against
+    ``tests/test_bond_transverse_w.py``'s V=0 near-machine pin, then
+    reverted -- ``git diff`` on this file carries no trace, per the
+    established mutation-check discipline in
+    ``tests/test_bubble_kernel.py``/``tests/test_bond_transverse_ed.py``'s
+    H3): with the roles swapped, the pin's max-abs distance jumps from
+    round-off (~1e-13) to a MEASURED 2.465e-2 (norb=1, L=5 fixture) /
+    2.959e-2 (norb=2, L=3 fixture) -- an O(1) margin (the same ~2.5e-2
+    class H3's own mutation check measures), confirming the role
+    assignment above is load-bearing and not absorbable elsewhere.
+    """
+    if green_kw.ndim != 5:
+        raise ValueError(
+            "bubble kernel: green_kw must have ndim 5 "
+            "(nblock, nmat, nvol, p, p), got ndim={} shape={}".format(
+                green_kw.ndim, green_kw.shape))
+    nblock = green_kw.shape[0]
+    if nblock != 2:
+        # Checked FIRST, before _validate_dense_inputs's own (looser,
+        # nblock in {1, 2}) guard -- mirrors transverse_bubble's identical
+        # early check: the cross-block down/up contraction requires
+        # exactly 2 blocks, so both nblock=1 and nblock=3+ must surface
+        # THIS message (naming the actual nblock and the required value)
+        # rather than the generic one.
+        raise ValueError(
+            "bubble kernel: transverse_bond_bubble_static requires "
+            "green_kw's block axis to be exactly 2 (a spin-diag Green's "
+            "function with G_up as block 0 and G_down as block 1 -- the "
+            "down/up cross-block contraction this entry point computes "
+            "has no meaning for any other block count), got nblock={} "
+            "(required: 2)".format(nblock))
+
+    (green_kw, green0_tail, beta, nblock, nmat, nvol, nd, spatial_shape
+     ) = _validate_dense_inputs(green_kw, green0_tail, beta, spatial_shape,
+                                "general")
+    _validate_even_nmat_for_bond(nmat)
+
+    # The ONE mesh-dependent validation lifecycle point (spec, "The master
+    # transverse topology"), shared with W_pm_bond -- LOCAL import (see the
+    # module docstring's import-graph note: bond_channels imports this
+    # module at its own top level, so a module-level import here would
+    # cycle).
+    from . import bond_channels as _bc
+    _bc.validate_topology_against_mesh(topo, spatial_shape)
+    # Re-fetch a freshly-validated, alias-safe topology for local use (the
+    # same defensive re-construction validate_topology_against_mesh applies
+    # internally -- topo.coeffs is a plain dict a caller could have
+    # re-keyed between that call returning and this line; delta_r/reverse
+    # are read-only arrays, but re-running the constructor costs little and
+    # keeps this entry point's own invariants independent of that detail).
+    topo = _bc.TransverseTopology(topo.delta_r, topo.reverse, topo.coeffs)
+
+    delta_r = np.asarray(topo.delta_r)
+    B = delta_r.shape[0]
+
+    prepped = _prepare_dense(green_kw, green0_tail, beta, spatial_shape,
+                             workers)
+
+    xp = _bk.array_module_of(green_kw)
+    npair = nd * nd
+    ND = npair * B
+    static_index = nmat // 2
+
+    chi_bar = xp.zeros((nvol, ND, ND), dtype=xp.complex128)
+
+    for (m, mp), block in _iter_transverse_bond_channel_pairs(
+            prepped, delta_r, beta, spatial_shape, workers):
+        chi_bar[:, m * npair:(m + 1) * npair,
+                mp * npair:(mp + 1) * npair] = block[static_index]
+        del block
 
     return chi_bar

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -4190,15 +4190,82 @@ class RPA:
         ``transverse_bond_memory_cap_gb`` (spec "Phase W -- Budget
         (stated, not deferred)").
 
-        Byte estimate: persistent storage for ``chi0_pm_bond`` +
-        ``W_pm_bond`` + the dressed output + the ``_solve_rpa`` solve
-        workspace, ``(3 + K_solve) * Nq * ND**2 * 16`` bytes with
-        ``ND = B * norb**2`` and ``K_solve = 3`` -- a documented
-        CONSERVATIVE POLICY ALLOWANCE for the numpy backend (LU factor
-        copy + pivots + solve output; the ``_solve_rpa`` block-detection
-        temporary is counted inside it), NOT a guaranteed LAPACK bound:
-        backend-specific workspaces may exceed it, and the cap's safety
-        margin beyond this estimate is the caller's responsibility. Named
+        The pipeline (``_run_transverse_bond_pipeline``, rpa.py) has two
+        phases that do NOT overlap in time -- the bubble phase
+        (``bubble.transverse_bond_bubble_static``, called first) returns
+        its result before the dressing phase (``_solve_rpa``, called
+        second) allocates anything, so the two phases' peaks are taken as
+        a ``max(...)``, not summed: whichever phase is more expensive for
+        the given shapes bounds the run.
+
+        Byte estimate, phase by phase (``itemsize = 16`` for complex128,
+        ``P = norb**2`` the single-channel orbital-pair count, ``ND = B *
+        P`` the bond-enlarged dimension, ``Nq = self.lattice.nvol``,
+        ``Nmat = self.nmat`` -- available here because ``_init_param``
+        (which sets ``self.nmat``, see ``__init__``'s ordered
+        ``_init_mode -> _init_param -> ... -> _init_interaction``
+        sequence) has already run by the time ``solve()`` reaches this
+        preflight call, well before the (still-unrun) longitudinal
+        solve):
+
+        - **Dressing (solve) phase**: persistent storage for
+          ``chi0_pm_bond`` + ``W_pm_bond`` + the dressed output + the
+          ``_solve_rpa`` solve workspace, ``solve_bytes = (3 + K_solve) *
+          Nq * ND**2 * itemsize`` with ``K_solve = 3`` -- a documented
+          CONSERVATIVE POLICY ALLOWANCE for the numpy backend (LU factor
+          copy + pivots + solve output; the ``_solve_rpa`` block-detection
+          temporary is counted inside it), NOT a guaranteed LAPACK bound.
+          This term has NO ``Nmat`` dependence: the solve only ever sees
+          the static (``Omega=0``) slice.
+
+        - **Bubble phase** (previously OMITTED -- this is the fix):
+          ``_run_transverse_bond_pipeline`` builds ``W`` (via
+          ``bond_channels.W_pm_bond``, shape ``(Nq, ND, ND)``) BEFORE
+          calling ``bubble.transverse_bond_bubble_static``, and that call
+          holds ``W`` resident throughout (it is consumed only afterwards,
+          by the dressing phase). Inside the bubble call:
+
+            * ``chi_bar`` (the ``(Nq, ND, ND)`` static accumulator,
+              returned as ``chi0``) is allocated up front and stays live
+              for the whole channel-pair loop -- together with the
+              already-resident ``W`` this contributes
+              ``2 * Nq * ND**2 * itemsize``.
+            * ``_iter_transverse_bond_channel_pairs`` extracts and holds,
+              for the ENTIRE ``B x B`` pair loop, two full-frequency
+              Green carriers ``green_fwd_sgn`` and ``green_rev``, each
+              shape ``(Nmat, Nq, norb, norb)`` (one block out of the
+              ``nblock=2`` up/down pair, the other half released
+              immediately per the Task-4 per-block ``del`` discipline) --
+              contributing ``2 * Nmat * Nq * norb**2 * itemsize``.
+            * Per pair, ``_bond_pair_full_block`` materializes the
+              FULL-frequency block ``(Nmat, Nq, norb, norb, norb, norb)``
+              == ``(Nmat, Nq, P, P)`` (``contract_general``'s outer-product
+              buffer, immediately reinterpreted as the ``(npair, npair)``
+              pair block). Because that buffer is a non-contiguous
+              ``swapaxes`` view, the subsequent ``.reshape`` forces a
+              fresh contiguous copy, and each of the following steps
+              (``spatial_fftn``, ``tau_to_boson``, the final ``*
+              (-1/beta)`` scale) again allocates a fresh
+              ``(Nmat, Nq, P, P)``-sized buffer that briefly coexists with
+              its predecessor until the explicit ``del`` -- so the
+              per-pair transient working set peaks at TWO such buffers,
+              ``2 * Nmat * Nq * P**2 * itemsize`` (``P**2 = norb**4``).
+              Successive pairs reuse this same transient budget (each
+              generator step ``del``s its own ``block`` right after
+              ``yield``), so it does not accumulate across the ``B x B``
+              loop -- only ONE pair's transient set is ever live at once.
+
+          Summing (and using ``P*(P+1) = P**2 + P``, i.e. ``norb**4 +
+          norb**2``, to fold the last two bullets together):
+          ``bubble_bytes = itemsize * Nq * (2*ND**2 +
+          2*Nmat*norb**2*(norb**2 + 1))``.
+
+        ``peak_bytes = max(bubble_bytes, solve_bytes)``. For small ``B``
+        (few bond channels, so ``ND`` and therefore ``solve_bytes`` stay
+        small) and large ``Nmat``, ``bubble_bytes`` -- which has no
+        counterpart bounding it in the old solve-only estimate -- can
+        exceed ``solve_bytes`` arbitrarily; this is exactly the case the
+        old estimate missed and could OOM on after passing the cap. Named
         an ESTIMATE in every user-facing message, per spec.
 
         Also emits a WARNING (never a refusal) when the estimated solve
@@ -4206,40 +4273,58 @@ class RPA:
         still be compute-prohibitive.
         """
         B = int(len(topo.delta_r))
-        ND = B * self.norb ** 2
+        norb = self.norb
+        P = norb ** 2
+        ND = B * P
         Nq = int(self.lattice.nvol)
+        Nmat = int(self.nmat)
         K_solve = 3
         itemsize = 16  # complex128
 
-        peak_bytes = (3 + K_solve) * Nq * (ND ** 2) * itemsize
+        solve_bytes = (3 + K_solve) * Nq * (ND ** 2) * itemsize
+        bubble_bytes = itemsize * Nq * (
+            2 * (ND ** 2) + 2 * Nmat * P * (P + 1))
+        peak_bytes = max(bubble_bytes, solve_bytes)
         op_count = Nq * (ND ** 3)
 
         logger.info(
             "Transverse bond-channel preflight (ESTIMATE): B = %d "
-            "channels, ND = B*norb**2 = %d, N_q = %d, K_solve = %d "
-            "(numpy-backend conservative allowance), estimated peak "
-            "memory = %.3f GB (cap %.3f GB), estimated solve op-count "
+            "channels, ND = B*norb**2 = %d, N_q = %d, Nmat = %d, "
+            "K_solve = %d (numpy-backend conservative allowance), "
+            "estimated bubble-phase peak = %.3f GB, estimated "
+            "solve-phase peak = %.3f GB, estimated overall peak memory "
+            "= %.3f GB (cap %.3f GB), estimated solve op-count "
             "Nq*ND**3 = %.3e",
-            B, ND, Nq, K_solve, peak_bytes / 1.0e9,
+            B, ND, Nq, Nmat, K_solve, bubble_bytes / 1.0e9,
+            solve_bytes / 1.0e9, peak_bytes / 1.0e9,
             self.transverse_bond_memory_cap_gb, op_count)
 
         if peak_bytes > self.transverse_bond_memory_cap_gb * 1.0e9:
             raise ValueError(
                 "[mode.param] transverse_bond_channels: ESTIMATED peak "
                 "memory {:.3f} GB exceeds transverse_bond_memory_cap_gb = "
-                "{:.3f} GB. The estimate is (3 + K_solve) * Nq * ND**2 * "
-                "16 bytes with ND = B*norb**2 = {}, Nq = {}, K_solve = {} "
-                "(a numpy-backend conservative allowance, not a "
-                "guaranteed LAPACK bound). Restrict or remove some "
-                "off-site CoulombInter/Ising/Exchange declarations to "
-                "shrink the channel set B, use a coarser k-mesh, or raise "
-                "transverse_bond_memory_cap_gb. transverse_bond_max_shells "
-                "only helps if the outer shells you would drop are "
-                "declared-zero -- resolve_transverse_topology refuses any "
-                "truncation that would discard a declared nonzero "
-                "off-site coefficient.".format(
+                "{:.3f} GB (bubble-phase estimate {:.3f} GB, solve-phase "
+                "estimate {:.3f} GB; peak = max of the two, they do not "
+                "overlap in time). The solve-phase estimate is "
+                "(3 + K_solve) * Nq * ND**2 * 16 bytes with ND = "
+                "B*norb**2 = {}, Nq = {}, K_solve = {}. The bubble-phase "
+                "estimate is 16 * Nq * (2*ND**2 + 2*Nmat*norb**2*"
+                "(norb**2+1)) bytes with Nmat = {} (both are numpy-backend "
+                "conservative allowances, not guaranteed LAPACK/BLAS "
+                "bounds). Restrict or remove some off-site "
+                "CoulombInter/Ising/Exchange declarations to shrink the "
+                "channel set B, use a coarser k-mesh, reduce Nmat (a "
+                "lever for the bubble-phase estimate specifically, since "
+                "the solve-phase estimate does not depend on it), or "
+                "raise transverse_bond_memory_cap_gb. "
+                "transverse_bond_max_shells only helps if the outer "
+                "shells you would drop are declared-zero -- "
+                "resolve_transverse_topology refuses any truncation that "
+                "would discard a declared nonzero off-site "
+                "coefficient.".format(
                     peak_bytes / 1.0e9, self.transverse_bond_memory_cap_gb,
-                    ND, Nq, K_solve))
+                    bubble_bytes / 1.0e9, solve_bytes / 1.0e9,
+                    ND, Nq, K_solve, Nmat))
 
         if op_count > 1.0e12:
             logger.warning(

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -4177,11 +4177,24 @@ class RPA:
         # present; the merge below is still written generally (update,
         # not overwrite) so it stays correct even if that guard's scope
         # ever changes.
+        #
+        # ``interactions`` (``self.ham_info.param_ham``/``param_ham_orig``)
+        # is a ``CaseInsensitiveDict`` (see ``Interaction._init_interaction``'s
+        # own comment on this exact defect class): callers may declare
+        # 'ising'/'exchange'/'coulomb' in any case and ``_make_ham_inter``
+        # still honors it. A plain ``dict(interactions)`` copy would
+        # DOWNGRADE that -- it preserves each key's stored case as an
+        # ordinary (case-SENSITIVE) dict key, so a lowercase 'ising' would
+        # silently stop matching ``resolve_transverse_topology``'s
+        # canonical-cased ``interactions.get('Ising', {})`` lookup and
+        # vanish from the topology. Copy into a fresh
+        # ``CaseInsensitiveDict`` instead, which preserves case-insensitive
+        # lookup for every key untouched by this merge.
         if 'Coulomb' in interactions:
             _coulomb_intra, coulomb_inter_agg = wan90.split_coulomb(
                 interactions['Coulomb'])
-            interactions = dict(interactions)
-            merged_inter = dict(interactions.get('CoulombInter', {}))
+            interactions = CaseInsensitiveDict(interactions)
+            merged_inter = dict(interactions.get('CoulombInter', {}) or {})
             merged_inter.update(coulomb_inter_agg)
             interactions['CoulombInter'] = merged_inter
 
@@ -4247,47 +4260,100 @@ class RPA:
           This term has NO ``Nmat`` dependence: the solve only ever sees
           the static (``Omega=0``) slice.
 
-        - **Bubble phase** (previously OMITTED -- this is the fix):
-          ``_run_transverse_bond_pipeline`` builds ``W`` (via
-          ``bond_channels.W_pm_bond``, shape ``(Nq, ND, ND)``) BEFORE
-          calling ``bubble.transverse_bond_bubble_static``, and that call
-          holds ``W`` resident throughout (it is consumed only afterwards,
-          by the dressing phase). Inside the bubble call:
+        - **Bubble phase** (previously OMITTED entirely -- this is the
+          fix; a first round undercounted its pair-processing sub-phase
+          and never bounded its preparation sub-phase -- this is the
+          correction). ``_run_transverse_bond_pipeline`` builds ``W``
+          (via ``bond_channels.W_pm_bond``, shape ``(Nq, ND, ND)``)
+          BEFORE calling ``bubble.transverse_bond_bubble_static``, and
+          that call holds ``W`` resident throughout (it is consumed only
+          afterwards, by the dressing phase). The bubble call itself has
+          two sub-phases with DIFFERENT resident sets -- ``W`` is the
+          only ``ND``-scale tensor alive during preparation (``chi_bar``
+          below does not exist yet), so the two sub-phases' peaks are
+          bounded SEPARATELY and combined with ``max(...)`` (never
+          summed, for the same non-overlap reason as the two top-level
+          phases):
 
-            * ``chi_bar`` (the ``(Nq, ND, ND)`` static accumulator,
-              returned as ``chi0``) is allocated up front and stays live
-              for the whole channel-pair loop -- together with the
-              already-resident ``W`` this contributes
-              ``2 * Nq * ND**2 * itemsize``.
-            * ``_iter_transverse_bond_channel_pairs`` extracts and holds,
-              for the ENTIRE ``B x B`` pair loop, two full-frequency
-              Green carriers ``green_fwd_sgn`` and ``green_rev``, each
-              shape ``(Nmat, Nq, norb, norb)`` (one block out of the
-              ``nblock=2`` up/down pair, the other half released
-              immediately per the Task-4 per-block ``del`` discipline) --
-              contributing ``2 * Nmat * Nq * norb**2 * itemsize``.
-            * Per pair, ``_bond_pair_full_block`` materializes the
-              FULL-frequency block ``(Nmat, Nq, norb, norb, norb, norb)``
-              == ``(Nmat, Nq, P, P)`` (``contract_general``'s outer-product
-              buffer, immediately reinterpreted as the ``(npair, npair)``
-              pair block). Because that buffer is a non-contiguous
-              ``swapaxes`` view, the subsequent ``.reshape`` forces a
-              fresh contiguous copy, and each of the following steps
-              (``spatial_fftn``, ``tau_to_boson``, the final ``*
-              (-1/beta)`` scale) again allocates a fresh
-              ``(Nmat, Nq, P, P)``-sized buffer that briefly coexists with
-              its predecessor until the explicit ``del`` -- so the
-              per-pair transient working set peaks at TWO such buffers,
-              ``2 * Nmat * Nq * P**2 * itemsize`` (``P**2 = norb**4``).
-              Successive pairs reuse this same transient budget (each
-              generator step ``del``s its own ``block`` right after
-              ``yield``), so it does not accumulate across the ``B x B``
-              loop -- only ONE pair's transient set is ever live at once.
+          *Preparation sub-phase* (``_prepare_dense``, called once on
+          the full ``nblock=2`` up/down Green tensor, BEFORE the
+          per-block split): let ``U = 2 * Nmat * Nq * P * itemsize`` be
+          the byte size of one full two-block ``(2, Nmat, Nq, norb,
+          norb)`` tensor. Every internal step that is not a pure
+          ``reshape`` (view) allocates a NEW ``U``-sized buffer while its
+          predecessor is still referenced -- ``matsubara.fermion_to_tau``
+          internally computes ``xp.fft.fft(arr, axis=1) *
+          _bcast(omg, ...)``, an ``fft`` output buffer times a
+          RESHAPED (not tiled) phase, so exactly one extra ``U``-buffer
+          coexists with the fft output during that multiply;
+          ``backend.spatial_ifftn`` (new buffer) runs while its input is
+          still bound; ``kgrid.reverse_fft_axes`` (its own docstring:
+          "New array") runs while ``green_rt`` is still bound because it
+          is returned alongside ``green_rev`` in ``prepped``. Each of
+          these is a 2-buffer transient, so the tail-OFF peak is
+          ``2*U = 4*Nmat*Nq*P*itemsize``. Tail-ON additionally builds
+          ``jump_f``/``jump_r_rev``/``fwd0_p``/``rev0_p``, four buffers
+          of size ``S = 2*Nq*P*itemsize`` each (a single-frequency slice
+          of the two-block tensor -- no ``Nmat`` factor) that all persist
+          to the return, on top of the still-resident ``green_rt``/
+          ``green_rev`` (``2*U``): tail-ON peak = ``2*U + 4*S =
+          4*Nmat*Nq*P*itemsize + 8*Nq*P*itemsize``. Tail-ON is the
+          uniformly larger (and therefore used) bound -- whether the
+          tail is actually active depends on runtime Green-function
+          content, not on anything known at preflight time:
+          ``prep_bytes = itemsize * Nq * (ND**2 + 4*P*(Nmat + 2))``
+          (the ``ND**2`` term is ``W`` alone).
 
-          Summing (and using ``P*(P+1) = P**2 + P``, i.e. ``norb**4 +
-          norb**2``, to fold the last two bullets together):
-          ``bubble_bytes = itemsize * Nq * (2*ND**2 +
-          2*Nmat*norb**2*(norb**2 + 1))``.
+          *Pair-processing sub-phase* (the ``B x B`` channel-pair loop):
+          ``_iter_transverse_bond_channel_pairs`` extracts and holds, for
+          the ENTIRE loop, two full-frequency Green carriers
+          ``green_fwd_sgn`` and ``green_rev``, each shape ``(Nmat, Nq,
+          norb, norb)`` (one block out of the ``nblock=2`` pair, the
+          other half released immediately per the Task-4 per-block
+          ``del`` discipline) -- contributing ``2 * Nmat * Nq * P *
+          itemsize`` (``P = norb**2``) alongside the already-resident
+          ``W`` AND, from this point on, ``chi_bar`` (the ``(Nq, ND,
+          ND)`` static accumulator, allocated right before the loop
+          starts): ``2 * Nq * ND**2 * itemsize``. Per pair,
+          ``_bond_pair_full_block`` materializes the FULL-frequency block
+          ``(Nmat, Nq, norb, norb, norb, norb)`` == ``(Nmat, Nq, P, P)``
+          (``contract_general``'s outer-product buffer, immediately
+          reinterpreted as the ``(npair, npair)`` pair block, ``npair =
+          P``). Because that buffer is a non-contiguous ``swapaxes``
+          view, the subsequent ``.reshape`` forces a fresh contiguous
+          copy, then ``spatial_fftn`` allocates its own output -- each of
+          these is an ordinary 2-buffer (old + new) transient. The THIRD
+          step, ``matsubara.tau_to_boson``, is NOT: it computes
+          ``xp.fft.ifft(arr * _bcast(omg_inv, ...), axis=0)`` where
+          ``arr`` is the caller's ``chi0_qt`` (still bound in
+          ``_bond_pair_full_block`` -- not ``del``'d until AFTER
+          ``tau_to_boson`` returns). ``arr * _bcast(...)`` allocates ONE
+          new buffer (``_bcast`` reshapes the phase vector, it does not
+          tile it, so the multiply is an ordinary broadcast producing a
+          single output), and ``xp.fft.ifft`` on THAT allocates a SECOND
+          new buffer while the first is still on the evaluation stack --
+          so at the peak, THREE full ``(Nmat, Nq, P, P)`` buffers coexist
+          simultaneously: ``arr`` (== ``chi0_qt``, the caller's still-live
+          reference), the multiply's output, and the ``ifft`` output (a
+          first review round only counted two, missing that ``chi0_qt``
+          itself remains alive across the call). The tail-correction
+          block (``chi0_rt[0] = ...``, when active) runs BEFORE this
+          chain, while only ONE full ``(Nmat, Nq, P, P)`` buffer
+          (``chi0_rt`` itself) is resident, and adds a bounded ``O(P**2)``
+          (no ``Nmat`` factor -- its own operands are single-frequency
+          slices): its own peak, ``(Nmat + 3) * P**2``, is algebraically
+          ``<= 3 * Nmat * P**2`` for every valid (even, positive)
+          ``Nmat >= 2``, so it never exceeds the THREE-buffer peak that
+          dominates regardless of the tail: ``pair_bytes = itemsize * Nq
+          * (2*ND**2 + 3*Nmat*P**2 + 2*Nmat*P)``.
+
+          ``bubble_bytes = max(prep_bytes, pair_bytes)`` -- ``pair_bytes``
+          dominates for realistic (multi-shell / larger-``Nmat``) runs,
+          but ``prep_bytes`` can exceed it at the smallest valid corner
+          (e.g. ``norb=1``, ``B=1``, ``Nmat=2``: ``prep_bytes`` works out
+          to ``17 * itemsize * Nq`` against ``pair_bytes``'s ``12 *
+          itemsize * Nq``), so the ``max`` is computed explicitly rather
+          than assumed away.
 
         ``peak_bytes = max(bubble_bytes, solve_bytes)``. For small ``B``
         (few bond channels, so ``ND`` and therefore ``solve_bytes`` stay
@@ -4311,8 +4377,10 @@ class RPA:
         itemsize = 16  # complex128
 
         solve_bytes = (3 + K_solve) * Nq * (ND ** 2) * itemsize
-        bubble_bytes = itemsize * Nq * (
-            2 * (ND ** 2) + 2 * Nmat * P * (P + 1))
+        prep_bytes = itemsize * Nq * ((ND ** 2) + 4 * P * (Nmat + 2))
+        pair_bytes = itemsize * Nq * (
+            2 * (ND ** 2) + 3 * Nmat * (P ** 2) + 2 * Nmat * P)
+        bubble_bytes = max(prep_bytes, pair_bytes)
         peak_bytes = max(bubble_bytes, solve_bytes)
         op_count = Nq * (ND ** 3)
 
@@ -4320,31 +4388,35 @@ class RPA:
             "Transverse bond-channel preflight (ESTIMATE): B = %d "
             "channels, ND = B*norb**2 = %d, N_q = %d, Nmat = %d, "
             "K_solve = %d (numpy-backend conservative allowance), "
-            "estimated bubble-phase peak = %.3f GB, estimated "
-            "solve-phase peak = %.3f GB, estimated overall peak memory "
-            "= %.3f GB (cap %.3f GB), estimated solve op-count "
-            "Nq*ND**3 = %.3e",
-            B, ND, Nq, Nmat, K_solve, bubble_bytes / 1.0e9,
-            solve_bytes / 1.0e9, peak_bytes / 1.0e9,
+            "estimated bubble-prep-phase peak = %.3f GB, estimated "
+            "bubble-pair-phase peak = %.3f GB, estimated solve-phase "
+            "peak = %.3f GB, estimated overall peak memory = %.3f GB "
+            "(cap %.3f GB), estimated solve op-count Nq*ND**3 = %.3e",
+            B, ND, Nq, Nmat, K_solve, prep_bytes / 1.0e9,
+            pair_bytes / 1.0e9, solve_bytes / 1.0e9, peak_bytes / 1.0e9,
             self.transverse_bond_memory_cap_gb, op_count)
 
         if peak_bytes > self.transverse_bond_memory_cap_gb * 1.0e9:
             raise ValueError(
                 "[mode.param] transverse_bond_channels: ESTIMATED peak "
                 "memory {:.3f} GB exceeds transverse_bond_memory_cap_gb = "
-                "{:.3f} GB (bubble-phase estimate {:.3f} GB, solve-phase "
-                "estimate {:.3f} GB; peak = max of the two, they do not "
+                "{:.3f} GB (bubble-phase estimate {:.3f} GB [prep {:.3f} "
+                "GB, pair-loop {:.3f} GB, peak = max of the two "
+                "sub-phases], solve-phase estimate {:.3f} GB; overall "
+                "peak = max of the bubble and solve phases, they do not "
                 "overlap in time). The solve-phase estimate is "
                 "(3 + K_solve) * Nq * ND**2 * 16 bytes with ND = "
-                "B*norb**2 = {}, Nq = {}, K_solve = {}. The bubble-phase "
-                "estimate is 16 * Nq * (2*ND**2 + 2*Nmat*norb**2*"
-                "(norb**2+1)) bytes with Nmat = {} (both are numpy-backend "
-                "conservative allowances, not guaranteed LAPACK/BLAS "
+                "B*norb**2 = {}, Nq = {}, K_solve = {}. The bubble "
+                "prep-phase estimate is 16 * Nq * (ND**2 + 4*P*(Nmat+2)) "
+                "bytes and the pair-loop estimate is 16 * Nq * (2*ND**2 "
+                "+ 3*Nmat*P**2 + 2*Nmat*P) bytes, both with P = "
+                "norb**2 and Nmat = {} (all are numpy-backend "
+                "conservative allowances, not guaranteed LAPACK/BLAS/FFT "
                 "bounds). Restrict or remove some off-site "
                 "CoulombInter/Ising/Exchange declarations to shrink the "
                 "channel set B, use a coarser k-mesh, reduce Nmat (a "
-                "lever for the bubble-phase estimate specifically, since "
-                "the solve-phase estimate does not depend on it), or "
+                "lever for BOTH bubble sub-phase estimates, since the "
+                "solve-phase estimate does not depend on it), or "
                 "raise transverse_bond_memory_cap_gb. "
                 "transverse_bond_max_shells only helps if the outer "
                 "shells you would drop are declared-zero -- "
@@ -4352,7 +4424,8 @@ class RPA:
                 "would discard a declared nonzero off-site "
                 "coefficient.".format(
                     peak_bytes / 1.0e9, self.transverse_bond_memory_cap_gb,
-                    bubble_bytes / 1.0e9, solve_bytes / 1.0e9,
+                    bubble_bytes / 1.0e9, prep_bytes / 1.0e9,
+                    pair_bytes / 1.0e9, solve_bytes / 1.0e9,
                     ND, Nq, K_solve, Nmat))
 
         if op_count > 1.0e12:

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -4063,6 +4063,11 @@ class RPA:
             spatial_shape=spatial_shape, workers=workers)
 
         ND = W.shape[-1]
+        # W_pm_bond assembles on the host (numpy) by design; under GPU
+        # execution chi0 lives on the device, and _solve_rpa dispatches on
+        # chi0's backend -- move W there first (numpy.asarray is a no-op
+        # on the CPU path).
+        W = _bk.array_module_of(chi0).asarray(W)
         # The dressing (spec "The dressing (static)"): the EXISTING
         # _solve_rpa's I + chi0 @ ham convention, with the leading
         # length-1 axis satisfying its frequency-axis interface. No sign

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -2068,6 +2068,13 @@ class RPA:
                 if self.transverse_bond_channels:
                     self._transverse_bond_topo = \
                         self._validate_transverse_bond_prereqs()
+                    # Resource preflight immediately AFTER the (cheap)
+                    # prereq validation but BEFORE ANY expensive solve --
+                    # including the longitudinal (ring) solve just below,
+                    # not only the bond-resolved solve -- so a cap
+                    # rejection fires before either expensive step runs.
+                    self._transverse_bond_resource_preflight(
+                        self._transverse_bond_topo)
                 else:
                     self._check_transverse_representable(ham_orig)
 
@@ -2080,11 +2087,6 @@ class RPA:
             # Solve transverse (ladder) RPA if requested
             if self.calc_type == "ring+ladder":
                 if self.transverse_bond_channels:
-                    # Resource preflight AFTER the (cheap) prereq
-                    # validation but BEFORE the bond-resolved solve
-                    # itself, which is the expensive step.
-                    self._transverse_bond_resource_preflight(
-                        self._transverse_bond_topo)
                     chi_pm_bond_static, chiq_pm_static = \
                         self._run_transverse_bond_pipeline(
                             self.green0, self.green0_tail, beta,
@@ -4143,6 +4145,15 @@ class RPA:
                 "Recompute chi0q internally (omit chi0q_init) or set "
                 "transverse_bond_channels=false.")
 
+        if getattr(self.lattice, "has_sublattice", False):
+            raise ValueError(
+                "[mode.param] transverse_bond_channels=true is not "
+                "supported with a sublattice (SubShape < CellShape): the "
+                "bond-resolved transverse channel does not yet implement "
+                "the sublattice folding map for its off-site channels. "
+                "Run without a sublattice (SubShape == CellShape) or set "
+                "transverse_bond_channels=false.")
+
         has_sub = getattr(self.lattice, "has_sublattice", False)
         interactions = (self.ham_info.param_ham_orig if has_sub
                         else self.ham_info.param_ham)
@@ -4219,9 +4230,14 @@ class RPA:
                 "{:.3f} GB. The estimate is (3 + K_solve) * Nq * ND**2 * "
                 "16 bytes with ND = B*norb**2 = {}, Nq = {}, K_solve = {} "
                 "(a numpy-backend conservative allowance, not a "
-                "guaranteed LAPACK bound). Reduce "
-                "transverse_bond_max_shells (fewer channels), reduce the "
-                "k-grid, or raise transverse_bond_memory_cap_gb.".format(
+                "guaranteed LAPACK bound). Restrict or remove some "
+                "off-site CoulombInter/Ising/Exchange declarations to "
+                "shrink the channel set B, use a coarser k-mesh, or raise "
+                "transverse_bond_memory_cap_gb. transverse_bond_max_shells "
+                "only helps if the outer shells you would drop are "
+                "declared-zero -- resolve_transverse_topology refuses any "
+                "truncation that would discard a declared nonzero "
+                "off-site coefficient.".format(
                     peak_bytes / 1.0e9, self.transverse_bond_memory_cap_gb,
                     ND, Nq, K_solve))
 

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -4157,6 +4157,34 @@ class RPA:
         has_sub = getattr(self.lattice, "has_sublattice", False)
         interactions = (self.ham_info.param_ham_orig if has_sub
                         else self.ham_info.param_ham)
+
+        # The aggregate 'Coulomb' table (wan90.split_coulomb's shared
+        # decomposition -- the SAME split _make_ham_inter and
+        # _build_ham_pm_onsite each apply to feed the Hamiltonian and the
+        # on-site vertex) is invisible to resolve_transverse_topology,
+        # which only ever reads the 'CoulombInter'/'Ising'/'Exchange'
+        # keys: without this, an off-site inter-orbital term declared
+        # ONLY via aggregate 'Coulomb' would be seen everywhere else in
+        # the pipeline but not by this gate's topology (wrongly reporting
+        # "no active declaration", or silently computing without that
+        # channel). Merge its inter-orbital off-site part into the
+        # 'CoulombInter' table fed to the resolver. The ambiguity guard
+        # ('Coulomb' cannot coexist with an explicit 'CoulombIntra'/
+        # 'CoulombInter' declaration) already ran at construction time
+        # (Interaction.__init__ -> _make_ham_inter, long before solve()
+        # -- and therefore this method -- is ever reached), so
+        # 'CoulombInter' is always empty here whenever 'Coulomb' is
+        # present; the merge below is still written generally (update,
+        # not overwrite) so it stays correct even if that guard's scope
+        # ever changes.
+        if 'Coulomb' in interactions:
+            _coulomb_intra, coulomb_inter_agg = wan90.split_coulomb(
+                interactions['Coulomb'])
+            interactions = dict(interactions)
+            merged_inter = dict(interactions.get('CoulombInter', {}))
+            merged_inter.update(coulomb_inter_agg)
+            interactions['CoulombInter'] = merged_inter
+
         topo = bond_channels.resolve_transverse_topology(
             interactions, np.eye(3), self.norb,
             max_shells=self.transverse_bond_max_shells)
@@ -4174,8 +4202,9 @@ class RPA:
             raise ValueError(
                 "[mode.param] transverse_bond_channels=true requires an "
                 "active off-site transverse-resolved declaration "
-                "(CoulombInter, Ising or Exchange with a nonzero off-site "
-                "coefficient after duplicate summation, Hermitian "
+                "(CoulombInter, Ising or Exchange -- or the off-site part "
+                "of an aggregate Coulomb declaration -- with a nonzero "
+                "off-site coefficient after duplicate summation, Hermitian "
                 "projection and transverse_bond_max_shells truncation); "
                 "none is present, so the bond-resolved gate has nothing "
                 "to represent. Declare an off-site term, relax "

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -4343,17 +4343,73 @@ class RPA:
           (no ``Nmat`` factor -- its own operands are single-frequency
           slices): its own peak, ``(Nmat + 3) * P**2``, is algebraically
           ``<= 3 * Nmat * P**2`` for every valid (even, positive)
-          ``Nmat >= 2``, so it never exceeds the THREE-buffer peak that
-          dominates regardless of the tail: ``pair_bytes = itemsize * Nq
-          * (2*ND**2 + 3*Nmat*P**2 + 2*Nmat*P)``.
+          ``Nmat >= 2``, so it never exceeds the THREE-buffer peak.
 
-          ``bubble_bytes = max(prep_bytes, pair_bytes)`` -- ``pair_bytes``
-          dominates for realistic (multi-shell / larger-``Nmat``) runs,
-          but ``prep_bytes`` can exceed it at the smallest valid corner
-          (e.g. ``norb=1``, ``B=1``, ``Nmat=2``: ``prep_bytes`` works out
-          to ``17 * itemsize * Nq`` against ``pair_bytes``'s ``12 *
-          itemsize * Nq``), so the ``max`` is computed explicitly rather
-          than assumed away.
+          RETAINED TAIL CARRIERS (a second review round's fix -- these
+          were bounded inside ``prep_bytes`` but omitted from
+          ``pair_bytes``): ``prepped`` (the ``_DensePrepared`` instance
+          ``_prepare_dense`` returns) is held alive by
+          ``transverse_bond_bubble_static``'s own local variable for the
+          ENTIRE function, including the whole pair-processing loop --
+          not just during preparation. ``_iter_transverse_bond_channel_
+          pairs`` only clears ``prepped.green_rt``/``prepped.green_rev``
+          (setting them ``None`` right after extracting the single-block
+          carriers above); it never touches ``prepped.fwd0_p``/
+          ``rev0_p``/``jump_f``/``jump_r_rev``. When tail-on, those are
+          the SAME four full two-block ``S = 2*Nq*P*itemsize`` buffers
+          ``prep_bytes`` already counts -- ``tail_pack`` (built once,
+          also for the whole loop) holds only single-block VIEWS into
+          them, so the underlying two-block buffers are what actually
+          stay resident, not merely their views. This is genuinely
+          additional storage throughout the pair loop, on top of the
+          THREE-buffer per-pair transient: ``+ 4*S = 8*Nq*P*itemsize``.
+          Whether these four arrays exist at all is decided by
+          ``_prepare_dense``'s own ``tail_on = bool(xp.any(green0_tail
+          ...[:, 0] != 0))`` check on actual Green-function content --
+          ``self.green0_tail`` is available at preflight time (set by
+          ``solve()`` before this method runs), but RPA's own
+          ``_calc_green`` NEVER returns ``None`` for it (its docstring:
+          "materializes a shape-matched all-zero tail" when
+          ``coeff_tail == 0``), so an ``is not None`` presence check
+          would always be ``True`` here and provide no tightening --
+          replicating ``xp.any(...)`` itself would duplicate a
+          host/device-synchronizing reduction ``_prepare_dense`` already
+          performs once, which is not "cheap" to redo speculatively at
+          preflight time. So, like ``prep_bytes``, this term is counted
+          UNCONDITIONALLY (the conservative bound, per this function's
+          existing policy):
+          ``pair_bytes = itemsize * Nq * (2*ND**2 + 3*Nmat*P**2 +
+          2*Nmat*P + 8*P)``.
+
+          CARRIER-EXTRACTION TRANSITION (verified, not merely assumed):
+          at the instant ``_iter_transverse_bond_channel_pairs`` begins
+          -- ``prepped.green_rt`` (2-block, ``2*Nmat*P``) and
+          ``prepped.green_rev`` (2-block, ``2*Nmat*P``) both still whole,
+          plus the newly-forming single-block ``green_fwd_sgn``
+          (``Nmat*P``), plus the same retained tail carriers (``8*P``),
+          plus ``W``+``chi_bar`` (``2*ND**2``) -- the total is
+          ``2*ND**2 + 5*Nmat*P + 8*P``. Comparing to the steady-state
+          ``pair_bytes`` above (``2*ND**2 + 3*Nmat*P**2 + 2*Nmat*P +
+          8*P``), the difference is ``3*Nmat*P**2 - 3*Nmat*P =
+          3*Nmat*P*(P - 1)``, which is exactly ``0`` at ``norb=1``
+          (``P=1``) and strictly positive for ``norb>1``: the
+          steady-state ``pair_bytes`` formula bounds the extraction
+          transition too, with equality (not slack) at the ``norb=1``
+          corner -- so no separate term is needed, but the bound is
+          tight there, not merely "large enough by coincidence".
+
+          ``bubble_bytes = max(prep_bytes, pair_bytes)``. With the
+          retained-tail-carrier term now in BOTH, ``pair_bytes -
+          prep_bytes = ND**2 + Nmat*P*(3*P - 2)``, which is strictly
+          positive for every valid ``P >= 1``, ``Nmat >= 2``, ``ND >= 1``
+          -- so ``pair_bytes`` now provably dominates ``prep_bytes``
+          everywhere (unlike before this fix, where ``prep_bytes`` won
+          at the smallest corner, ``norb=1``/``B=1``/``Nmat=2``: ``17``
+          vs the OLD ``pair_bytes``'s ``12``, in units of ``itemsize *
+          Nq`` -- with the fix, the same corner gives ``17`` vs the NEW
+          ``pair_bytes``'s ``20``). The ``max`` is still computed
+          explicitly in code rather than simplified away, for robustness
+          against future changes to either sub-phase.
 
         ``peak_bytes = max(bubble_bytes, solve_bytes)``. For small ``B``
         (few bond channels, so ``ND`` and therefore ``solve_bytes`` stay
@@ -4379,7 +4435,7 @@ class RPA:
         solve_bytes = (3 + K_solve) * Nq * (ND ** 2) * itemsize
         prep_bytes = itemsize * Nq * ((ND ** 2) + 4 * P * (Nmat + 2))
         pair_bytes = itemsize * Nq * (
-            2 * (ND ** 2) + 3 * Nmat * (P ** 2) + 2 * Nmat * P)
+            2 * (ND ** 2) + 3 * Nmat * (P ** 2) + 2 * Nmat * P + 8 * P)
         bubble_bytes = max(prep_bytes, pair_bytes)
         peak_bytes = max(bubble_bytes, solve_bytes)
         op_count = Nq * (ND ** 3)
@@ -4409,7 +4465,7 @@ class RPA:
                 "B*norb**2 = {}, Nq = {}, K_solve = {}. The bubble "
                 "prep-phase estimate is 16 * Nq * (ND**2 + 4*P*(Nmat+2)) "
                 "bytes and the pair-loop estimate is 16 * Nq * (2*ND**2 "
-                "+ 3*Nmat*P**2 + 2*Nmat*P) bytes, both with P = "
+                "+ 3*Nmat*P**2 + 2*Nmat*P + 8*P) bytes, both with P = "
                 "norb**2 and Nmat = {} (all are numpy-backend "
                 "conservative allowances, not guaranteed LAPACK/BLAS/FFT "
                 "bounds). Restrict or remove some off-site "

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -4129,8 +4129,7 @@ class RPA:
                 "spin-orbit-coupled H0): the bond-resolved dressing is "
                 "implemented for the spin-diagonal transverse channel "
                 "only. Composing it with the full spinful space is a "
-                "deferred follow-up (spec 'Phase S -- the full spinful "
-                "transverse'). Use a spin-diagonal system (no spin-mixing "
+                "planned extension. Use a spin-diagonal system (no spin-mixing "
                 "transfer/enable_spin_orbital term) or set "
                 "transverse_bond_channels=false.")
 

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -29,6 +29,7 @@ from hwave.solver.kgrid import reverse_fft_axes
 from hwave.solver.declarations import symmetrise_dense
 from hwave.solver.density_projection import project_density_pairs
 from . import backend as _bk
+from . import bond_channels
 from . import bubble
 from . import fold
 from . import green as green_mod
@@ -3650,6 +3651,241 @@ class RPA:
             return None
 
         return list(components.values())
+
+    # -------------------------------------------------------------------
+    # Phase W (bond-resolved transverse channel): the internal pipeline
+    # entry (spec 2026-08-15-bond-transverse-design.md, "Phase W --
+    # implementation + ED campaign"; plan Task 5). Appended for this task
+    # only -- the methods above are unmodified.
+    # -------------------------------------------------------------------
+
+    def _build_ham_pm_onsite(self):
+        """Build the on-site-only transverse vertex that feeds channel 0
+        of ``W_pm_bond`` (spec "The dressing (static)", step 1).
+
+        Locality is judged on the ORIGINAL PRE-FOLD declarations
+        (``self.ham_info.param_ham_orig`` when the lattice has a
+        sublattice, else ``self.ham_info.param_ham``), filtered to
+        ``irvec == (0, 0, 0)`` -- the SAME pattern ``_make_ham_inter``'s
+        ``onsite_r``/``_append_onsite_direct`` closures use for the
+        spinful Fierz-exchange correction (issue #137), generalized here
+        across every interaction type and independent of
+        ``enable_spin_orbital``. Reading locality off the FOLDED table
+        (``self.ham_info.param_ham`` under sublattice folding) would fold
+        an off-site bond onto ``r=(0,0,0)`` between supercell orbitals
+        and silently smuggle off-site content into the on-site channel --
+        the pre-fold locality trap ``_append_inter_cross``/
+        ``_append_onsite_direct`` document and PR history has hit
+        repeatedly.
+
+        Each filtered table is symmetrised with the SAME per-slot-family
+        rule ``_make_ham_inter``'s ``_symmetrised`` closure applies
+        (plain mean for the density/flip types, Hermitian mean for
+        PairHop): restricted to a single (on-site) cell, the two
+        closures are algebraically identical, because
+        ``reverse_fft_axes`` "leaves index 0 in place" for any mesh
+        shape -- the reversal partner of an ``r=(0,0,0)`` entry is always
+        the SAME cell with orbitals swapped.
+
+        The resulting on-site tensor is q-INDEPENDENT (an on-site
+        interaction cannot produce a q-dependent vertex --
+        ``_assemble_transverse_vertex``'s own docstring measurement), so
+        it is broadcast identically across ``nvol`` before assembly.
+
+        Returns
+        -------
+        ndarray, complex128, shape (nvol, norb, norb, norb, norb)
+            ``_assemble_transverse_vertex`` applied to the on-site-only
+            interaction tensor.
+        """
+        ham_info = self.ham_info
+        lattice = self.lattice
+        nvol = lattice.nvol
+        norb = self.norb
+        ns = self.ns
+        nd = norb * ns
+        has_sub = getattr(lattice, "has_sublattice", False)
+        source = ham_info.param_ham_orig if has_sub else ham_info.param_ham
+
+        spin_table_cache = {
+            t: ring_spin_table(t)
+            for t in ('CoulombIntra', 'CoulombInter', 'Hund', 'Ising',
+                      'PairLift', 'Exchange', 'PairHop')
+        }
+
+        def _onsite_table(tbl):
+            # Filter a PRE-FOLD table to irvec == (0, 0, 0), fold
+            # orbital indices under sublattice (never spatial content --
+            # an on-site declaration stays on-site under folding, but the
+            # re-filter below stays defensive, mirroring
+            # _append_onsite_direct exactly).
+            filtered = {}
+            for (irvec, orbvec), v in (tbl or {}).items():
+                if tuple(int(x) for x in irvec) == (0, 0, 0):
+                    filtered[((0, 0, 0),
+                              (int(orbvec[0]), int(orbvec[1])))] = v
+            if not filtered:
+                return {}
+            if has_sub:
+                filtered = ham_info._reshape_interaction(filtered, False)
+                filtered = {
+                    (irvec, orbvec): v
+                    for (irvec, orbvec), v in filtered.items()
+                    if tuple(irvec) == (0, 0, 0)
+                }
+            return filtered
+
+        def _symmetrised_onsite(type_name, tbl):
+            # Algebraic equivalent of _make_ham_inter's _symmetrised
+            # closure, restricted to the on-site cell (see docstring).
+            arr = np.zeros((norb, norb), dtype=np.complex128)
+            for (_irvec, orbvec), v in tbl.items():
+                arr[orbvec] += v
+            if type_name == "PairHop":
+                sym = 0.5 * (arr + np.conjugate(arr.T))
+            else:
+                sym = 0.5 * (arr + arr.T)
+            out = {}
+            for a, b in zip(*np.nonzero(sym)):
+                out[((0, 0, 0), (int(a), int(b)))] = sym[a, b]
+            return out
+
+        ham_r8 = np.zeros((*(ns, norb) * 4,), dtype=np.complex128)
+
+        def _append_density_like(type_name, tbl=None):
+            src_tbl = tbl if tbl is not None else source.get(type_name)
+            sym = _symmetrised_onsite(type_name, _onsite_table(src_tbl))
+            for (_irvec, orbvec), v in sym.items():
+                a, b = orbvec
+                for spinvec, w in spin_table_cache[type_name].items():
+                    s1, s2, s3, s4 = spinvec
+                    # beta beta' alpha alpha' -- same slot layout as
+                    # _make_ham_inter's _append_inter.
+                    orb = (s4, b, s3, b, s1, a, s2, a)
+                    ham_r8[orb] += v * w
+
+        def _append_pairhop_like(type_name, tbl=None):
+            src_tbl = tbl if tbl is not None else source.get(type_name)
+            sym = _symmetrised_onsite(type_name, _onsite_table(src_tbl))
+            for (_irvec, orbvec), v in sym.items():
+                a, b = orbvec
+                for spinvec, w in spin_table_cache[type_name].items():
+                    s1, s2, s3, s4 = spinvec
+                    # same slot layout as _make_ham_inter's
+                    # _append_pairhop.
+                    orb = (s4, b, s3, a, s1, a, s2, b)
+                    ham_r8[orb] += v * w
+
+        if 'Coulomb' in source:
+            # Aggregate 'Coulomb' input splits into intra/inter parts on
+            # the PRE-FOLD table, mirroring _make_ham_inter's own
+            # _append_onsite_direct call sites for the 'Coulomb' key.
+            coulomb_intra_pre, coulomb_inter_pre = wan90.split_coulomb(
+                source['Coulomb'])
+            _append_density_like('CoulombIntra', tbl=coulomb_intra_pre)
+            _append_density_like('CoulombInter', tbl=coulomb_inter_pre)
+        if 'CoulombIntra' in source:
+            _append_density_like('CoulombIntra')
+        if 'CoulombInter' in source:
+            _append_density_like('CoulombInter')
+        if 'Hund' in source:
+            _append_density_like('Hund')
+        if 'Ising' in source:
+            _append_density_like('Ising')
+        if 'PairLift' in source:
+            _append_density_like('PairLift')
+        if 'Exchange' in source:
+            _append_density_like('Exchange')
+        if 'PairHop' in source:
+            _append_pairhop_like('PairHop')
+
+        ham_r4 = ham_r8.reshape(nd, nd, nd, nd)
+        ham_onsite_nvol = np.broadcast_to(
+            ham_r4[None, :, :, :, :], (nvol, nd, nd, nd, nd)).copy()
+        return self._assemble_transverse_vertex(ham_onsite_nvol)
+
+    def _run_transverse_bond_pipeline(self, green_kw, green0_tail, beta,
+                                       topo):
+        """The bond-resolved transverse (Phase W) internal pipeline
+        entry: on-site vertex assembly -> ``W_pm_bond`` ->
+        ``transverse_bond_bubble_static`` -> dressing (the EXISTING
+        ``_solve_rpa``'s ``I + chi0.ham`` convention) -> collapse to the
+        plain ``(nvol, norb, norb, norb, norb)`` shape (spec "The
+        dressing (static)" / "Collapse rule (exact)").
+
+        Test-invocable, NO prereq fallback (anti-vacuity, spec "Phase W
+        -- implementation + ED campaign"): every granule and gate W1 call
+        this entry directly; the production gate's own fallback behavior
+        (Task 7) is validated separately by its own config matrix.
+
+        Parameters
+        ----------
+        green_kw : ndarray, complex, shape (2, nmat, nvol, norb, norb)
+            Canonical two-block Green's function (block 0 = up, block 1
+            = down) -- same contract as ``_calc_chi0q_transverse``.
+        green0_tail : ndarray or None
+            Paired tau-space tail add-back, forwarded to
+            ``bubble.transverse_bond_bubble_static`` (``None`` disables
+            the tail correction).
+        beta : float
+            Inverse temperature.
+        topo : bond_channels.TransverseTopology
+            The master transverse bond topology (e.g.
+            ``bond_channels.resolve_transverse_topology`` or an
+            equivalent hand-built, invariant-satisfying instance); its
+            off-site channels feed ``W_pm_bond``'s cross/flip families
+            and ``chi0``'s bond-pair structure. On-site (channel 0)
+            content is NOT read from ``topo`` -- it is built
+            independently by ``_build_ham_pm_onsite`` from the solver's
+            OWN pre-fold declarations (spec step 1); ``W_pm_bond`` places
+            it verbatim into channel 0.
+
+        Returns
+        -------
+        chi_pm_bond_static : ndarray, complex128, shape (nvol, ND, ND)
+            The dressed bond-transverse static susceptibility, ``ND =
+            B * norb**2``.
+        chiq_pm_static : ndarray, complex128, shape
+            (nvol, norb, norb, norb, norb)
+            The collapsed (m=0, m'=0) sub-block (spec "Collapse rule
+            (exact)": ``chiq_pm_static[q, a, c, b, d] =
+            chi_pm_bond[q, (0, a, c), (0, b, d)]``) -- the same object
+            gate W1 compares against today's plain ``chiq_pm``.
+        """
+        spatial_shape = tuple(int(x) for x in self.lattice.shape)
+        nvol = self.lattice.nvol
+        workers = getattr(self, "fft_workers", 1)
+        norb = self.norb
+
+        ham_pm_onsite = self._build_ham_pm_onsite()
+
+        W = bond_channels.W_pm_bond(
+            topo, ham_pm_onsite, spatial_shape=spatial_shape)
+        chi0 = bubble.transverse_bond_bubble_static(
+            green_kw, green0_tail, beta, topo,
+            spatial_shape=spatial_shape, workers=workers)
+
+        ND = W.shape[-1]
+        # The dressing (spec "The dressing (static)"): the EXISTING
+        # _solve_rpa's I + chi0 @ ham convention, with the leading
+        # length-1 axis satisfying its frequency-axis interface. No sign
+        # flip anywhere -- W's channel-0 block IS ham_pm_onsite verbatim.
+        sol = self._solve_rpa(chi0.reshape(1, nvol, ND, ND), W)
+        chi_pm_bond_static = sol[0]
+
+        # Collapse (spec "Collapse rule (exact)"): the elementwise
+        # (m=0, m'=0) sub-block. Channel 0 occupies indices [0, nd) on
+        # both axes (W_pm_bond step 1), and the local orbital-pair index
+        # within that block is (a, c) -> a*norb+c (the SAME bond-major/
+        # orbital-minor convention transverse_bond_bubble_static and
+        # W_pm_bond's channel-zero embedding use) -- so a bare slice +
+        # C-order reshape recovers (q, a, c, b, d) directly, with no
+        # further transpose.
+        nd = norb * norb
+        chiq_pm_static = chi_pm_bond_static[:, :nd, :nd].reshape(
+            nvol, norb, norb, norb, norb)
+
+        return chi_pm_bond_static, chiq_pm_static
 
 
 def run(*, input_dict: Optional[dict] = None, input_file: Optional[str] = None):

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -953,8 +953,8 @@ class Interaction:
                     "PairHop declares %d off-site term(s) (irvec != "
                     "(0,0,0)) that this solver silently discards: only "
                     "the on-site part of PairHop is represented (off-site "
-                    "PairHop physics is not implemented; tracking issue "
-                    "pending). Restrict PairHop to on-site declarations "
+                    "PairHop physics is not implemented; see issue #157). "
+                    "Restrict PairHop to on-site declarations "
                     "if this is unintended. Declarations dropped: %s%s",
                     len(offsite),
                     "; ".join(

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -80,6 +80,13 @@ def validate_chi0q_index_convention(data, enable_spin_orbital, file_name=""):
 
 MOMENTUM_CONVENTION = "e_plus_ikR"
 
+# Default [mode.param] transverse_bond_memory_cap_gb (Phase W experimental
+# gate, spec 2026-08-15-bond-transverse-design.md "Production surface"):
+# same default sc.py's [eliashberg] bond_memory_cap_gb uses for its
+# longitudinal sibling (_BOND_MEMORY_CAP_GB), so the two bond-channel
+# gates share one documented default rather than drifting apart.
+TRANSVERSE_BOND_MEMORY_CAP_GB_DEFAULT = 8.0
+
 
 def check_momentum_marker(data, file_name):
     """Strictly validate a PRESENT momentum_convention marker.
@@ -921,6 +928,42 @@ class Interaction:
         #        + (up <-> down)
         def _append_pairhop(type):
             spins = spin_table[type]
+
+            # Off-site PairHop physics is not implemented (spec
+            # "Deferred (recorded)": "Off-site PairHop physics (warning +
+            # tracking issue only)."). Only the on-site (irvec=(0,0,0))
+            # part is read below; warn LOUDLY instead of silently
+            # discarding the rest, naming the ORIGINAL (pre-fold) user
+            # declarations. Locality is judged on the PRE-fold table
+            # (self.param_ham_orig when the lattice has a sublattice,
+            # else self.param_ham) -- the same pre-fold locality rule
+            # _append_onsite_direct/_append_inter_cross above apply, for
+            # the same reason: reading it off the FOLDED self.param_ham
+            # table could let an off-site bond folded onto r=(0,0,0)
+            # between supercell orbitals escape detection here.
+            has_sub = getattr(self.lattice, "has_sublattice", False)
+            orig_tbl = (self.param_ham_orig.get(type, {}) if has_sub
+                        else self.param_ham.get(type, {}))
+            offsite = [(irvec, orbvec, v)
+                       for (irvec, orbvec), v in orig_tbl.items()
+                       if tuple(int(x) for x in irvec) != (0, 0, 0)]
+            if offsite:
+                shown = offsite[:8]
+                logger.warning(
+                    "PairHop declares %d off-site term(s) (irvec != "
+                    "(0,0,0)) that this solver silently discards: only "
+                    "the on-site part of PairHop is represented (off-site "
+                    "PairHop physics is not implemented; tracking issue "
+                    "pending). Restrict PairHop to on-site declarations "
+                    "if this is unintended. Declarations dropped: %s%s",
+                    len(offsite),
+                    "; ".join(
+                        "irvec={} orb=({},{}) v={}".format(
+                            tuple(int(x) for x in irv), ov[0], ov[1], v)
+                        for irv, ov, v in shown),
+                    " ... ({} more)".format(len(offsite) - 8)
+                    if len(offsite) > 8 else "")
+
             tbl = _symmetrised(type, self.param_ham[type])
             for (irvec,orbvec), v in tbl.items():
                 # take account of same-site interaction only
@@ -1418,7 +1461,98 @@ class RPA:
         if err > 0:
             sys.exit(1)
 
+        self._init_transverse_bond_config()
+
         pass
+
+    def _init_transverse_bond_config(self):
+        """Parse ``[mode.param] transverse_bond_channels`` and its
+        companion options (Phase W experimental gate, spec
+        2026-08-15-bond-transverse-design.md "Production surface").
+
+        Mirrors sc.py's ``_read_bond_config`` for the (eliashberg)
+        longitudinal bond gate: the switch defaults to ``False``, is
+        parsed ONLY under ``calc_type='ring+ladder'`` (the transverse
+        ladder channel itself is unreachable otherwise), and every
+        companion option set while the switch is stale (calc_type='ring',
+        or transverse_bond_channels=false) is IGNORED WITH A WARNING
+        rather than silently doing nothing or failing an otherwise valid
+        run. ``self.param_mod`` is a ``CaseInsensitiveDict``, so every
+        lookup here is case-robust by construction.
+        """
+        import numbers
+
+        _tbc_keys = ("transverse_bond_channels",
+                     "transverse_bond_max_shells",
+                     "transverse_bond_memory_cap_gb")
+        present = [k for k in _tbc_keys if k in self.param_mod]
+
+        if self.calc_type != "ring+ladder":
+            if present:
+                logger.warning(
+                    "[mode.param] %s set but calc_type='%s'; the "
+                    "bond-resolved transverse gate only applies to "
+                    "calc_type='ring+ladder' and %s ignored here.",
+                    ", ".join(present), self.calc_type,
+                    "is" if len(present) == 1 else "are")
+            self.transverse_bond_channels = False
+            self.transverse_bond_max_shells = None
+            self.transverse_bond_memory_cap_gb = \
+                TRANSVERSE_BOND_MEMORY_CAP_GB_DEFAULT
+            return
+
+        _flag = self.param_mod.get("transverse_bond_channels", False)
+        if not isinstance(_flag, (bool, np.bool_)):
+            raise ValueError(
+                "[mode.param] transverse_bond_channels must be a boolean, "
+                "got {!r}".format(_flag))
+        self.transverse_bond_channels = bool(_flag)
+
+        if not self.transverse_bond_channels:
+            stale = [k for k in _tbc_keys
+                     if k != "transverse_bond_channels" and k in self.param_mod]
+            if stale:
+                logger.warning(
+                    "[mode.param] %s set but transverse_bond_channels="
+                    "false; these options only apply to "
+                    "transverse_bond_channels=true and are ignored here.",
+                    ", ".join(stale))
+            self.transverse_bond_max_shells = None
+            self.transverse_bond_memory_cap_gb = \
+                TRANSVERSE_BOND_MEMORY_CAP_GB_DEFAULT
+            return
+
+        # transverse_bond_max_shells: int >= 0, or absent/None (keep every
+        # declared off-site shell) -- same semantics
+        # resolve_transverse_topology documents for its own max_shells.
+        _max_shells = self.param_mod.get("transverse_bond_max_shells", None)
+        if _max_shells is not None:
+            if (isinstance(_max_shells, (bool, np.bool_))
+                    or not isinstance(_max_shells, numbers.Integral)):
+                raise ValueError(
+                    "[mode.param] transverse_bond_max_shells must be a "
+                    "non-negative integer, got {!r}".format(_max_shells))
+            _max_shells = int(_max_shells)
+            if _max_shells < 0:
+                raise ValueError(
+                    "[mode.param] transverse_bond_max_shells must be >= 0 "
+                    "(shell 0 = the on-site Delta r = 0 point), got "
+                    "{}".format(_max_shells))
+        self.transverse_bond_max_shells = _max_shells
+
+        _cap_gb = self.param_mod.get("transverse_bond_memory_cap_gb",
+                                      TRANSVERSE_BOND_MEMORY_CAP_GB_DEFAULT)
+        if (isinstance(_cap_gb, (bool, np.bool_))
+                or not isinstance(_cap_gb, numbers.Real)):
+            raise ValueError(
+                "[mode.param] transverse_bond_memory_cap_gb must be a "
+                "real number, got {!r}".format(_cap_gb))
+        _cap_gb = float(_cap_gb)
+        if not np.isfinite(_cap_gb) or _cap_gb <= 0.0:
+            raise ValueError(
+                "[mode.param] transverse_bond_memory_cap_gb must be a "
+                "positive finite number, got {}".format(_cap_gb))
+        self.transverse_bond_memory_cap_gb = _cap_gb
 
     def _round_to_int(self, val, mode):
         import math
@@ -1478,6 +1612,8 @@ class RPA:
         logger.info("    spin_orbital    = {}".format(self.ham_info.enable_spin_orbital))
         logger.info("    calc_scheme     = {}".format(self.calc_scheme))
         logger.info("    calc_type       = {}".format(self.calc_type))
+        logger.info("    transverse_bond_channels = {}".format(
+            self.transverse_bond_channels))
         pass
 
     @do_profile
@@ -1532,6 +1668,8 @@ class RPA:
         # review, round 3).
         green_info.pop("chiq", None)
         green_info.pop("chiq_pm", None)
+        green_info.pop("chiq_pm_bond_static", None)
+        green_info.pop("chiq_pm_static", None)
 
         beta = 1.0/self.T
 
@@ -1920,8 +2058,18 @@ class RPA:
             # For ring+ladder, validate the transverse channel BEFORE the
             # longitudinal solve: an unrepresentable input should fail here,
             # not after the expensive solve has already populated chiq.
+            # transverse_bond_channels=true (Phase W experimental gate)
+            # represents off-site cross-spin/spin-flip content that
+            # _check_transverse_representable would otherwise reject, so
+            # the representability check is bypassed ONLY on that path --
+            # with the gate off this branch is unchanged, so the bypass is
+            # unreachable there.
             if self.calc_type == "ring+ladder":
-                self._check_transverse_representable(ham_orig)
+                if self.transverse_bond_channels:
+                    self._transverse_bond_topo = \
+                        self._validate_transverse_bond_prereqs()
+                else:
+                    self._check_transverse_representable(ham_orig)
 
             # solve longitudinal (ring) RPA
             sol = self._solve_rpa(chi0q, ham)
@@ -1931,10 +2079,28 @@ class RPA:
 
             # Solve transverse (ladder) RPA if requested
             if self.calc_type == "ring+ladder":
-                chi0q_pm, ham_pm = self._build_transverse_channel(
-                    chi0q_orig, ham_orig)
-                sol_pm = self._solve_rpa(chi0q_pm, ham_pm)
-                green_info["chiq_pm"] = _bk.to_host(sol_pm)
+                if self.transverse_bond_channels:
+                    # Resource preflight AFTER the (cheap) prereq
+                    # validation but BEFORE the bond-resolved solve
+                    # itself, which is the expensive step.
+                    self._transverse_bond_resource_preflight(
+                        self._transverse_bond_topo)
+                    chi_pm_bond_static, chiq_pm_static = \
+                        self._run_transverse_bond_pipeline(
+                            self.green0, self.green0_tail, beta,
+                            self._transverse_bond_topo)
+                    green_info["chiq_pm_bond_static"] = \
+                        _bk.to_host(chi_pm_bond_static)
+                    green_info["chiq_pm_static"] = \
+                        _bk.to_host(chiq_pm_static)
+                    # Gated-run output ownership (spec): the plain ladder
+                    # is NOT additionally executed, so green_info["chiq_pm"]
+                    # (the legacy key) is intentionally never populated here.
+                else:
+                    chi0q_pm, ham_pm = self._build_transverse_channel(
+                        chi0q_orig, ham_orig)
+                    sol_pm = self._solve_rpa(chi0q_pm, ham_pm)
+                    green_info["chiq_pm"] = _bk.to_host(sol_pm)
 
         # Restore the solver's public attributes to host arrays so the
         # post-solve object state is backend-independent for downstream
@@ -2040,6 +2206,35 @@ class RPA:
                 # transverse channel chi_+-(q), present for calc_type ring+ladder
                 if green_info.get("chiq_pm") is not None:
                     save_kwargs["chiq_pm"] = green_info["chiq_pm"]
+                # Bond-resolved transverse channel (Phase W experimental
+                # gate, transverse_bond_channels=true): gate-owned output,
+                # mutually exclusive with the legacy chiq_pm key above --
+                # solve() only ever populates one of the two. Schema keys
+                # verbatim per spec ("Production surface").
+                if green_info.get("chiq_pm_bond_static") is not None:
+                    topo = self._transverse_bond_topo
+                    save_kwargs["chiq_pm_bond_static"] = \
+                        green_info["chiq_pm_bond_static"]
+                    save_kwargs["chiq_pm_static"] = \
+                        green_info["chiq_pm_static"]
+                    save_kwargs["transverse_bond_schema_version"] = 1
+                    save_kwargs["transverse_output_kind"] = "bond_static"
+                    save_kwargs["transverse_bond_delta_r"] = \
+                        np.asarray(topo.delta_r)
+                    save_kwargs["transverse_bond_reverse"] = \
+                        np.asarray(topo.reverse)
+                    save_kwargs["transverse_bond_index_order"] = \
+                        "m*norb**2 + a*norb + b"
+                    save_kwargs["transverse_bond_max_shells"] = (
+                        -1 if self.transverse_bond_max_shells is None
+                        else int(self.transverse_bond_max_shells))
+                    save_kwargs["transverse_spatial_shape"] = \
+                        np.array(self.lattice.shape, dtype=np.int64)
+                    save_kwargs["transverse_q_convention"] = \
+                        "q_d = 2*pi*n_d/N_d, C-order flattening"
+                    save_kwargs["transverse_spin_mode"] = self.spin_mode
+                    save_kwargs["transverse_normalization"] = \
+                        "per-site, 1/sqrt(Nvol) bilinears"
                 np.savez(file_name, **save_kwargs)
                 logger.info("save_results: save chiq in file {}".format(file_name))
             else:
@@ -3232,8 +3427,10 @@ class RPA:
         vertex also means an internal TABLE whose off-site parts cancel in the
         symmetrised sum is accepted, which is correct: what the channel uses
         is then well-defined. (File input never reaches here unclosed: since
-        #93 the readers reject declarations that are not Hermitian-closed.) (`_append_pairhop` silently discards off-site
-        PairHop before this point; see the documentation warning.)
+        #93 the readers reject declarations that are not Hermitian-closed.)
+        (`_append_pairhop` discards off-site PairHop before this point,
+        with a ``logger.warning`` naming the dropped declarations; see
+        also the documentation warning.)
         """
         nvol = self.lattice.nvol
         if nvol <= 1:
@@ -3886,6 +4083,150 @@ class RPA:
             nvol, norb, norb, norb, norb)
 
         return chi_pm_bond_static, chiq_pm_static
+
+    # -------------------------------------------------------------------
+    # Phase W Task 7: the experimental gate's own prereq validation and
+    # resource preflight. Both are called from solve() ONLY when
+    # transverse_bond_channels=true (calc_type='ring+ladder' already
+    # required to reach either), mirroring where sc.py's
+    # _validate_bond_prereqs / _bond_resource_preflight run for the
+    # (eliashberg) longitudinal bond gate: after the prerequisite runtime
+    # state (here, self.spin_mode) is known, and BEFORE the expensive
+    # solve, so an invalid/oversized request fails fast.
+    # -------------------------------------------------------------------
+
+    def _validate_transverse_bond_prereqs(self):
+        """Top-level guards for ``transverse_bond_channels=true`` (spec
+        "Production surface"): no active off-site transverse-resolved
+        declaration, ``spin_mode='spinful'``, and an externally supplied
+        ``chi0q_init`` are each a REJECT, naming the gate as inapplicable
+        rather than silently falling back to the plain path -- every
+        gate-on run that starts is bond-owned (spec: "the rev-3
+        warn-and-fall-back is RETRACTED").
+
+        Must be called AFTER ``self.spin_mode`` is known (i.e. from
+        inside ``solve()``, at the same point ``_check_transverse_
+        representable`` would otherwise run) and BEFORE the expensive
+        solve.
+
+        Returns
+        -------
+        bond_channels.TransverseTopology
+            The resolved master transverse topology, computed once here
+            so the activity predicate and the actual pipeline call see
+            the identical object (never re-resolved, and therefore never
+            able to silently disagree with what was just validated).
+        """
+        if self.spin_mode == "spinful":
+            raise ValueError(
+                "[mode.param] transverse_bond_channels=true is not "
+                "supported with spin_mode='spinful' (a genuinely "
+                "spin-orbit-coupled H0): the bond-resolved dressing is "
+                "implemented for the spin-diagonal transverse channel "
+                "only. Composing it with the full spinful space is a "
+                "deferred follow-up (spec 'Phase S -- the full spinful "
+                "transverse'). Use a spin-diagonal system (no spin-mixing "
+                "transfer/enable_spin_orbital term) or set "
+                "transverse_bond_channels=false.")
+
+        if getattr(self, "_chi0q_external", False):
+            raise ValueError(
+                "[mode.param] transverse_bond_channels=true cannot be "
+                "combined with an externally supplied chi0q (chi0q_init): "
+                "the bond path needs the Green's functions that produced "
+                "the bubble (chi0_pm_bond is built from G_up/G_down "
+                "directly), which a file-based chi0q does not carry. "
+                "Recompute chi0q internally (omit chi0q_init) or set "
+                "transverse_bond_channels=false.")
+
+        has_sub = getattr(self.lattice, "has_sublattice", False)
+        interactions = (self.ham_info.param_ham_orig if has_sub
+                        else self.ham_info.param_ham)
+        topo = bond_channels.resolve_transverse_topology(
+            interactions, np.eye(3), self.norb,
+            max_shells=self.transverse_bond_max_shells)
+
+        # "Active" is defined ONCE, operationally, by the shared
+        # predicate (spec): the same function the topology resolver's
+        # own truncation guard implicitly relies on. A topology that
+        # resolves to nothing off-site (nothing declared, or everything
+        # truncated away -- resolve_transverse_topology itself already
+        # refuses a truncation that would drop declared nonzero content,
+        # so "truncated to nothing" here only ever means "nothing was
+        # declared to begin with") has no transverse bond physics to
+        # represent.
+        if not bond_channels.transverse_effective_activity(topo):
+            raise ValueError(
+                "[mode.param] transverse_bond_channels=true requires an "
+                "active off-site transverse-resolved declaration "
+                "(CoulombInter, Ising or Exchange with a nonzero off-site "
+                "coefficient after duplicate summation, Hermitian "
+                "projection and transverse_bond_max_shells truncation); "
+                "none is present, so the bond-resolved gate has nothing "
+                "to represent. Declare an off-site term, relax "
+                "transverse_bond_max_shells, or set "
+                "transverse_bond_channels=false.")
+
+        return topo
+
+    def _transverse_bond_resource_preflight(self, topo):
+        """Estimate the peak memory/compute cost of the bond-resolved
+        transverse gate and refuse to exceed
+        ``transverse_bond_memory_cap_gb`` (spec "Phase W -- Budget
+        (stated, not deferred)").
+
+        Byte estimate: persistent storage for ``chi0_pm_bond`` +
+        ``W_pm_bond`` + the dressed output + the ``_solve_rpa`` solve
+        workspace, ``(3 + K_solve) * Nq * ND**2 * 16`` bytes with
+        ``ND = B * norb**2`` and ``K_solve = 3`` -- a documented
+        CONSERVATIVE POLICY ALLOWANCE for the numpy backend (LU factor
+        copy + pivots + solve output; the ``_solve_rpa`` block-detection
+        temporary is counted inside it), NOT a guaranteed LAPACK bound:
+        backend-specific workspaces may exceed it, and the cap's safety
+        margin beyond this estimate is the caller's responsibility. Named
+        an ESTIMATE in every user-facing message, per spec.
+
+        Also emits a WARNING (never a refusal) when the estimated solve
+        op-count ``Nq * ND**3`` exceeds ``1e12``: a memory-fitting run can
+        still be compute-prohibitive.
+        """
+        B = int(len(topo.delta_r))
+        ND = B * self.norb ** 2
+        Nq = int(self.lattice.nvol)
+        K_solve = 3
+        itemsize = 16  # complex128
+
+        peak_bytes = (3 + K_solve) * Nq * (ND ** 2) * itemsize
+        op_count = Nq * (ND ** 3)
+
+        logger.info(
+            "Transverse bond-channel preflight (ESTIMATE): B = %d "
+            "channels, ND = B*norb**2 = %d, N_q = %d, K_solve = %d "
+            "(numpy-backend conservative allowance), estimated peak "
+            "memory = %.3f GB (cap %.3f GB), estimated solve op-count "
+            "Nq*ND**3 = %.3e",
+            B, ND, Nq, K_solve, peak_bytes / 1.0e9,
+            self.transverse_bond_memory_cap_gb, op_count)
+
+        if peak_bytes > self.transverse_bond_memory_cap_gb * 1.0e9:
+            raise ValueError(
+                "[mode.param] transverse_bond_channels: ESTIMATED peak "
+                "memory {:.3f} GB exceeds transverse_bond_memory_cap_gb = "
+                "{:.3f} GB. The estimate is (3 + K_solve) * Nq * ND**2 * "
+                "16 bytes with ND = B*norb**2 = {}, Nq = {}, K_solve = {} "
+                "(a numpy-backend conservative allowance, not a "
+                "guaranteed LAPACK bound). Reduce "
+                "transverse_bond_max_shells (fewer channels), reduce the "
+                "k-grid, or raise transverse_bond_memory_cap_gb.".format(
+                    peak_bytes / 1.0e9, self.transverse_bond_memory_cap_gb,
+                    ND, Nq, K_solve))
+
+        if op_count > 1.0e12:
+            logger.warning(
+                "[mode.param] transverse_bond_channels: estimated solve "
+                "op-count Nq*ND**3 = %.3e exceeds 1e12 (ND = %d, Nq = "
+                "%d); this run fits the memory cap but may be "
+                "compute-prohibitive.", op_count, ND, Nq)
 
 
 def run(*, input_dict: Optional[dict] = None, input_file: Optional[str] = None):

--- a/tests/test_bond_transverse_ed.py
+++ b/tests/test_bond_transverse_ed.py
@@ -36,6 +36,7 @@ covers:
 Tests must be run from the repository root.
 """
 
+import collections
 import functools
 import unittest
 
@@ -476,17 +477,28 @@ class TestH2OnsiteTableReadjudication(unittest.TestCase):
 
         def _dense_ising(v):
             H = np.zeros((fx.dim, fx.dim), dtype=complex)
-            for j in range(fx.L):
-                sz0 = _n(j, 0, 0) - _n(j, 0, 1)
-                sz1 = _n(j, 1, 0) - _n(j, 1, 1)
-                H = H + v * (sz0 @ sz1)
+            # Phase-H deferred minor (folded into Phase W's Task 1): this
+            # dense (dim, dim) matmul is warning-noisy under some BLAS
+            # backends (spurious "invalid value encountered" on an
+            # all-zero/near-degenerate product) -- the same class of
+            # benign warning ed_oracle_util._diagonalize and
+            # SectorED._build_sectors already guard with
+            # np.errstate(all="ignore") around their own dense linear
+            # algebra; the result here is exact integer/half-integer
+            # arithmetic on a projector product, never actually NaN/Inf.
+            with np.errstate(all="ignore"):
+                for j in range(fx.L):
+                    sz0 = _n(j, 0, 0) - _n(j, 0, 1)
+                    sz1 = _n(j, 1, 0) - _n(j, 1, 1)
+                    H = H + v * (sz0 @ sz1)
             return H
 
         def _dense_hund(v):
             H = np.zeros((fx.dim, fx.dim), dtype=complex)
-            for j in range(fx.L):
-                H = H - v * (_n(j, 0, 0) @ _n(j, 1, 0)
-                             + _n(j, 0, 1) @ _n(j, 1, 1))
+            with np.errstate(all="ignore"):
+                for j in range(fx.L):
+                    H = H - v * (_n(j, 0, 0) @ _n(j, 1, 0)
+                                 + _n(j, 0, 1) @ _n(j, 1, 1))
             return H
 
         for kind, dense_fn in (("Ising", _dense_ising),
@@ -885,7 +897,24 @@ class TestH3FrameMapVZero(unittest.TestCase):
         reproduce the ALREADY-ESTABLISHED H1/H2 ``_frame_map`` (the
         Kubo pair-slot-swap, verified in H1/H2 against the bespoke
         ``_chi_pm_ed`` reference and the on-site table) to round-off, on
-        the SAME H1/H2 fixture."""
+        the SAME H1/H2 fixture.
+
+        Phase-H deferred minor (folded into Phase W's Task 1, per the
+        binding plan's Global Constraints): this ``smap == _frame_map``
+        identity is SPIN-SYMMETRY-CONDITIONAL, not a general fact about
+        ``transverse_ed_to_solver_map`` -- it holds here because the H1/H2
+        fixture (``oracle._fx2_state()``) carries no Zeeman splitting
+        (``G_up == G_dn``), the same condition ``_h3_zeeman_h1``'s own
+        docstring names as the reason H3 needs an explicit Zeeman term at
+        all ("a spin-SYMMETRIC fixture cannot distinguish fwd=up,rev=down
+        from fwd=down,rev=up"). Using the spin-symmetric ``_frame_map``
+        shortcut is correct HERE, on fx2, and nowhere else in this module
+        (H3's own granules below use ``transverse_ed_to_solver_map``
+        directly, never ``_frame_map``, precisely because they are
+        Zeeman-split). Phase W's production/ED-oracle code imports the
+        Zeeman-ROBUST ``transverse_ed_to_solver_map``, never the
+        R=0-only, spin-symmetric ``_frame_map`` shortcut this test
+        exists to calibrate."""
         fx, _C, _CD, h1 = oracle._fx2_state()
         se = ed_oracle_util.SectorED(fx, h1=h1)
         norb = oracle.NORB
@@ -942,6 +971,843 @@ class TestH3FrameMapVZero(unittest.TestCase):
         orb_pairs = [(0, 0), (1, 1), (0, 1), (1, 0)]
         channels = [(R, a, b) for R in Rs for (a, b) in orb_pairs]
         self._check(fx, 0.12, channels, Rs, 2)
+
+
+# ---------------------------------------------------------------------------
+# Phase W, Task 1: Gate W0 -- the pre-implementation numeric oracle for the
+# binding spec's derived W_{+-} element equations
+# (docs/superpowers/specs/2026-08-15-bond-transverse-design.md, "The vertex
+# -- element equations" + "Gate W0"). This section is TEST-LOCAL and
+# PRE-IMPLEMENTATION: none of TransverseTopology/W_pm_bond/
+# resolve_transverse_topology exist yet (Tasks 2-3 of the Phase-W plan build
+# those AFTER this gate passes) -- `w_expected_from_records` is a standalone
+# encoding of the spec's ordered-record equations, built from a lightweight
+# test-local topology stand-in (`_TopoLike`) rather than the production
+# `TransverseTopology` NamedTuple. A FAIL on any granule below reopens the
+# spec section (the discrepancy protocol, #151): never adjust
+# `w_expected_from_records` to force a PASS.
+# ---------------------------------------------------------------------------
+
+_TopoLike = collections.namedtuple("_TopoLike", ["delta_r", "reverse"])
+
+
+def _reversal_orbit_representatives(delta_r, reverse, norb):
+    """Test-local replica of the spec's shared `iter_reversal_orbits`
+    helper (spec, "Canonical orbit rule"): enumerates ONE representative
+    ``(m, a, b)`` per reversal orbit ``{(m, a, b), (reverse[m], b, a)}``,
+    restricted to the OFF-SITE construction domain (``m != 0`` --
+    "steps 2-3 iterate OFF-SITE (R != 0) content EXCLUSIVELY", spec
+    "Construction domain"), tuple-minimum representative (matching the
+    shared helper's stated rule). Channel 0 (on-site) never
+    participates here -- its content lives exclusively in the
+    caller-supplied ``onsite_ham_pm`` block of `w_expected_from_records`.
+    """
+    B = len(delta_r)
+    seen = set()
+    reps = []
+    for m in range(1, B):
+        for a in range(norb):
+            for b in range(norb):
+                key = (m, a, b)
+                if key in seen:
+                    continue
+                partner = (int(reverse[m]), b, a)
+                seen.add(key)
+                seen.add(partner)
+                reps.append(min(key, partner))
+    return reps
+
+
+def _w0_q_mesh_flat(q_mesh):
+    """``(nvol, 3)`` flattened q array, ``q_d = 2*pi*n_d/N_d`` with
+    C-order flattening -- the SAME convention the spec's "Gate W0"
+    section fixes ("q runs on the reciprocal mesh... the SAME
+    convention sc._build_bond_m0_blocks' phase uses") and
+    ``bond_channels.make_bond_kernel_parts``'s own bond-phase
+    construction (``PH[m] = exp(1j*(KX*dm[0]+KY*dm[1]+KZ*dm[2]))`` on
+    ``meshgrid(kx, ky, kz, indexing='ij')``, reshaped C-order)
+    already uses."""
+    Nx, Ny, Nz = q_mesh
+    kx = 2.0 * np.pi * np.arange(Nx) / Nx
+    ky = 2.0 * np.pi * np.arange(Ny) / Ny
+    kz = 2.0 * np.pi * np.arange(Nz) / Nz
+    KX, KY, KZ = np.meshgrid(kx, ky, kz, indexing='ij')
+    return np.stack([KX.ravel(), KY.ravel(), KZ.ravel()], axis=-1)
+
+
+def w_expected_from_records(topo_like, declarations, q_mesh):
+    """Test-local oracle: the spec's ordered-record ``W_{+-}`` equations
+    (spec, "The vertex -- element equations"), encoded directly rather
+    than via the not-yet-implemented production ``W_pm_bond``. This IS
+    gate W0's reference against which this module's ED granules
+    adjudicate the spec's derivation, BEFORE any of that production
+    code exists.
+
+    Parameters
+    ----------
+    topo_like : _TopoLike(delta_r, reverse)
+        ``delta_r``: int array (B, 3), channel 0 ALWAYS (0, 0, 0).
+        ``reverse``: int array (B,), ``reverse[reverse[m]] == m``,
+        ``reverse[0] == 0``.
+    declarations : dict
+        ``declarations["onsite_ham_pm"]``: the ALREADY-ASSEMBLED
+        ``(norb, norb, norb, norb)`` on-site vertex (spec step 1: "the
+        RECEIVED ham_pm_onsite ... `W_pm_bond` performs NO assembly of
+        its own here"), broadcast verbatim into the channel-0 block.
+        ``declarations["CoulombInter"]``, ``declarations["Ising"]``,
+        ``declarations["Exchange"]``: OFF-SITE-ONLY
+        ``dict[m] -> (norb, norb) complex`` coefficient blocks,
+        Hermitian-closed exactly like ``resolve_transverse_topology``'s
+        ``coeffs`` contract (``coeffs[type][reverse[m]] ==
+        conj(coeffs[type][m]).T``) -- entries need only be supplied at
+        whichever channel ``_reversal_orbit_representatives`` picks as
+        the representative's first element (closure lets the formula
+        below recover the mirrored value without a second lookup; see
+        the derivation in the docstring body below). Missing types /
+        missing channels are treated as zero (PASS-ZERO controls, e.g.
+        Hund/PairLift, need not appear at all).
+    q_mesh : (Nx, Ny, Nz)
+        Spatial shape supplying the q mesh (spec: "q runs on the
+        reciprocal mesh q = 2*pi*(n_x/N_x, ...)").
+
+    Returns
+    -------
+    W : ndarray, complex128, shape (nvol, ND, ND)
+        ``ND = B * norb**2``, ``nvol = Nx*Ny*Nz``, C-order flattened --
+        the canonical flattened convention every numerical object in
+        the spec uses.
+
+    Construction (spec steps 1-3, verbatim):
+
+    1. Channel-0 block = the broadcast on-site ``ham_pm``
+       (q-INDEPENDENT).
+    2. Cross family (CoulombInter -Re, Ising +Re): for each off-site
+       reversal-orbit representative ``(m, a, b)`` with declared
+       coefficient ``C = declarations[type][m][a, b]``, BOTH mirrored
+       diagonal TARGET cells get the SAME value ``s_type * Re(C)``::
+
+           W[q, (reverse[m],a,b), (reverse[m],a,b)] += s_type * Re(C)
+           W[q, (m,b,a), (m,b,a)]                   += s_type * Re(C)
+
+       (the two target cells are the reversal orbit of the TARGET
+       diagonal index; closure guarantees they carry the identical
+       ``Re(.)`` value, so ONE lookup at the representative channel
+       ``m`` suffices for both -- derivation below.)
+    3. Flip family (Exchange, ``f_J = -1``): for each off-site
+       reversal-orbit representative ``(m, a, b)`` with
+       ``J = declarations["Exchange"][m][a, b]`` at ``R = delta_r[m]``::
+
+           W[q, (0,a,a), (0,b,b)] += -conj(J)  * exp(-i q.R)
+           W[q, (0,b,b), (0,a,a)] += -J        * exp(+i q.R)
+
+       AMENDED (2026-08-16, gate W0 adjudication): the design doc's
+       original draft assigned ``-J*exp(+iqR)`` to the ``(aa,bb))``
+       element; this module's own W0 granule (a) (multi-orbital
+       off-site Exchange, complex J, non-self-inverse q) FAILED that
+       assignment systematically (residuals 0.18-0.33 across every
+       tested orientation and R sign) and PASSED, at the Richardson
+       noise floor, the SWAPPED assignment above. The spec
+       (docs/superpowers/specs/2026-08-15-bond-transverse-design.md,
+       "Flip family", the "AMENDED (2026-08-16, GATE W0 ADJUDICATION)"
+       paragraph) was updated accordingly: the un-conjugated ``J`` is
+       the ``(bb)->(aa)`` scattering amplitude (row=out/col=in, the
+       col leg daggered in ``<A;B^dagger>``), landing on
+       ``W[(0,b,b),(0,a,a)]`` with phase ``exp(+iq.R)``; the Hermitian
+       partner supplies the transposed element. The R=0 (on-site) limit
+       is UNCHANGED (both forms coincide there after Hermitian closure
+       -- precisely why H2's on-site-only readjudication could not by
+       itself catch this, and the off-site granule was required).
+
+    Derivation of step 2's "one lookup, both cells" shortcut: writing
+    the formula generally as "target cell (T, x, y) gets
+    ``s*Re(coeffs[reverse[T]][x, y])``", the representative ``(m, a,
+    b)`` feeds TWO target cells: ``(reverse[m], a, b)`` [value
+    ``s*Re(coeffs[m][a, b])``] and ``(m, b, a)`` [value
+    ``s*Re(coeffs[reverse[m]][b, a])``]. Closure
+    (``coeffs[reverse[m]][x, y] = conj(coeffs[m][y, x])``) gives
+    ``coeffs[reverse[m]][b, a] = conj(coeffs[m][a, b])``, whose real
+    part equals ``Re(coeffs[m][a, b])`` -- so both target cells carry
+    the SAME value, computed from the ONE representative-channel
+    lookup.
+    """
+    delta_r = np.asarray(topo_like.delta_r, dtype=int)
+    reverse = np.asarray(topo_like.reverse, dtype=int)
+    B = delta_r.shape[0]
+    if delta_r.shape != (B, 3):
+        raise ValueError(
+            "w_expected_from_records: delta_r must have shape (B, 3), got "
+            "{}".format(delta_r.shape))
+    if reverse.shape != (B,):
+        raise ValueError(
+            "w_expected_from_records: reverse must have shape (B,), got "
+            "{}".format(reverse.shape))
+    if not np.array_equal(delta_r[0], np.zeros(3, dtype=int)):
+        raise ValueError(
+            "w_expected_from_records: channel 0 must be R=(0,0,0), got "
+            "{}".format(delta_r[0]))
+    if not np.array_equal(reverse[reverse], np.arange(B)):
+        raise ValueError(
+            "w_expected_from_records: reverse must be an involution "
+            "(reverse[reverse[m]] == m for every m)")
+    if int(reverse[0]) != 0:
+        raise ValueError(
+            "w_expected_from_records: reverse[0] must be 0 (channel 0 is "
+            "its own reversal partner)")
+
+    onsite_ham_pm = np.asarray(declarations["onsite_ham_pm"], dtype=complex)
+    norb = onsite_ham_pm.shape[0]
+    if onsite_ham_pm.shape != (norb, norb, norb, norb):
+        raise ValueError(
+            "w_expected_from_records: onsite_ham_pm must have shape "
+            "(norb, norb, norb, norb), got {}".format(onsite_ham_pm.shape))
+    nd = norb * norb
+    ND = B * nd
+
+    q_flat = _w0_q_mesh_flat(q_mesh)         # (nvol, 3)
+    nvol = q_flat.shape[0]
+
+    W = np.zeros((nvol, ND, ND), dtype=complex)
+
+    # Step 1: channel-0 block = the broadcast on-site ham_pm, q-independent.
+    W[:, 0:nd, 0:nd] = onsite_ham_pm.reshape(nd, nd)[None, :, :]
+
+    reps = _reversal_orbit_representatives(delta_r, reverse, norb)
+
+    # Step 2: cross family (CoulombInter, Ising), bond-diagonal,
+    # q-independent.
+    for kind, s_type in (("CoulombInter", -1.0), ("Ising", 1.0)):
+        coeffs_map = declarations.get(kind, {})
+        for (m, a, b) in reps:
+            block = coeffs_map.get(m)
+            if block is None:
+                continue
+            val = s_type * float(np.real(np.asarray(block)[a, b]))
+            if val == 0.0:
+                continue
+            target1 = int(reverse[m])
+            idx1 = target1 * nd + a * norb + b
+            W[:, idx1, idx1] += val
+            idx2 = m * nd + b * norb + a
+            W[:, idx2, idx2] += val
+
+    # Step 3: flip family (Exchange), the two ordered records,
+    # q-dependent ONLY through this local-channel phase (spec:
+    # "W_pm_bond is q-dependent ONLY through the flip-family
+    # local-channel entries"). AMENDED (2026-08-16, gate W0
+    # adjudication -- see the docstring above): the un-conjugated J is
+    # the (bb)->(aa) scattering amplitude with phase exp(+iq.R); the
+    # (aa,bb) element carries conj(J)*exp(-iq.R). The draft's swapped
+    # assignment FAILED W0's off-site multi-orbital Exchange granule
+    # (residuals 0.18-0.33); this assignment PASSES at the Richardson
+    # noise floor.
+    exch_map = declarations.get("Exchange", {})
+    for (m, a, b) in reps:
+        block = exch_map.get(m)
+        if block is None:
+            continue
+        J = complex(np.asarray(block)[a, b])
+        if J == 0.0:
+            continue
+        R = delta_r[m].astype(float)
+        phase = np.exp(1j * (q_flat @ R))            # exp(+i q.R), (nvol,)
+        idx_aa = a * norb + a
+        idx_bb = b * norb + b
+        W[:, idx_aa, idx_bb] += -1.0 * np.conj(J) * np.conj(phase)
+        W[:, idx_bb, idx_aa] += -1.0 * J * phase
+
+    return W
+
+
+class TestW0OrderedRecordOracle(unittest.TestCase):
+    """Structural self-tests for ``w_expected_from_records`` -- pure
+    algebra, no ED involved (the ED-comparison granules are
+    ``TestW0Granules`` below). Per Task 1 Step 1's brief: Hermiticity at
+    every q, the two Exchange records pinned individually with a
+    genuinely complex ``J`` at a non-self-inverse q, and the B=1 on-site
+    reduction."""
+
+    _TOPO_OFFSITE = _TopoLike(
+        delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]]),
+        reverse=np.array([0, 2, 1]))
+
+    def test_hermitian_at_every_q(self):
+        norb = 2
+        J = 0.6 - 0.35j
+        declarations = {
+            "onsite_ham_pm": np.zeros((norb, norb, norb, norb),
+                                       dtype=complex),
+            "Exchange": {1: np.array([[0, J], [0, 0]], dtype=complex)},
+            "CoulombInter": {1: np.array([[0.3 + 0j, 0], [0, 0]],
+                                          dtype=complex)},
+            "Ising": {1: np.array([[0.2 + 0j, 0], [0, 0]], dtype=complex)},
+        }
+        W = w_expected_from_records(self._TOPO_OFFSITE, declarations,
+                                     (5, 1, 1))
+        got_dagger = np.conj(np.transpose(W, (0, 2, 1)))
+        assert_approx_array(got_dagger, W, rel=0, abs=1e-12)
+
+    def test_exchange_entries_pinned_individually(self):
+        """A genuinely complex J at a non-self-inverse q (spec, "Gate
+        W0": "the two Exchange entries SEPARATELY equal f_J*conj(J)*
+        e^{-iqR} and f_J*J*e^{+iqR}" -- the AMENDED (2026-08-16, gate W0
+        adjudication) assignment: the un-conjugated J is the (bb)->(aa)
+        scattering amplitude, landing on W[(0,b,b),(0,a,a)] with phase
+        e^{+iqR}; see `w_expected_from_records`'s own docstring for the
+        full amendment note). L=5 (odd) -> every nonzero q is
+        non-self-inverse; q_idx=1 (q=2*pi/5) is used here."""
+        norb = 2
+        J = 0.6 - 0.35j
+        declarations = {
+            "onsite_ham_pm": np.zeros((norb, norb, norb, norb),
+                                       dtype=complex),
+            "Exchange": {1: np.array([[0, J], [0, 0]], dtype=complex)},
+        }
+        Nx = 5
+        W = w_expected_from_records(self._TOPO_OFFSITE, declarations,
+                                     (Nx, 1, 1))
+        q_flat = _w0_q_mesh_flat((Nx, 1, 1))
+        q_idx = 1
+        q = q_flat[q_idx, 0]
+        phase = np.exp(1j * q * 1.0)          # R = delta_r[1] = (1, 0, 0)
+        idx_aa, idx_bb = 0, 3                 # channel 0, (0,0) and (1,1)
+        assert_approx_array(
+            np.array([W[q_idx, idx_aa, idx_bb]]),
+            np.array([-np.conj(J) * np.conj(phase)]), rel=0, abs=1e-13)
+        assert_approx_array(
+            np.array([W[q_idx, idx_bb, idx_aa]]), np.array([-J * phase]),
+            rel=0, abs=1e-13)
+
+    def test_b1_reduction_equals_broadcast_onsite_ham_pm(self):
+        """Spec step 1: "B=1 reduction: on-site-only declarations give
+        B=1 and W_pm_bond IS the broadcast ham_pm -- gate W1's algebraic
+        basis." ``onsite_ham_pm`` here is H2's own already-ED-
+        readjudicated table (`_h2_ham_pm_expected`, "reuse H2's spied
+        builder" per the task brief) at a real CoulombIntra coupling."""
+        norb = 2
+        topo = _TopoLike(delta_r=np.array([[0, 0, 0]]),
+                          reverse=np.array([0]))
+        onsite = _h2_ham_pm_expected("CoulombIntra", 1.3, norb=norb)
+        declarations = {
+            "onsite_ham_pm": onsite.reshape(norb, norb, norb, norb)}
+        W = w_expected_from_records(topo, declarations, (3, 2, 1))
+        nvol = 6
+        broadcast = np.broadcast_to(
+            onsite[None, :, :], (nvol,) + onsite.shape)
+        assert_approx_array(W, broadcast, rel=0, abs=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# Task 1, Step 2: the three W0 ED granules. New off-site term builders
+# (Exchange, Ising) not covered by any existing module -- canonical_
+# density_terms (ed_oracle_util.py) already covers off-site CoulombInter
+# (plain spin-summed density-density), and is reused directly below.
+# ---------------------------------------------------------------------------
+
+def _terms_exchange_offsite(fx, a, b, R, J):
+    """Off-site Exchange term, generalizing
+    ``tests.test_rpa_vs_ed_oracle._terms_for``'s ON-SITE Exchange
+    operator convention (``c^+_{a,up} c_{b,up} c^+_{b,dn} c_{a,dn}``,
+    already ED-validated on-site to produce ``ham_pm``'s ``-J`` entry --
+    H2's ``test_exchange`` above re-confirms it through this module's
+    own harness) to a nonzero bond displacement ``R``: the ``b``-orbital
+    legs move to site ``j+R``, the ``a``-orbital legs stay at site
+    ``j`` (a bond from site ``j``, orbital ``a``, to site ``j+R``,
+    orbital ``b``). ``coeffs["Exchange"][m][a, b] = J`` fed to
+    ``w_expected_from_records`` uses EXACTLY this same operator
+    convention, so the ``f_J = -1`` coefficient-table sign is consistent
+    between the ED side and the oracle side by construction (never
+    independently re-derived here -- consistency, not an a-priori
+    physical claim, is what gate W0 needs and what
+    ``TestW0TermBuilderHamiltonianPins`` below pins at the Hamiltonian
+    level). The Hermitian partner is the EXACT operator dagger
+    (``conj(J) * (c^+_p c_q c^+_r c_s)^dagger = conj(J) * c^+_s c_r
+    c^+_q c_p``), guaranteeing H is Hermitian by construction rather
+    than by re-deriving a second, independent physical form for the
+    reversed bond."""
+    terms = []
+    for j in range(fx.L):
+        jr = (j + R) % fx.L
+        p = fx.mode(j, a, 0)
+        q = fx.mode(jr, b, 0)
+        r = fx.mode(jr, b, 1)
+        s = fx.mode(j, a, 1)
+        terms.append((p, q, r, s, J))
+        terms.append((s, r, q, p, np.conj(J)))
+    return terms
+
+
+def _terms_ising_offsite(fx, a, b, R, v):
+    """Off-site Ising term, generalizing this module's own
+    ``_terms_ising_hund``'s ON-SITE (R=0) Ising formula (uhfk.py's
+    documented Hamiltonian ``J (n_up - n_down)(n_up - n_down)``) to a
+    nonzero bond displacement ``R``: ``H = v * sum_j (n_{j,a,up} -
+    n_{j,a,dn}) * (n_{j+R,b,up} - n_{j+R,b,dn})``. Manifestly Hermitian
+    for real ``v`` without any mirrored (-R) declaration -- density
+    operators at DIFFERENT sites commute, so
+    ``(n_{j,a,up}-n_{j,a,dn}) @ (n_{j+R,b,up}-n_{j+R,b,dn})`` is
+    Hermitian term by term, and the ``j``-sum over one period already
+    visits every bond exactly once (the same reasoning
+    ``canonical_density_terms``'s off-site branch relies on)."""
+    terms = []
+    for j in range(fx.L):
+        jr = (j + R) % fx.L
+        for su, su_sign in ((0, 1.0), (1, -1.0)):
+            for sv, sv_sign in ((0, 1.0), (1, -1.0)):
+                p = fx.mode(j, a, su)
+                r = fx.mode(jr, b, sv)
+                terms.append((p, p, r, r, v * su_sign * sv_sign))
+    return terms
+
+
+class TestW0TermBuilderHamiltonianPins(unittest.TestCase):
+    """Hamiltonian-level dense pins (the H2 fix-round pattern -- see
+    ``test_ising_hund_term_builders_match_dense_hamiltonian`` above) for
+    the two NEW off-site term builders Task 1 needs: neither
+    ``canonical_density_terms`` (CoulombInter-shaped, unsigned density-
+    density only) nor this module's own on-site ``_terms_ising_hund``
+    (R=0 only) covers off-site Exchange or off-site Ising. Each pin uses
+    a SMALL tractable fixture (dense ``fx.annihilators()`` -- NOT
+    SectorED, since this is a direct-operator-construction check)
+    distinct from (and smaller than) the granule fixtures the term
+    builders are actually exercised on in ``TestW0Granules`` below (case
+    M's dense route is intractable -- see ``ed_oracle_util.SectorED``'s
+    own docstring -- which is exactly why the granules use SectorED and
+    this pin uses a separate, smaller fixture instead)."""
+
+    def test_offsite_exchange_term_builder_matches_dense_hamiltonian(self):
+        fx = ed_oracle_util.EDFixture(
+            L=2, norb=2,
+            t={(0, 0): 0.3, (1, 1): 0.2, (0, 1): 0.1, (1, 0): 0.1},
+            eps=(0.05, -0.02), T=0.5, mu=0.1)
+        C = fx.annihilators()
+        CD = [c.conj().T for c in C]
+        J = 0.4 + 0.3j
+        R, a, b = 1, 0, 1
+
+        def _dense():
+            H = np.zeros((fx.dim, fx.dim), dtype=complex)
+            # np.errstate wrap: this dense (dim, dim) matmul is
+            # warning-noisy under some BLAS backends (spurious
+            # divide-by-zero/overflow/invalid-value warnings on a
+            # near-nilpotent operator product), the same benign-warning
+            # class the earlier Ising/Hund dense pin above already
+            # guards.
+            with np.errstate(all="ignore"):
+                for j in range(fx.L):
+                    jr = (j + R) % fx.L
+                    op = (CD[fx.mode(j, a, 0)] @ C[fx.mode(jr, b, 0)]
+                          @ CD[fx.mode(jr, b, 1)] @ C[fx.mode(j, a, 1)])
+                    H = H + J * op + np.conj(J) * op.conj().T
+            return H
+
+        terms = _terms_exchange_offsite(fx, a, b, R, J)
+        got = ed_oracle_util.h_int_from_terms(fx, terms)
+        assert_approx_array(got, _dense(), rel=0, abs=1e-13)
+
+    def test_offsite_ising_term_builder_matches_dense_hamiltonian(self):
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=1, t={(0, 0): 0.6 + 0.1j}, eps=(0.0,), T=0.4, mu=0.15)
+        C = fx.annihilators()
+        CD = [c.conj().T for c in C]
+        v = 0.37
+        R, a, b = 1, 0, 0
+
+        def _n(j, o, s):
+            m = fx.mode(j, o, s)
+            return CD[m] @ C[m]
+
+        def _dense():
+            H = np.zeros((fx.dim, fx.dim), dtype=complex)
+            with np.errstate(all="ignore"):
+                for j in range(fx.L):
+                    jr = (j + R) % fx.L
+                    sz_j = _n(j, a, 0) - _n(j, a, 1)
+                    sz_jr = _n(jr, b, 0) - _n(jr, b, 1)
+                    H = H + v * (sz_j @ sz_jr)
+            return H
+
+        terms = _terms_ising_offsite(fx, a, b, R, v)
+        got = ed_oracle_util.h_int_from_terms(fx, terms)
+        assert_approx_array(got, _dense(), rel=0, abs=1e-13)
+
+
+def _w0_delta_r_1d(delta_r):
+    """This module's granule fixtures are all 1-D rings (y, z always 0
+    in the canonical ``(B, 3)`` ``delta_r``); ``bond_correlator_
+    transverse``/``transverse_ed_to_solver_map`` (Phase H) both take the
+    scalar ring offset ``R`` (their ``(R,)``/``(R, a, b)`` channel
+    convention has no y/z component -- see
+    ``transverse_ed_to_solver_map``'s own docstring: "y/z components are
+    out of scope"), so this extracts just the x-component as a plain int
+    list."""
+    return [int(r) for r in np.asarray(delta_r)[:, 0]]
+
+
+def _w0_channels_for(delta_r_1d, norb):
+    """The full ``(R, a, b)`` channel list ``transverse_ed_to_solver_map``
+    needs (its docstring: "Must contain, for every delta_r[m] and every
+    physical orbital pair (l1, l2), the SWAPPED entry (delta_r[m], l2,
+    l1)" -- ranging a, b over every combination already contains every
+    swap)."""
+    if norb == 1:
+        return [(R,) for R in delta_r_1d]
+    return [(R, a, b) for R in delta_r_1d for a in range(norb)
+            for b in range(norb)]
+
+
+def _w0_ed_derivative_solver_frame(fx, terms_of_v, delta_r, norb):
+    """Richardson-extrapolated d(bond_correlator_transverse)/dv at
+    v -> 0, full-minus-HF-only (the #151/H2 pattern), frame-mapped into
+    the enlarged (``m*norb**2 + a*norb + b``) slot convention via
+    ``transverse_ed_to_solver_map`` -- the Zeeman-robust map (this
+    module's Phase-H deferred-minor clarification above:
+    ``_frame_map`` is a spin-symmetric, R=0-only shortcut, not usable
+    here since these granule fixtures have off-site channels, B>1).
+    Returns ``(D_v1, D_vhalf)``, the two Richardson estimates
+    ``adjudicate_granule`` needs."""
+    delta_r_1d = _w0_delta_r_1d(delta_r)
+    channels = _w0_channels_for(delta_r_1d, norb)
+    smap = transverse_ed_to_solver_map(channels, delta_r_1d, norb)
+
+    @functools.lru_cache(maxsize=None)
+    def X_of_v(v):
+        terms = terms_of_v(v)
+        full = ed_oracle_util.SectorED(
+            fx, terms=terms).bond_correlator_transverse(channels)
+        hf_h1 = ed_oracle_util.hf_h1_from_terms(fx, terms)
+        hf_only = ed_oracle_util.SectorED(
+            fx, terms=(), h1=hf_h1).bond_correlator_transverse(channels)
+        diff = full - hf_only
+        return diff[:, smap][:, :, smap]
+
+    D_v1 = ed_oracle_util.richardson(X_of_v, CAMPAIGN_V1)
+    D_vhalf = ed_oracle_util.richardson(X_of_v, CAMPAIGN_V1 / 2)
+    return D_v1, D_vhalf
+
+
+def _w0_chi0_solver_frame(fx, delta_r, norb):
+    """The V=0 transverse correlator (exact ED, every declared channel),
+    frame-mapped into solver space via ``transverse_ed_to_solver_map``
+    -- gate W0's ``chi0`` ("chi0 evaluated on the FIXED noninteracting
+    Hamiltonian", spec "Gate W0")."""
+    delta_r_1d = _w0_delta_r_1d(delta_r)
+    channels = _w0_channels_for(delta_r_1d, norb)
+    smap = transverse_ed_to_solver_map(channels, delta_r_1d, norb)
+    se = ed_oracle_util.SectorED(fx)
+    raw = se.bond_correlator_transverse(channels)
+    return raw[:, smap][:, :, smap]
+
+
+def _w0_adjudicate_direction(fx, terms_of_v, topo, declarations, q_mesh,
+                              label):
+    """One granule direction, end to end: measure the ED-side
+    derivative, build gate W0's oracle prediction
+    ``-chi0 . w_expected_from_records(...) . chi0`` (chi0 EXACT ED, no
+    Matsubara truncation anywhere on the predicted side -- so, exactly
+    as H2 documents, ``D_pred`` is passed at BOTH the ``nmat`` and
+    ``2*nmat`` slots of ``adjudicate_granule``, making ``delta_nmat``
+    structurally 0, the honest statement when there is no solver-side
+    approximation to converge), and adjudicate."""
+    delta_r = np.asarray(topo.delta_r)
+    reverse = np.asarray(topo.reverse)
+    norb = np.asarray(declarations["onsite_ham_pm"]).shape[0]
+    D_ed_v1, D_ed_vhalf = _w0_ed_derivative_solver_frame(
+        fx, terms_of_v, delta_r, norb)
+    chi0 = _w0_chi0_solver_frame(fx, delta_r, norb)
+    W_expected = w_expected_from_records(topo, declarations, q_mesh)
+    D_pred = -np.einsum('qij,qjk,qkl->qil', chi0, W_expected, chi0)
+    # zero_mask: the same H2 argument -- D_pred is a MATRIX PRODUCT, so a
+    # single nonzero W_expected cell spreads dense signal across most
+    # (I, J) cells via chi0's own off-diagonal content. The only
+    # structurally-zero case is W_expected being the all-zero matrix.
+    all_zero = bool(np.all(W_expected == 0))
+    zero_mask = np.full(W_expected.shape, all_zero, dtype=bool)
+    return ed_oracle_util.adjudicate_granule(
+        D_ed_v1, D_ed_vhalf, D_pred, D_pred, zero_mask, label)
+
+
+def _w0_direction_set_sv_gate(records, label):
+    """Test-local replica of ``ed_oracle_util.sensitivity_rank``'s SVD
+    gate (``sv_ratio >= SENS_SV_FLOOR``, ``sigma_min >=
+    100*delta_rich``) -- the spec's "Gate W0" campaign-level condition
+    on top of each direction's own ``adjudicate_granule`` verdict
+    ("the direction-set SVD gate ... whose sensitivity matrix passes
+    the #151 SVD gate", spec "Gate W0"). A LOCAL replica, not
+    ``ed_oracle_util.sensitivity_rank`` itself: that function's a-priori
+    ``SENSITIVITY_EXPECTED_ACTIVE``/``SENSITIVITY_EXPECTED_NULL``
+    registry is keyed to the #151 pp/ph campaign's own (fixture,
+    channel) labels, and this task's Files list is
+    ``tests/test_bond_transverse_ed.py`` alone -- ``ed_oracle_util.py``
+    is not touched (nor does it need to be: the math below is the exact
+    same formula, just without that unrelated campaign's label
+    registry)."""
+    names = sorted(records)
+    for name in names:
+        status = records[name]["status"]
+        if status not in ("PASS", "PASS-ZERO"):
+            raise ValueError(
+                "_w0_direction_set_sv_gate[{}]: direction {!r} has status "
+                "{!r} -- only PASS/PASS-ZERO granules feed the SVD gate"
+                .format(label, name, status))
+    active = [n for n in names if records[n]["status"] != "PASS-ZERO"]
+    if not active:
+        raise ValueError(
+            "_w0_direction_set_sv_gate[{}]: every direction is PASS-ZERO "
+            "-- no active column to rank".format(label))
+
+    bearing_arrays = [np.asarray(records[n]["bearing_mask"], dtype=bool)
+                       for n in active]
+    union_mask = bearing_arrays[0].copy()
+    for barr in bearing_arrays[1:]:
+        union_mask |= barr
+    n_rows = int(np.count_nonzero(union_mask))
+
+    columns = []
+    for n in active:
+        pred = np.asarray(records[n]["pred_full"], dtype=float)
+        bearing = np.asarray(records[n]["bearing_mask"], dtype=bool)
+        columns.append(np.where(bearing, pred, 0.0)[union_mask])
+    matrix = np.stack(columns, axis=1)
+    n_cols = matrix.shape[1]
+    delta_rich_max = max(records[n]["delta_rich"] for n in active)
+
+    if n_rows < n_cols:
+        sv = np.zeros(0)
+        sigma_min, sigma_max, sv_ratio = 0.0, float("nan"), 0.0
+    else:
+        sv = np.linalg.svd(matrix, compute_uv=False)
+        sigma_max, sigma_min = float(sv[0]), float(sv[-1])
+        sv_ratio = sigma_min / sigma_max if sigma_max > 0.0 else 0.0
+
+    print("W0 direction-set SVD[{}]: active={} rows={} cols={} "
+          "singular_values={} sv_ratio={:.6e} sigma_min={:.6e} "
+          "100*delta_rich_max={:.6e}".format(
+              label, active, n_rows, n_cols,
+              np.array2string(sv, precision=6), sv_ratio, sigma_min,
+              100.0 * delta_rich_max))
+    return dict(active=active, n_rows=n_rows, n_cols=n_cols,
+                singular_values=sv, sv_ratio=sv_ratio, sigma_min=sigma_min,
+                sigma_max=sigma_max, delta_rich_max=delta_rich_max)
+
+
+class TestW0Granules(unittest.TestCase):
+    """Gate W0's three ED granules (spec: "Gate W0" + the Phase-W plan's
+    Task 1 Step 2): forward comparison of the measured
+    d(bond_correlator_transverse)/dv (full-minus-HF-only, frame-mapped)
+    against ``-chi0 . w_expected_from_records(...) . chi0``, chi0 = the
+    exact V=0 ED correlator -- NO reconstruction, per the spec's binding
+    procedure ("FORWARD comparison, no W reconstruction", spec "Gate
+    W0"). Each granule runs 2 directions sharing one topology/fixture
+    (CoulombInter/Ising: the g1 (R=+-1) and g2 (R=+-2) shells; Exchange:
+    two independent complex phases of the SAME off-site bond), so the
+    #151 direction-set SVD gate has a genuine (non-trivial-rank)
+    sensitivity matrix to rank.
+
+    CRITICAL: a FAIL on any of these is a genuine mismatch between the
+    spec's derived W_{+-} equations and exact diagonalization -- STOP,
+    do not commit, report verbatim (the discrepancy protocol, #151:
+    re-check the encoding against the spec text, the frame map, the
+    term builders via their Hamiltonian-level pins, Richardson
+    conditioning -- never adjust ``w_expected_from_records`` to force a
+    PASS).
+    """
+
+    def test_granule_a_multiorbital_offsite_exchange(self):
+        """(a) L=3, norb=2, off-site Exchange at R=1 with a != b (a=0,
+        b=1) and a genuinely complex J -- the norb=1 Exchange granule
+        would collapse the two ordered elements W[(0,aa),(0,bb)] and
+        W[(0,bb),(0,aa)] onto the same cell and could not adjudicate
+        the record placement (spec, "ED granules"); this one checks
+        BOTH independently via the full-grid adjudicate_granule
+        comparison. Two directions ("real"/"imag": J = v*1 and
+        J = v*1j) on the SAME topology give the SVD gate a rank-2
+        matrix to check.
+
+        ADJUDICATION OUTCOME (gate W0 working exactly as designed): the
+        design doc's ORIGINAL DRAFT flip-family assignment
+        (`W[(0,a,a),(0,b,b)] += -J*e^{+iqR}`,
+        `W[(0,b,b),(0,a,a)] += -conj(J)*e^{-iqR}`) FAILED this granule
+        systematically -- both directions, `status=FAIL`, residuals
+        0.18-0.33 at every nonzero q (q=0 matched exactly, isolating the
+        defect to the phase/orientation of the two records, not their
+        magnitude or the term builder -- see the investigation recorded
+        in `w_expected_from_records`'s docstring and
+        docs/superpowers/specs/2026-08-15-bond-transverse-design.md's
+        "AMENDED (2026-08-16, GATE W0 ADJUDICATION)" paragraph). The
+        finding was adjudicated (coordinator-level) and the spec AMENDED
+        to the swapped assignment now encoded in `w_expected_from_records`
+        (`W[(0,a,a),(0,b,b)] += -conj(J)*e^{-iqR}`,
+        `W[(0,b,b),(0,a,a)] += -J*e^{+iqR}`); with the amendment, this
+        granule PASSES at the Richardson noise floor (both directions;
+        see the module-level test-run output for the exact numbers)."""
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=2,
+            t={(0, 0): 0.5 + 0.2j, (1, 1): 0.35 - 0.15j,
+               (0, 1): 0.1 + 0.05j, (1, 0): 0.1 + 0.05j},
+            eps=(0.05, -0.03), T=0.45, mu=0.1)
+        topo = _TopoLike(delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]]),
+                          reverse=np.array([0, 2, 1]))
+        q_mesh = (3, 1, 1)
+        onsite_ham_pm = np.zeros((2, 2, 2, 2), dtype=complex)
+        a, b, R = 0, 1, 1
+
+        records = {}
+        for name, phase in (("real", 1.0 + 0.0j), ("imag", 0.0 + 1.0j)):
+            def terms_of_v(v, phase=phase):
+                return _terms_exchange_offsite(fx, a, b, R, v * phase)
+
+            block = np.zeros((2, 2), dtype=complex)
+            block[a, b] = phase
+            declarations = {"onsite_ham_pm": onsite_ham_pm,
+                             "Exchange": {1: block}}
+            records[name] = _w0_adjudicate_direction(
+                fx, terms_of_v, topo, declarations, q_mesh,
+                "W0/exchange/{}".format(name))
+
+        for name, rec in records.items():
+            self.assertEqual(
+                rec["status"], "PASS",
+                "W0 granule (a) direction {} status={} (delta_rich={:.3e} "
+                "tol={:.3e} max_signal={:.3e} first_failures={}) -- STOP, "
+                "do not commit; see TestW0Granules docstring's discrepancy "
+                "protocol".format(
+                    name, rec["status"], rec["delta_rich"], rec["tol"],
+                    rec["max_signal"], rec["failures"][:5]))
+
+        gate = _w0_direction_set_sv_gate(records, "W0/exchange")
+        self.assertGreaterEqual(
+            gate["sv_ratio"], ed_oracle_util.SENS_SV_FLOOR,
+            "W0/exchange direction-set SVD gate: sv_ratio={:.3e} below "
+            "floor {:.3e}".format(gate["sv_ratio"],
+                                   ed_oracle_util.SENS_SV_FLOOR))
+        self.assertGreaterEqual(
+            gate["sigma_min"], 100.0 * gate["delta_rich_max"],
+            "W0/exchange direction-set SVD gate: sigma_min={:.3e} below "
+            "100*delta_rich_max={:.3e}".format(
+                gate["sigma_min"], 100.0 * gate["delta_rich_max"]))
+
+    def test_granule_b_complex_offsite_coulomb_inter(self):
+        """(b) L=5, norb=1, off-site CoulombInter, real coupling,
+        SINGLE-DIRECTION declaration (R=+1/+2 only -- see the
+        investigation note below on why NOT also declaring the -R
+        mirror as a separate many-body term is the correct construction
+        here, not a simplification). Two directions, g1 (R=+1) and g2
+        (R=+2), on the SAME topology for the SVD gate. Exact-magnitude
+        adjudication (adjudicate_granule's tol sits at the Richardson
+        noise floor, ~1e-4 here) already distinguishes the coefficient
+        table's -Re(C) from -2*Re(C) or -Re(C)/2 -- any such factor
+        error would show up as a clean, well-outside-tolerance ratio.
+
+        Investigation note (recorded per the discrepancy protocol, since
+        an earlier draft of this granule used a Hermitian-mirrored (R
+        AND -R) declaration and FAILED by a clean, uniform factor of
+        ~2.0 at every grid cell): a density-density operator commutes
+        with itself at every site pair, so X_{+R} := sum_j n_j n_{j+R}
+        and X_{-R} := sum_j n_j n_{j-R} are the SAME operator (reindex
+        j -> j-R). Explicitly declaring BOTH "C at R" and "conj(C) at
+        -R" as SEPARATE many-body terms therefore builds
+        H = C*X_{+R} + conj(C)*X_{+R} = 2*Re(C)*X_{+R} -- twice the
+        physical bond strength a single-channel declaration represents
+        -- which is exactly the measured ~2x discrepancy. The topology's
+        Hermitian CLOSURE (coeffs[reverse[m]] = conj(coeffs[m])) is
+        bookkeeping for `w_expected_from_records`'s representative-based
+        LOOKUP (Task 1 Step 1's derivation: one lookup already feeds
+        BOTH mirrored target cells), not an instruction to additionally
+        re-declare the mirror as a second physical Hamiltonian term on
+        the ED side -- exactly mirroring how off-site Ising already
+        works below (single R declaration, no explicit mirror) and
+        `resolve_interactions` (bond_channels.py) itself: when only ONE
+        direction is declared in a real file, the STORED value at that
+        channel is the RAW declared value (unaveraged), never doubled.
+        A genuinely complex C has ZERO net physical effect here in
+        EITHER construction (Im(C) always cancels once Hermiticity is
+        enforced for a commuting density-density pair), so this granule
+        uses a real coupling and lets adjudicate_granule's exact-value
+        comparison catch a magnitude or sign error directly."""
+        fx = ed_oracle_util.EDFixture(
+            L=5, norb=1, t={(0, 0): 0.7 * np.exp(0.3j)}, eps=(0.0,), T=0.5,
+            mu=0.2)
+        topo = _TopoLike(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0],
+                               [2, 0, 0], [-2, 0, 0]]),
+            reverse=np.array([0, 2, 1, 4, 3]))
+        q_mesh = (5, 1, 1)
+        onsite_ham_pm = np.zeros((1, 1, 1, 1), dtype=complex)
+        C = 0.6 + 0.0j
+
+        records = {}
+        for name, R, m_pos in (("g1", 1, 1), ("g2", 2, 3)):
+            def terms_of_v(v, R=R):
+                return ed_oracle_util.canonical_density_terms(
+                    fx, [(0, 0, R, v * C)])
+
+            declarations = {
+                "onsite_ham_pm": onsite_ham_pm,
+                "CoulombInter": {m_pos: np.array([[C]], dtype=complex)},
+            }
+            records[name] = _w0_adjudicate_direction(
+                fx, terms_of_v, topo, declarations, q_mesh,
+                "W0/coulombinter/{}".format(name))
+
+        for name, rec in records.items():
+            self.assertEqual(
+                rec["status"], "PASS",
+                "W0 granule (b) direction {} status={} (delta_rich={:.3e} "
+                "tol={:.3e} max_signal={:.3e} first_failures={}) -- STOP, "
+                "do not commit; see TestW0Granules docstring's discrepancy "
+                "protocol".format(
+                    name, rec["status"], rec["delta_rich"], rec["tol"],
+                    rec["max_signal"], rec["failures"][:5]))
+
+        gate = _w0_direction_set_sv_gate(records, "W0/coulombinter")
+        self.assertGreaterEqual(gate["sv_ratio"], ed_oracle_util.SENS_SV_FLOOR)
+        self.assertGreaterEqual(gate["sigma_min"],
+                                 100.0 * gate["delta_rich_max"])
+
+    def test_granule_c_offsite_ising(self):
+        """(c) L=5, norb=1, off-site Ising, real coupling. Two
+        directions, g1 (R=+1) and g2 (R=+2), on the SAME topology for
+        the SVD gate (Ising's own Hamiltonian is already Hermitian
+        without a mirrored declaration, unlike CoulombInter's genuinely
+        complex granule above -- see ``_terms_ising_offsite``'s
+        docstring)."""
+        fx = ed_oracle_util.EDFixture(
+            L=5, norb=1, t={(0, 0): 0.55 * np.exp(-0.25j)}, eps=(0.0,),
+            T=0.6, mu=0.15)
+        topo = _TopoLike(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0],
+                               [2, 0, 0], [-2, 0, 0]]),
+            reverse=np.array([0, 2, 1, 4, 3]))
+        q_mesh = (5, 1, 1)
+        onsite_ham_pm = np.zeros((1, 1, 1, 1), dtype=complex)
+
+        records = {}
+        for name, R, m_pos in (("g1", 1, 1), ("g2", 2, 3)):
+            def terms_of_v(v, R=R):
+                return _terms_ising_offsite(fx, 0, 0, R, v)
+
+            declarations = {
+                "onsite_ham_pm": onsite_ham_pm,
+                "Ising": {m_pos: np.array([[1.0 + 0j]], dtype=complex)},
+            }
+            records[name] = _w0_adjudicate_direction(
+                fx, terms_of_v, topo, declarations, q_mesh,
+                "W0/ising/{}".format(name))
+
+        for name, rec in records.items():
+            self.assertEqual(
+                rec["status"], "PASS",
+                "W0 granule (c) direction {} status={} (delta_rich={:.3e} "
+                "tol={:.3e} max_signal={:.3e} first_failures={}) -- STOP, "
+                "do not commit; see TestW0Granules docstring's discrepancy "
+                "protocol".format(
+                    name, rec["status"], rec["delta_rich"], rec["tol"],
+                    rec["max_signal"], rec["failures"][:5]))
+
+        gate = _w0_direction_set_sv_gate(records, "W0/ising")
+        self.assertGreaterEqual(gate["sv_ratio"], ed_oracle_util.SENS_SV_FLOOR)
+        self.assertGreaterEqual(gate["sigma_min"],
+                                 100.0 * gate["delta_rich_max"])
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_ed.py
+++ b/tests/test_bond_transverse_ed.py
@@ -2101,6 +2101,319 @@ class TestTask6ProductionPipelineGranules(unittest.TestCase):
             L=5, norb=1, t={(0, 0): 0.7 * np.exp(0.3j)}, eps=(0.0,), T=0.5,
             mu=0.2)
 
+    def test_granule_coulombinter_g1(self):
+        """CoulombInter g1 (R=+-1), real coupling C=0.6 (single-direction
+        declaration, avoiding the "declare both R and -R separately"
+        doubling trap Gate W0 granule (b) already documents). Measured:
+        status=PASS, delta_rich=1.5e-05, delta_nmat=4.4e-05, tol=4.4e-04,
+        max_signal=8.1e-02."""
+        fx = self._fx5t()
+        Cc = 0.6 + 0.0j
+
+        def topo_of_v(v):
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((1, 0, 0), (0, 0)): v * Cc}},
+                np.eye(3), 1)
+
+        def terms_of_v(v):
+            return ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 1, v * Cc)])
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 1, terms_of_v, topo_of_v, "task6/coulombinter_g1")
+        self.assertEqual(rec["status"], "PASS", rec)
+
+    def test_granule_coulombinter_g2(self):
+        """CoulombInter g2 (R=+-2), real coupling C=0.6. Measured:
+        status=PASS, delta_rich=1.2e-05, delta_nmat=4.4e-05, tol=4.4e-04,
+        max_signal=8.1e-02."""
+        fx = self._fx5t()
+        Cc = 0.6 + 0.0j
+
+        def topo_of_v(v):
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((2, 0, 0), (0, 0)): v * Cc}},
+                np.eye(3), 1)
+
+        def terms_of_v(v):
+            return ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 2, v * Cc)])
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 1, terms_of_v, topo_of_v, "task6/coulombinter_g2")
+        self.assertEqual(rec["status"], "PASS", rec)
+
+    def test_granule_coulombinter_g1_g2_sv_gate(self):
+        """The direction-set SVD gate over {g1, g2} (mirroring Gate W0's
+        own CoulombInter granule (b) pattern exactly: two shells of the
+        SAME type, sharing ONE topology so the sensitivity matrix has a
+        genuine common grid to rank -- see the module docstring's note on
+        why a naive 4-type combined gate is DEGENERATE below). Measured:
+        sv_ratio=0.887, sigma_min=0.204, 100*delta_rich_max=1.5e-03."""
+        fx = self._fx5t()
+        Cc = 0.6 + 0.0j
+
+        def shared_topo(v_g1=0.0, v_g2=0.0):
+            # BOTH shells declared in EVERY call (even when one is exactly
+            # 0) so every richardson sample point (v=0, v1, 2*v1) shares
+            # the IDENTICAL B=5 channel layout -- richardson differences a
+            # B=3 baseline against a B=5 perturbed point otherwise
+            # (broadcasting silently produces nonsense, measured: a
+            # spurious max_signal~117 during this task's own construction).
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((1, 0, 0), (0, 0)): v_g1,
+                                   ((2, 0, 0), (0, 0)): v_g2}},
+                np.eye(3), 1)
+
+        def topo_g1(v):
+            return shared_topo(v_g1=v * Cc)
+
+        def topo_g2(v):
+            return shared_topo(v_g2=v * Cc)
+
+        def terms_g1(v):
+            return ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 1, v * Cc)])
+
+        def terms_g2(v):
+            return ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 2, v * Cc)])
+
+        records = {
+            "coulombinter_g1": _task6_adjudicate_bond_direction(
+                fx, 1, terms_g1, topo_g1, "task6/sv/coulombinter_g1"),
+            "coulombinter_g2": _task6_adjudicate_bond_direction(
+                fx, 1, terms_g2, topo_g2, "task6/sv/coulombinter_g2"),
+        }
+        for name, rec in records.items():
+            self.assertEqual(rec["status"], "PASS", (name, rec))
+
+        gate = _w0_direction_set_sv_gate(records, "task6/coulombinter_g1_g2")
+        self.assertGreaterEqual(gate["sv_ratio"], ed_oracle_util.SENS_SV_FLOOR)
+        self.assertGreaterEqual(gate["sigma_min"],
+                                 100.0 * gate["delta_rich_max"])
+
+    def test_granule_ising_g1(self):
+        """Ising g1 (R=+-1), real coupling V=1.0. Measured: status=PASS,
+        delta_rich=6.1e-07, delta_nmat=7.3e-05, tol=7.3e-04,
+        max_signal=1.4e-01."""
+        fx = self._fx5t()
+        Vi = 1.0 + 0.0j
+
+        def topo_of_v(v):
+            return bond_channels.resolve_transverse_topology(
+                {"Ising": {((1, 0, 0), (0, 0)): v * Vi}}, np.eye(3), 1)
+
+        def terms_of_v(v):
+            return _terms_ising_offsite(fx, 0, 0, 1, v * Vi.real)
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 1, terms_of_v, topo_of_v, "task6/ising_g1")
+        self.assertEqual(rec["status"], "PASS", rec)
+
+    def test_granule_exchange_g1(self):
+        """Exchange g1 (R=+-1), a=b=0 (single-orbital fx5T -- the spec's
+        own note applies: "off-site Exchange with a == b is VALID input, an
+        ordinary non-singleton orbit at R != 0"), complex J=0.5-0.3i.
+        Measured: status=PASS, delta_rich=4.1e-07, delta_nmat=8.4e-05,
+        tol=8.4e-04, max_signal=1.6e-01."""
+        fx = self._fx5t()
+        J0 = 0.5 - 0.3j
+
+        def topo_of_v(v):
+            return bond_channels.resolve_transverse_topology(
+                {"Exchange": {((1, 0, 0), (0, 0)): v * J0}}, np.eye(3), 1)
+
+        def terms_of_v(v):
+            return _terms_exchange_offsite(fx, 0, 0, 1, v * J0)
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 1, terms_of_v, topo_of_v, "task6/exchange_g1")
+        self.assertEqual(rec["status"], "PASS", rec)
+
+    def test_granule_joint_ray_superposition(self):
+        """Joint-ray superposition (spec: "two directions declared
+        together, first-order additivity"): CoulombInter g1 AND Ising g1
+        declared SIMULTANEOUSLY at R=+-1, BOTH scaled by the SAME v --
+        exercises W_pm_bond's per-type accumulation at an OVERLAPPING
+        channel/orbital cell (both types insert at the identical (m,0,0)
+        diagonal target), not just isolated single-type topologies.
+        Measured: status=PASS, delta_rich=2.1e-05, delta_nmat=2.9e-05,
+        tol=2.9e-04, max_signal=5.4e-02. Additivity independently confirmed
+        (not asserted as its own numeric pin here, since adjudicate_granule
+        already IS the additivity check by construction -- the ED side's
+        own terms are the literal sum of the two individual granules'
+        terms): D_pred(joint) vs D_pred(coulombinter_g1)+D_pred(ising_g1)
+        agree to 6.6e-07 against a 5.4e-02 scale (measured separately
+        during this task's construction)."""
+        fx = self._fx5t()
+        Cc = 0.6 + 0.0j
+        Vi = 1.0 + 0.0j
+
+        def topo_of_v(v):
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((1, 0, 0), (0, 0)): v * Cc},
+                 "Ising": {((1, 0, 0), (0, 0)): v * Vi}}, np.eye(3), 1)
+
+        def terms_of_v(v):
+            a = ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 1, v * Cc)])
+            b = _terms_ising_offsite(fx, 0, 0, 1, v * Vi.real)
+            return a + b
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 1, terms_of_v, topo_of_v, "task6/joint_ray")
+        self.assertEqual(rec["status"], "PASS", rec)
+
+    def test_granule_hund_offsite_passzero_control(self):
+        """PASS-ZERO off-site Hund control, co-declared with the active
+        CoulombInter g1 term (spec, Global Constraints: "PASS-ZERO controls
+        ... declared ALONGSIDE one active calibrated CoulombInter term, and
+        the granule isolates the control's derivative -- the #151 pattern:
+        the zero must be measured as a derivative, not as a fallback").
+
+        INVESTIGATION NOTE (recorded per the discrepancy protocol): a first
+        construction co-declared Hund at a FIXED coupling scaled
+        INDEPENDENTLY of the varying active CoulombInter term (i.e. the
+        active term present at its full value even as Hund's coupling -> 0)
+        and FAILED -- ED showed a genuine, non-negligible (~0.09 at
+        C0=0.6, scaling roughly linearly with C0, present even at C0=0.01)
+        first-order-in-Hund-coupling signal. This is NOT a production bug:
+        it is a real beyond-RPA (beyond-ladder) many-body correlation
+        between the two DIFFERENT interaction types, visible to EXACT
+        diagonalization but structurally outside what ANY ladder/RPA
+        resummation (production's OWN approximation class) could ever
+        capture -- Hund's own single-vertex insertion into the bubble is
+        exactly zero (a Sz-conserving, same-spin-only interaction cannot
+        connect the up/down propagators of the transverse loop, the
+        on-site table's own argument, unaffected by which site pair is
+        involved), and confirmed independently at v->0 with NO active term
+        present at all (measured ~3e-6, at the Richardson noise floor).
+        The FIX: declare BOTH the active CoulombInter g1 term AND the Hund
+        control at the SAME v (this method's construction) -- their
+        cross-correlation is then second order in v (proportional to
+        v*v), invisible to a first-derivative comparison, while the
+        topology/Hamiltonian genuinely carries BOTH declarations
+        simultaneously (satisfying anti-vacuity: the ED side's Hamiltonian
+        is never Hund-alone-at-zero-coupling). Verified: the joint-v ED
+        response matches the CoulombInter-g1-alone response to 4.9e-06
+        (against a 0.045-0.08 scale) -- Hund's marginal joint-v
+        contribution is zero, confirming the production topology's
+        structural omission of Hund (it is not one of
+        resolve_transverse_topology's transverse-active types at all) is
+        physically correct. Measured (this test): status=PASS,
+        delta_rich=1.4e-07, delta_nmat=4.4e-05, tol=4.4e-04,
+        max_signal=8.1e-02 (== the CoulombInter-g1-alone signal, since
+        production's topology represents CoulombInter only -- Hund is
+        never read by resolve_transverse_topology's
+        _TRANSVERSE_ACTIVE_TYPES union at all)."""
+        fx = self._fx5t()
+        Cc = 0.6 + 0.0j
+
+        def topo_of_v(v):
+            # Production topology: CoulombInter g1 only -- Hund is
+            # structurally absent regardless of v (bit-identical topology
+            # at every richardson sample point).
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((1, 0, 0), (0, 0)): v * Cc}},
+                np.eye(3), 1)
+
+        def terms_of_v(v):
+            active = ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 1, v * Cc)])
+            control = _terms_hund_offsite(fx, 0, 0, 1, v)
+            return active + control
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 1, terms_of_v, topo_of_v, "task6/hund_control")
+        self.assertEqual(rec["status"], "PASS", rec)
+
+    def test_granule_pairlift_offsite_passzero_control_dense(self):
+        """PASS-ZERO off-site PairLift control, co-declared with an active
+        CoulombInter term at a FIXED (v-independent) coupling -- UNLIKE the
+        Hund control above, a FIXED active coupling here does NOT
+        contaminate the measurement: PairLift's operator changes total Sz
+        by +-2 (Sz-BREAKING, spec/Global Constraints: "PairLift's quartic
+        operator is Sz-BREAKING -- any PairLift ED reference uses the dense
+        route, never SectorED"), so a SINGLE PairLift insertion can never
+        contribute to the Sz-changing-by-1 transverse <S+;S+dagger>
+        response AT ANY PERTURBATIVE ORDER (an exact spin-selection-rule
+        argument, not merely an RPA-order one -- unlike Hund, which
+        conserves Sz and has no such protection). Measured directly:
+        status=PASS-ZERO, ED derivative magnitude ~1.3e-09 (Richardson
+        noise floor), delta_rich=9.2e-09, tol=9.2e-08, production side
+        EXACTLY zero (bit-identical across both Matsubara resolutions,
+        since PairLift is not a transverse-active type at all).
+
+        MESH CONSTRAINT (recorded, per the spec's Fixture bounds): the
+        bond-transverse topology's mesh-injectivity requirement
+        (validate_topology_against_mesh, Task 2) REJECTS any off-site
+        channel R with 2*R == 0 (mod L) -- at L=2 this rejects EVERY
+        off-site shell (R=1 self-collides, R=-1==R=1 mod 2), so a literal
+        2-site ring cannot carry ANY off-site declaration through the
+        production pipeline at all (a genuine, load-bearing consequence of
+        Task 2's own contract, discovered while constructing this granule
+        -- not a defect). This granule therefore uses the smallest ODD ring
+        (L=3, avoiding the even-mesh self-reversal) that both satisfies
+        mesh-injectivity for R=1 AND keeps the DENSE (full, non-sector)
+        diagonalization tractable (dim = 2**(3*1*2) = 64) -- "dense", not
+        "2-site", is the load-bearing part of the spec's constraint (Sz-
+        breaking implies SectorED is unusable; the dense route's cost is
+        what bounds the fixture size, not a literal 2-site requirement)."""
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=1, t={(0, 0): 0.55 * np.exp(-0.15j)}, eps=(0.0,),
+            T=0.55, mu=0.1)
+        C0 = 0.5 + 0.0j
+        channels_full = [(0, 0, 0), (1, 0, 0), (2, 0, 0)]
+
+        def topo_of_v(v):
+            # v is unused: PairLift is not read by resolve_transverse_
+            # topology at all, so the topology (carrying only the FIXED
+            # active CoulombInter) is bit-identical at every v.
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((1, 0, 0), (0, 0)): C0}}, np.eye(3), 1)
+
+        def terms_of_v(v):
+            active = ed_oracle_util.canonical_density_terms(
+                fx, [(0, 0, 1, C0)])
+            control = _terms_pairlift_offsite(fx, 0, 0, 1, v)
+            return active + control
+
+        def dense_derivative(v1):
+            @functools.lru_cache(maxsize=None)
+            def X_of_v(v):
+                terms = terms_of_v(v)
+                full = _dense_bond_correlator_transverse(
+                    fx, channels_full,
+                    hint=ed_oracle_util.h_int_from_terms(fx, terms))
+                hf_h1 = ed_oracle_util.hf_h1_from_terms(fx, terms)
+                hf_only = _dense_bond_correlator_transverse(
+                    fx, channels_full, h1=hf_h1)
+                return full - hf_only
+            return ed_oracle_util.richardson(X_of_v, v1)
+
+        D_ed_v1 = dense_derivative(CAMPAIGN_V1_TASK6)
+        D_ed_vhalf = dense_derivative(CAMPAIGN_V1_TASK6 / 2)
+
+        delta_r = np.asarray(topo_of_v(1.0).delta_r)
+        delta_r_1d = _w0_delta_r_1d(delta_r)
+        # transverse_ed_to_solver_map wants the norb=1 (R,) shorthand
+        # channel list; _w0_channels_for's output is built from the SAME
+        # delta_r_1d in the SAME order as channels_full (full (R,a,b)
+        # triples) above, so the returned smap indices apply unchanged.
+        smap = transverse_ed_to_solver_map(
+            _w0_channels_for(delta_r_1d, 1), delta_r_1d, 1)
+        D_ed_v1 = D_ed_v1[:, smap][:, :, smap]
+        D_ed_vhalf = D_ed_vhalf[:, smap][:, :, smap]
+
+        D_pred_1 = _task6_bond_pipeline_derivative(fx, 0.0, 1, 1024, topo_of_v)
+        D_pred_2 = _task6_bond_pipeline_derivative(fx, 0.0, 1, 2048, topo_of_v)
+        zero_mask = np.ones(D_pred_2.shape, dtype=bool)
+        rec = ed_oracle_util.adjudicate_granule(
+            D_ed_v1, D_ed_vhalf, D_pred_1, D_pred_2, zero_mask,
+            "task6/pairlift_control_dense")
+        self.assertEqual(rec["status"], "PASS-ZERO", rec)
+
     def test_granule_multiorbital_offsite_coulombinter_regression(self):
         """THE REGRESSION PIN (spec, "Cross family", 2026-08-16 amendment;
         this module's own coordinator-adjudicated finding): the orbital
@@ -2167,6 +2480,304 @@ class TestTask6ProductionPipelineGranules(unittest.TestCase):
             "report verbatim.".format(
                 rec["status"], rec["delta_rich"], rec["tol"],
                 rec["max_signal"], rec["failures"][:5]))
+
+    def test_granule_multiorbital_offsite_exchange_both_orientations(self):
+        """The multi-orbital off-site Exchange granule (spec, "ED
+        granules": "a MULTI-ORBITAL OFF-SITE EXCHANGE granule (norb=2,
+        a != b, odd ring L=5 [here L=3, matching the CoulombInter
+        regression pin's own fixture], evaluated at a non-self-inverse q)
+        that checks BOTH ordered local-channel elements ... plus a
+        complex/asymmetric-orientation null-direction variant"). L=3,
+        norb=2 (the SAME fixture as the regression pin above), off-site
+        Exchange at R=+1 with a=0 != b=1. Two directions on the SAME
+        topology: "real" (J=v*1, pins the REAL-coefficient orientation) and
+        "imag" (J=v*1i -- the complex/null-direction variant: a purely
+        imaginary coupling pins the two-record symmetrization
+        independently of the real-coefficient direction, since the two
+        ordered records W[(0,a,a),(0,b,b)]/W[(0,b,b),(0,a,a)] carry
+        conj(J)/J respectively -- a real-only check cannot distinguish
+        conj(J) from J). Since the comparison is over the FULL (nvol, ND,
+        ND) grid (not just the on-site sub-block), BOTH ordered elements
+        are independently exercised by construction -- the norb=1 fx5T
+        Exchange granule above collapses them onto one cell and could not.
+        Measured: status=PASS for both directions (real:
+        delta_rich=8.9e-07, delta_nmat=9.6e-05, tol=9.6e-04,
+        max_signal=1.90e-01; imag: delta_rich=3.1e-06, SAME delta_nmat/
+        tol/max_signal). Direction-set SVD gate: sv_ratio=1.0 (to
+        displayed precision), sigma_min=0.437, 100*delta_rich_max=3.1e-04
+        -- a clean, well-conditioned rank-2 matrix (unlike the
+        cross-family {CoulombInter, Ising} pair at a SHARED channel, which
+        is exactly degenerate -- see the SV-gate note on
+        test_granule_coulombinter_g1_g2_sv_gate)."""
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=2,
+            t={(0, 0): 0.5 + 0.2j, (1, 1): 0.35 - 0.15j,
+               (0, 1): 0.1 + 0.05j, (1, 0): 0.1 + 0.05j},
+            eps=(0.05, -0.03), T=0.45, mu=0.1)
+
+        records = {}
+        for name, phase in (("real", 1.0 + 0.0j), ("imag", 0.0 + 1.0j)):
+            def topo_of_v(v, phase=phase):
+                return bond_channels.resolve_transverse_topology(
+                    {"Exchange": {((1, 0, 0), (0, 1)): v * phase}},
+                    np.eye(3), 2)
+
+            def terms_of_v(v, phase=phase):
+                return _terms_exchange_offsite(fx, 0, 1, 1, v * phase)
+
+            records[name] = _task6_adjudicate_bond_direction(
+                fx, 2, terms_of_v, topo_of_v,
+                "task6/multiorb_exchange/{}".format(name))
+
+        for name, rec in records.items():
+            self.assertEqual(rec["status"], "PASS", (name, rec))
+
+        gate = _w0_direction_set_sv_gate(records, "task6/multiorb_exchange")
+        self.assertGreaterEqual(gate["sv_ratio"], ed_oracle_util.SENS_SV_FLOOR)
+        self.assertGreaterEqual(gate["sigma_min"],
+                                 100.0 * gate["delta_rich_max"])
+
+
+def _sector_s_minus_correlator(se, channels):
+    """The conjugate object to ``SectorED.bond_correlator_transverse``'s
+    ``<S+;S+dagger>``: ``<S-;S-dagger>``, built the SAME way but with the
+    creation/annihilation SPIN ROLES SWAPPED on the bilinear --
+    ``S-_{R,a,b}(q) = sum_j e^{+iqj} c^+_{j+R,a,dn} c_{j,b,up}`` (creation
+    DOWN, annihilation UP, the opposite of S+'s creation UP/annihilation
+    DOWN). Built directly from ``SectorED``'s own
+    ``_build_operator``/``_lehmann_dagger``/``_thermal_avg`` primitives (the
+    SAME primitives ``bond_correlator_transverse`` uses internally, already
+    called directly from this module's own contract tests, e.g.
+    ``TestBondCorrelatorTransverseContract.
+    test_mixed_spin_delta_is_plus_minus_one``) -- this is a spin-flipped
+    SIBLING of that method's construction, not a re-derivation of its
+    machinery, chosen (per the production conjugate-pair granule's brief)
+    over the "conjugate/transpose the S+ correlator" route: building S-
+    DIRECTLY needs no Kubo-relation derivation and is unambiguous by
+    construction (the SAME contraction ``bond_correlator_transverse``
+    itself already uses, applied to a differently-labeled bilinear)."""
+    fx = se.fx
+    seen = set()
+    wrapped = []
+    for chan in channels:
+        R, a, b = se._channel_orbitals(chan)
+        Rw = R % fx.L
+        key = (Rw, a, b)
+        if key in seen:
+            raise ValueError(
+                "_sector_s_minus_correlator: duplicate channel {!r} after "
+                "wrapping R mod L (wrapped key {!r})".format(chan, key))
+        seen.add(key)
+        wrapped.append((Rw, a, b))
+    n_i = len(wrapped)
+    out = np.zeros((fx.L, n_i, n_i), dtype=complex)
+    for qi in range(fx.L):
+        built = []
+        for (R, a, b) in wrapped:
+            mode_terms = [
+                (fx.mode((j + R) % fx.L, a, 1), fx.mode(j, b, 0),
+                 np.exp(2j * np.pi * qi * j / fx.L))
+                for j in range(fx.L)]
+            delta, op = se._build_operator(mode_terms)
+            built.append((delta, op, se._thermal_avg(op, delta)))
+        for i in range(n_i):
+            deltaA, opA, avgA = built[i]
+            for j in range(n_i):
+                deltaB, opB, avgB = built[j]
+                val = se._lehmann_dagger(opA, deltaA, opB, deltaB)
+                val -= fx.beta * avgA * np.conj(avgB)
+                out[qi, i, j] = val
+    return out / fx.L
+
+
+def _hf_h1_from_terms_at(fx, terms, h1_base):
+    """Zeeman-aware generalization of ``ed_oracle_util.hf_h1_from_terms``
+    (which hardcodes the density-matrix reference to ``fx.build_h1()``,
+    i.e. no Zeeman split): the SAME first-order Hartree-Fock self-energy
+    Wick-contraction formula (the ``add()`` closure, reproduced verbatim),
+    but built from an explicit ``h1_base`` (the Zeeman-split one-body
+    Hamiltonian) rather than the bare ``fx.build_h1()`` -- needed because
+    the production conjugate-pair granule's ED reference must subtract the
+    HF-only response evaluated on the SAME (Zeeman-split) free reference
+    the "full" side uses; the module-level helper cannot express this
+    (round-trip verified: at hz=0 this reduces to the SAME numbers
+    ``hf_h1_from_terms`` gives, since ``h1_base == fx.build_h1()`` there)."""
+    ev, W = np.linalg.eigh(h1_base - fx.mu * np.eye(fx.nmode))
+    f = 1.0 / (np.exp(np.clip(fx.beta * ev, -500, 500)) + 1.0)
+    rho = ((W * f) @ W.conj().T).T
+    S = np.zeros((fx.nmode, fx.nmode), dtype=complex)
+
+    def add(p, q, r, s, c_):
+        S[p, q] += c_ * rho[r, s]
+        S[r, s] += c_ * rho[p, q]
+        S[p, s] += c_ * ((1.0 if q == r else 0.0) - rho[r, q])
+        S[r, q] += -c_ * rho[p, s]
+
+    for (p, q, r, s, coeff) in terms:
+        add(p, q, r, s, coeff)
+    return h1_base + 0.5 * (S + S.conj().T)
+
+
+class TestTask6ProductionConjugatePairGranule(unittest.TestCase):
+    """**The production conjugate-pair granule** (the Phase-H ledger's
+    MEDIUM, carried into Task 6, spec "Gate W1 (on-site reduction, exact
+    scope)": "the G_up != G_down conjugate-pair identity is adjudicated by
+    the production conjugate-pair granule (Task 6)"). On a Zeeman-split
+    ON-SITE fixture (G_up != G_down), adjudicates the PRODUCTION plain-
+    ladder ``chiq_pm`` -- via ``RPA._build_transverse_channel`` +
+    ``RPA._solve_rpa``, the pre-existing "ring+ladder" production path, NOT
+    the bond pipeline -- against exact diagonalization, using the
+    ``<S-;S-dagger>`` identification (``_sector_s_minus_correlator`` above):
+    ``_calc_chi0q_transverse``'s own docstring fixes this unambiguously
+    (``chi0_+-[a,c,b,d](r,tau) = -G_up[a,b](r,tau)*G_down[d,c](-r,-tau)``,
+    i.e. fwd=UP/rev=DOWN -- the OPPOSITE role assignment from the bond
+    pipeline's fwd=DOWN/rev=UP, hence the CONJUGATE object per the spec's
+    own "Gate W1" note: "the bond pipeline's chi0 ... computes
+    <S+;S+dagger> ... the plain channel's chi0_+- ... computes
+    <S-;S-dagger>"). A FAIL here is a PRODUCTION finding (per the task
+    brief: "STOP, do not commit, report verbatim").
+
+    Solver-side construction: a bare ``RPA`` stub (the SAME
+    ``object.__new__`` pattern as the bond-pipeline granules above) with
+    ``green0``/``green0_tail`` built directly from the fixture's own
+    Zeeman-split eigenbasis (``_h3_free_two_block_green``, reused verbatim
+    -- ALREADY the correct block convention here too: block 0 = +hz = up,
+    block 1 = -hz = down, matching ``_calc_chi0q_transverse``'s own "block
+    0=up, block1=down" contract), and the on-site vertex ``ham_orig`` built
+    directly via ``ring_spin_table("CoulombIntra")`` (the SAME building
+    block ``RPA._build_ham_pm_onsite`` uses internally) -- independently
+    cross-checked against this module's own H2 table
+    (``_h2_ham_pm_expected("CoulombIntra", U, norb=1)``, already
+    ED-validated) via ``RPA._assemble_transverse_vertex`` before use
+    (exact match, confirming the hand-built ``ham_orig`` tensor is correct
+    before it feeds the granule). ``green0`` is v-independent (RPA's
+    non-interacting Green function never depends on the declared two-body
+    coupling -- see the module docstring above), so the SAME "chi0 fixed,
+    only the vertex varies" first-order construction applies here too.
+
+    INVESTIGATION NOTE (recorded per the discrepancy protocol -- two bugs
+    were found and fixed during this granule's own construction, neither a
+    production defect): (1) an early ED-side term builder reused
+    ``tests.test_rpa_vs_ed_oracle._terms_for``, which hardcodes that
+    module's OWN ``LX=2`` site count internally -- silently building an
+    interaction Hamiltonian covering only 2 of this granule's fixture's 3
+    sites. Fixed by switching to ``ed_oracle_util.canonical_density_terms``
+    (parameterized on ``fx.L`` correctly); the bare bubble (V=0) comparison
+    against production ALREADY matched to ~3e-4 (finite-nmat-only)
+    throughout, which is what made the CoulombIntra-only mismatch (a
+    genuine ~33% gap at hz=0, where the plain path should reduce to a
+    trivially self-consistent value) diagnosable as an ED-side term-count
+    bug rather than a solver-side one. (2) the HF-only reference for the
+    "full-minus-HF-only" subtraction must be built from the ZEEMAN-SPLIT
+    one-body Hamiltonian, not the bare one -- ``ed_oracle_util.
+    hf_h1_from_terms`` hardcodes the bare reference, hence
+    ``_hf_h1_from_terms_at`` above.
+
+    Measured (this test): status=PASS, delta_rich=3.6e-07,
+    delta_nmat=7.2e-05, tol=7.2e-04, max_signal=1.34e-01 -- the plain
+    bubble+vertex pair IS self-consistent as the ``<S-;S-dagger>`` conjugate
+    object at G_up != G_down, for the first time adjudicated against exact
+    diagonalization. This PASS resolves the Phase-H MEDIUM finding."""
+
+    def test_zeeman_split_onsite_conjugate_pair(self):
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=1, t={(0, 0): 0.6 * np.exp(0.2j)}, eps=(0.0,), T=0.5,
+            mu=0.15)
+        hz = 0.3
+        h1_zeeman = _h3_zeeman_h1(fx, hz)
+        norb = 1
+        nd = norb * 2
+        channels = [(0,)]
+
+        def solver_for_nmat(nmat):
+            solver = object.__new__(rpa_mod.RPA)
+            solver.norb = norb
+            solver.ns = 2
+            solver.fft_workers = 1
+            solver.lattice = types.SimpleNamespace(
+                nvol=fx.L, shape=(fx.L, 1, 1))
+            solver.spin_mode = "spin-diag"
+            solver.enable_reduced = False
+            solver.T = fx.T
+            solver.nmat = nmat
+            solver.freq_index = np.arange(nmat)
+            solver._chi0q_external = False
+            green_kw = _h3_free_two_block_green(fx, hz, nmat)
+            solver.green0 = green_kw
+            solver.green0_tail = np.zeros_like(green_kw)
+            return solver
+
+        def ham_orig_of(v):
+            ham_r8 = np.zeros((2, norb) * 4, dtype=complex)
+            for spinvec, w in ring_spin_table("CoulombIntra").items():
+                s1, s2, s3, s4 = spinvec
+                orb = (s4, 0, s3, 0, s1, 0, s2, 0)
+                ham_r8[orb] += v * w
+            return ham_r8.reshape(nd, nd, nd, nd)
+
+        # Cross-check: the hand-built ham_orig assembles to the SAME
+        # ED-validated H2 table entry for CoulombIntra (-U) before use.
+        probe_solver = object.__new__(rpa_mod.RPA)
+        probe_solver.norb = norb
+        probe_solver.ns = 2
+        probe_solver.lattice = types.SimpleNamespace(
+            nvol=1, shape=(1, 1, 1))
+        ham_pm_probe = probe_solver._assemble_transverse_vertex(
+            ham_orig_of(1.3)[None])
+        expected_probe = _h2_ham_pm_expected(
+            "CoulombIntra", 1.3, norb=norb)
+        assert_approx_array(ham_pm_probe, expected_probe, rel=0, abs=1e-13)
+
+        def pred_at_nmat(nmat, v1=CAMPAIGN_V1_TASK6):
+            solver = solver_for_nmat(nmat)
+
+            @functools.lru_cache(maxsize=None)
+            def Y(v):
+                nvol = fx.L
+                ham_orig = np.broadcast_to(
+                    ham_orig_of(v)[None], (nvol, nd, nd, nd, nd)).copy()
+                chi0q_pm, ham_pm = solver._build_transverse_channel(
+                    None, ham_orig)
+                chiq_pm = solver._solve_rpa(chi0q_pm, ham_pm)
+                return chiq_pm[nmat // 2]
+
+            return ed_oracle_util.richardson(Y, v1)
+
+        D_pred_1 = pred_at_nmat(1024)
+        D_pred_2 = pred_at_nmat(2048)
+
+        def terms_of_v(v):
+            return ed_oracle_util.canonical_density_terms(fx, [(0, 0, 0, v)])
+
+        def X_of_v(v):
+            terms = terms_of_v(v)
+            full = _sector_s_minus_correlator(
+                ed_oracle_util.SectorED(fx, terms=terms, h1=h1_zeeman),
+                channels)
+            hf_h1 = _hf_h1_from_terms_at(fx, terms, h1_zeeman)
+            hf_only = _sector_s_minus_correlator(
+                ed_oracle_util.SectorED(fx, terms=(), h1=hf_h1), channels)
+            return full - hf_only
+
+        v1 = CAMPAIGN_V1_TASK6
+        D_ed_v1 = ed_oracle_util.richardson(X_of_v, v1).reshape(
+            fx.L, norb, norb, norb, norb)
+        D_ed_vhalf = ed_oracle_util.richardson(X_of_v, v1 / 2).reshape(
+            fx.L, norb, norb, norb, norb)
+
+        zero_mask = np.zeros(D_pred_2.shape, dtype=bool)
+        rec = ed_oracle_util.adjudicate_granule(
+            D_ed_v1, D_ed_vhalf, D_pred_1, D_pred_2, zero_mask,
+            "task6/production_conjugate_pair")
+        self.assertEqual(
+            rec["status"], "PASS",
+            "PRODUCTION FINDING: the plain-ladder chiq_pm (via "
+            "_build_transverse_channel) is NOT self-consistent as the "
+            "<S-;S-dagger> conjugate object at G_up != G_down -- status={} "
+            "(delta_rich={:.3e} tol={:.3e} max_signal={:.3e} "
+            "first_failures={}). STOP, do not commit, report verbatim.".
+            format(rec["status"], rec["delta_rich"], rec["tol"],
+                   rec["max_signal"], rec["failures"][:5]))
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_ed.py
+++ b/tests/test_bond_transverse_ed.py
@@ -38,13 +38,17 @@ Tests must be run from the repository root.
 
 import collections
 import functools
+import types
 import unittest
 
 import numpy as np
 
 import tests.test_rpa_vs_ed_oracle as oracle
+from hwave.solver import bond_channels
 from hwave.solver import bubble as _hbubble
 from hwave.solver import green as _hgreen
+from hwave.solver import rpa as rpa_mod
+from hwave.solver.vertex_table import ring_spin_table
 from tests import ed_oracle_util
 from tests.approx_util import assert_approx_array
 
@@ -1084,15 +1088,38 @@ def w_expected_from_records(topo_like, declarations, q_mesh):
     2. Cross family (CoulombInter -Re, Ising +Re): for each off-site
        reversal-orbit representative ``(m, a, b)`` with declared
        coefficient ``C = declarations[type][m][a, b]``, BOTH mirrored
-       diagonal TARGET cells get the SAME value ``s_type * Re(C)``::
+       diagonal TARGET cells get the SAME value ``s_type * Re(C)``,
+       DIRECT placement (AMENDED 2026-08-16, Task-6 granule
+       adjudication -- the second measurement-driven correction of this
+       step; see the derivation note below)::
 
-           W[q, (reverse[m],a,b), (reverse[m],a,b)] += s_type * Re(C)
-           W[q, (m,b,a), (m,b,a)]                   += s_type * Re(C)
+           W[q, (m,a,b), (m,a,b)]                   += s_type * Re(C)
+           W[q, (reverse[m],b,a), (reverse[m],b,a)]  += s_type * Re(C)
 
-       (the two target cells are the reversal orbit of the TARGET
-       diagonal index; closure guarantees they carry the identical
-       ``Re(.)`` value, so ONE lookup at the representative channel
-       ``m`` suffices for both -- derivation below.)
+       (the two target cells are the reversal orbit of the
+       REPRESENTATIVE'S OWN channel/orbital pair -- i.e. the target IS
+       the representative and its orbit partner, no additional
+       ``m <-> reverse[m]`` swap; closure guarantees they carry the
+       identical ``Re(.)`` value, so ONE lookup at the representative
+       channel ``m`` suffices for both -- derivation below.)
+
+       AMENDED (2026-08-16, Task-6 granule adjudication): the PREVIOUS
+       form of this step placed the first entry at ``reverse[m]`` (same
+       ``(a,b)``) and the second at ``m`` (swapped ``(b,a)``) -- an
+       ``m <-> reverse[m]`` channel swap relative to the direct
+       placement above. The multi-orbital off-site CoulombInter granule
+       (L=3, norb=2, ``a != b`` -- the ONLY fixture class that can see
+       this swap: at ``a == b`` the two placements coincide, which is
+       exactly why Gate W0's norb=1 cross-family fixtures never caught
+       it) FAILED the swapped placement at O(1) (measured 0.12 against
+       ``tol=5.6e-4``) and PASSES, at 5.6e-5, the DIRECT placement above
+       -- the SAME rule the ALREADY ED-validated longitudinal
+       ``bare_bond_vertices`` Fock-diagonal insertion uses
+       (``bond_channels.py``, ``I = m*nd + l1*norb + l2`` gets
+       ``Re(v_bond[m][l1,l2])`` directly, no channel swap; #151 Finding
+       1). See ``docs/superpowers/specs/2026-08-15-bond-transverse-
+       design.md``, "Cross family", the 2026-08-16 amendment, for the
+       full derivation and the coordinator ruling.
     3. Flip family (Exchange, ``f_J = -1``): for each off-site
        reversal-orbit representative ``(m, a, b)`` with
        ``J = declarations["Exchange"][m][a, b]`` at ``R = delta_r[m]``::
@@ -1118,17 +1145,18 @@ def w_expected_from_records(topo_like, declarations, q_mesh):
        -- precisely why H2's on-site-only readjudication could not by
        itself catch this, and the off-site granule was required).
 
-    Derivation of step 2's "one lookup, both cells" shortcut: writing
-    the formula generally as "target cell (T, x, y) gets
-    ``s*Re(coeffs[reverse[T]][x, y])``", the representative ``(m, a,
-    b)`` feeds TWO target cells: ``(reverse[m], a, b)`` [value
-    ``s*Re(coeffs[m][a, b])``] and ``(m, b, a)`` [value
+    Derivation of step 2's "one lookup, both cells" shortcut (DIRECT
+    placement, 2026-08-16 amendment): writing the formula generally as
+    "target cell (T, x, y) gets ``s*Re(coeffs[T][x, y])``", the
+    representative ``(m, a, b)`` feeds TWO target cells: ``(m, a, b)``
+    [value ``s*Re(coeffs[m][a, b])``] and ``(reverse[m], b, a)`` [value
     ``s*Re(coeffs[reverse[m]][b, a])``]. Closure
     (``coeffs[reverse[m]][x, y] = conj(coeffs[m][y, x])``) gives
     ``coeffs[reverse[m]][b, a] = conj(coeffs[m][a, b])``, whose real
     part equals ``Re(coeffs[m][a, b])`` -- so both target cells carry
     the SAME value, computed from the ONE representative-channel
-    lookup.
+    lookup (the lookup itself is unchanged by the amendment; only WHICH
+    cell each of the two values is written to changed).
     """
     delta_r = np.asarray(topo_like.delta_r, dtype=int)
     reverse = np.asarray(topo_like.reverse, dtype=int)
@@ -1174,7 +1202,10 @@ def w_expected_from_records(topo_like, declarations, q_mesh):
     reps = _reversal_orbit_representatives(delta_r, reverse, norb)
 
     # Step 2: cross family (CoulombInter, Ising), bond-diagonal,
-    # q-independent.
+    # q-independent. DIRECT placement (AMENDED 2026-08-16, Task-6
+    # granule adjudication -- see the docstring above): the target IS
+    # the representative's own (m,a,b), and its orbit partner
+    # (reverse[m],b,a) -- no additional m<->reverse[m] swap.
     for kind, s_type in (("CoulombInter", -1.0), ("Ising", 1.0)):
         coeffs_map = declarations.get(kind, {})
         for (m, a, b) in reps:
@@ -1184,10 +1215,10 @@ def w_expected_from_records(topo_like, declarations, q_mesh):
             val = s_type * float(np.real(np.asarray(block)[a, b]))
             if val == 0.0:
                 continue
-            target1 = int(reverse[m])
-            idx1 = target1 * nd + a * norb + b
+            idx1 = m * nd + a * norb + b
             W[:, idx1, idx1] += val
-            idx2 = m * nd + b * norb + a
+            target2 = int(reverse[m])
+            idx2 = target2 * nd + b * norb + a
             W[:, idx2, idx2] += val
 
     # Step 3: flip family (Exchange), the two ordered records,
@@ -1808,6 +1839,334 @@ class TestW0Granules(unittest.TestCase):
         self.assertGreaterEqual(gate["sv_ratio"], ed_oracle_util.SENS_SV_FLOOR)
         self.assertGreaterEqual(gate["sigma_min"],
                                  100.0 * gate["delta_rich_max"])
+
+
+# =============================================================================
+# Task 6: the ED granule campaign -- the PRODUCTION bond-transverse pipeline
+# (RPA._run_transverse_bond_pipeline, Task 5) and the PRODUCTION plain-ladder
+# channel (RPA._build_transverse_channel, the pre-existing "ring+ladder"
+# path) adjudicated against exact diagonalization to FIRST ORDER in the
+# declared coupling. Every granule below drives one of these two PRODUCTION
+# entry points directly (anti-vacuity, spec "Phase W -- implementation + ED
+# campaign": "a test-invocable internal entry ... executes the bond path
+# UNCONDITIONALLY ... every granule and gate W1 call THIS entry" -- Task 6
+# extends the same discipline to its own campaign).
+#
+# COORDINATOR RULING (2026-08-16): this module's own first pass through this
+# campaign FAILED the multi-orbital off-site CoulombInter granule (below,
+# "the regression pin") at O(1) (0.12 vs tol 5.6e-4) against the DRAFT
+# W_pm_bond cross-family formula (an m<->reverse[m] channel swap). The
+# investigation (recorded in this module's git history and
+# .superpowers/sdd/2026-08-16-bond-transverse-phase-w/task-6-report.md) was
+# adjudicated CONFIRMED: the spec's "Cross family" step 2 is AMENDED (see
+# docs/superpowers/specs/2026-08-15-bond-transverse-design.md) to DIRECT
+# placement (no channel swap, matching the longitudinal bare_bond_vertices
+# rule exactly), and BOTH `bond_channels.W_pm_bond` and this module's own
+# oracle `w_expected_from_records` (Task 1) were corrected identically. The
+# granule below is the PERMANENT regression pin for that fix.
+#
+# Solver-side construction pattern (uniform across every granule): a bare
+# `RPA` stub (`object.__new__` + the minimal attributes
+# `_run_transverse_bond_pipeline`/`_build_ham_pm_onsite`/
+# `_build_transverse_channel` actually read -- the SAME pattern
+# tests/test_bond_transverse_w.py's `TestCollapseRule`/
+# `TestDressingDirectFiniteMatrix` already use for this module's sibling
+# production tests) driven with `green_kw` built DIRECTLY from the ED
+# fixture's own eigenbasis via `_h3_free_two_block_green` (this module's own
+# Phase-H helper, reused verbatim) -- never through Wannier90 file I/O,
+# which would introduce an independent, unverified Transfer-file sign-
+# convention risk this campaign has no need to take on. Since RPA's
+# non-interacting Green function depends ONLY on the one-body Hamiltonian
+# (hopping + any Zeeman field), never on the declared two-body interaction
+# values (`_init_interaction`'s `ham_trans_r`/`ham_extern_r` construction,
+# rpa.py -- CoulombIntra/CoulombInter/etc. feed ONLY the vertex, never
+# green0), `green_kw` is held EXACTLY FIXED while the declared coupling `v`
+# varies -- the same "chi0 fixed, only the vertex varies" construction Gate
+# W0 uses (tests/test_bond_transverse_ed.py, Task 1), just now measured
+# through the REAL production pipeline (real `resolve_transverse_topology`,
+# real `W_pm_bond`, real `transverse_bond_bubble_static`, real `_solve_rpa`)
+# instead of the test-local oracle formula. Richardson-differencing the
+# EXACT (not first-order-truncated) exact solve's output over `v` at
+# `v -> 0` reduces algebraically to the SAME first-order quantity
+# `-chi0.dW/dv.chi0` the oracle predicts (chi0 is v-independent by
+# construction here), so the two constructions are directly comparable.
+#
+# Two Matsubara resolutions (nmat=1024, 2048; RAW/no-tail bubble,
+# `green0_tail=None`, matching the fwd=down/rev=up bond bubble's own
+# O(1/nmat) raw convergence) feed `adjudicate_granule`'s own `delta_nmat`
+# convergence estimate -- these values were tuned (empirically, during this
+# task's own construction) to bring `delta_nmat` comfortably below
+# `max_signal/100` for every granule below while staying fast (a few
+# milliseconds of `_solve_rpa` per direction; the ED side, at these small
+# fixtures -- L<=5, norb<=2 -- is the dominant, still sub-second, cost).
+CAMPAIGN_V1_TASK6 = CAMPAIGN_V1
+
+
+def _task6_bare_bond_solver(fx, norb):
+    """Minimal ``RPA`` stub providing exactly what
+    ``_run_transverse_bond_pipeline``/``_build_ham_pm_onsite`` read:
+    ``norb``, ``ns``, ``fft_workers``, ``lattice.nvol``/``lattice.shape``,
+    and ``ham_info.param_ham``/``param_ham_orig`` (both empty -- every
+    granule below declares its off-site content directly in a
+    ``TransverseTopology`` via ``bond_channels.resolve_transverse_topology``,
+    never through the solver's own interaction files, so
+    ``_build_ham_pm_onsite()`` correctly returns an all-zero on-site vertex
+    for every granule; the on-site reduction itself is gate W1's job, Task
+    5). Mirrors tests/test_bond_transverse_w.py's own bare-solver pattern
+    (``TestCollapseRule``/``TestDressingDirectFiniteMatrix``)."""
+    solver = object.__new__(rpa_mod.RPA)
+    solver.norb = norb
+    solver.ns = 2
+    solver.fft_workers = 1
+    solver.ham_info = types.SimpleNamespace(param_ham={}, param_ham_orig={})
+    solver.lattice = types.SimpleNamespace(nvol=fx.L, shape=(fx.L, 1, 1))
+    return solver
+
+
+def _task6_bond_pipeline_derivative(fx, hz, norb, nmat, topo_of_v,
+                                     v1=CAMPAIGN_V1_TASK6):
+    """Richardson-extrapolated d(chi_pm_bond_static)/dv at v -> 0, from TWO
+    calls of the PRODUCTION ``RPA._run_transverse_bond_pipeline`` (at v1 and
+    2*v1, plus the v=0 baseline) -- ``green_kw`` fixed for the whole sweep
+    (see the module docstring above), only ``topo_of_v(v)`` varies."""
+    solver = _task6_bare_bond_solver(fx, norb)
+    green_kw = _h3_free_two_block_green(fx, hz, nmat)
+    beta = fx.beta
+
+    @functools.lru_cache(maxsize=None)
+    def Y(v):
+        chi_bond, _collapsed = solver._run_transverse_bond_pipeline(
+            green_kw, None, beta, topo_of_v(v))
+        return chi_bond
+
+    return ed_oracle_util.richardson(Y, v1)
+
+
+def _task6_adjudicate_bond_direction(fx, norb, terms_of_v, topo_of_v, label,
+                                      nmat1=1024, nmat2=2048,
+                                      v1=CAMPAIGN_V1_TASK6, zero_mask=None):
+    """One granule direction, end to end, through the REAL production bond
+    pipeline: Richardson-in-v of ``_run_transverse_bond_pipeline`` at TWO
+    Matsubara resolutions (solver-side convergence, ``delta_nmat``) versus
+    Gate W0's own ED-side helper ``_w0_ed_derivative_solver_frame``
+    (full-minus-HF-only, frame-mapped via ``transverse_ed_to_solver_map`` --
+    reused verbatim, unmodified). ``zero_mask=None`` defaults to all-False
+    (a dense/bearing comparison -- the default for every ACTIVE granule
+    below; PASS-ZERO controls pass an explicit all-True mask)."""
+    D_pred_nmat = _task6_bond_pipeline_derivative(
+        fx, 0.0, norb, nmat1, topo_of_v, v1)
+    D_pred_2nmat = _task6_bond_pipeline_derivative(
+        fx, 0.0, norb, nmat2, topo_of_v, v1)
+    topo_probe = topo_of_v(1.0)
+    delta_r = np.asarray(topo_probe.delta_r)
+    D_ed_v1, D_ed_vhalf = _w0_ed_derivative_solver_frame(
+        fx, terms_of_v, delta_r, norb)
+    if zero_mask is None:
+        zero_mask = np.zeros(D_pred_2nmat.shape, dtype=bool)
+    return ed_oracle_util.adjudicate_granule(
+        D_ed_v1, D_ed_vhalf, D_pred_nmat, D_pred_2nmat, zero_mask, label)
+
+
+def _terms_hund_offsite(fx, a, b, R, v):
+    """Off-site Hund term, generalizing this module's own on-site Hund
+    formula (``_terms_ising_hund``, uhfk.py's documented Hamiltonian
+    ``H = -J^Hund (n_up n_up + n_dn n_dn)``, same-spin-only density-density)
+    to a nonzero bond displacement ``R``:
+    ``H = -v * sum_j (n_{j,a,up} n_{j+R,b,up} + n_{j,a,dn} n_{j+R,b,dn})``.
+    Same-spin density operators at DIFFERENT sites commute, so this is
+    manifestly Hermitian for real ``v`` without a mirrored declaration
+    (mirroring ``_terms_ising_offsite``'s own reasoning)."""
+    terms = []
+    for j in range(fx.L):
+        jr = (j + R) % fx.L
+        for s in range(2):
+            p = fx.mode(j, a, s)
+            r = fx.mode(jr, b, s)
+            terms.append((p, p, r, r, -v))
+    return terms
+
+
+def _terms_pairlift_offsite(fx, a, b, R, v):
+    """Off-site PairLift term (Sz-BREAKING: ``A = c^+_{a,up} c_{a,dn}
+    c^+_{b,up} c_{b,dn}`` changes total Sz by +2 -- SectorED's (Nup, Ndown)
+    sector blocking cannot represent it; the DENSE route below is required,
+    per the Global Constraints' "Fixture bounds" -- "PairLift's quartic
+    operator is Sz-BREAKING -- any PairLift ED reference uses the dense
+    route, never SectorED"), generalizing the on-site convention
+    (``oracle._terms_for``'s PairLift branch, ``H = v*A + conj(v)*A^dagger``)
+    to a nonzero bond displacement ``R`` (orbital ``a`` at site ``j``,
+    orbital ``b`` at site ``j+R``). The dagger term mirrors
+    ``_terms_exchange_offsite``'s own ``(s, r, q, p, conj(coeff))``
+    pattern exactly."""
+    terms = []
+    for j in range(fx.L):
+        jr = (j + R) % fx.L
+        p = fx.mode(j, a, 0)
+        q = fx.mode(j, a, 1)
+        r = fx.mode(jr, b, 0)
+        s = fx.mode(jr, b, 1)
+        terms.append((p, q, r, s, v))
+        terms.append((s, r, q, p, np.conj(v)))
+    return terms
+
+
+def _dense_bond_correlator_transverse(fx, channels, hint=None, h1=None):
+    """Dense (non-``SectorED``, no (Nup, Ndown) sector blocking) analogue of
+    ``SectorED.bond_correlator_transverse``, for Sz-BREAKING interactions
+    (PairLift) SectorED cannot represent. Built from the SAME primitives
+    ``ed_oracle_util.chi_connected``/``SectorED.bond_correlator_transverse``
+    both use (``ed_oracle_util._diagonalize``/``_static_kernel`` -- full
+    diagonalization of the ``(fx.dim, fx.dim)`` many-body Hamiltonian, no
+    sector shortcut, tractable only at the small fixtures this granule
+    uses), with the SAME ``<A;B^dagger>`` pointwise-kernel contraction
+    ``SectorED._lehmann_dagger`` applies (``K[m,n]*A[m,n]*conj(B[m,n])``,
+    summed -- NOT a matrix product, unlike ``chi_connected``'s own
+    ``A @ B.T`` formula, which pairs a DIFFERENT (q, -q) leg convention this
+    method does not use: both legs of the transverse bond operator sit at
+    the SAME q here, exactly as ``bond_correlator_transverse`` documents).
+
+    Independently self-validated (recorded, not committed as an automated
+    test -- consistent with this campaign's established discipline for a
+    new correctness-critical primitive): matches
+    ``SectorED.bond_correlator_transverse`` to round-off (~4e-16) both at
+    V=0 and for a Sz-CONSERVING interacting reference (where SectorED is
+    also valid and the two routes can be cross-checked directly) --
+    confirming this dense route's contraction convention BEFORE it is used
+    for the Sz-breaking PairLift case SectorED cannot check itself against.
+
+    Parameters
+    ----------
+    fx : EDFixture
+    channels : list of (R, a, b)
+        Same contract as ``SectorED.bond_correlator_transverse`` (creation
+        leg spin UP at site ``j+R`` orbital ``a``, annihilation leg spin
+        DOWN at site ``j`` orbital ``b``) -- ALWAYS the full triple (this
+        function has no norb=1 shorthand).
+    hint, h1 : see ``ed_oracle_util._diagonalize``.
+
+    Returns
+    -------
+    ndarray, complex128, shape (fx.L, len(channels), len(channels))
+        Connected, SAME 1/fx.L normalization as
+        ``SectorED.bond_correlator_transverse``.
+    """
+    C = fx.annihilators()
+    CD = [c.conj().T for c in C]
+    ev, w, V = ed_oracle_util._diagonalize(fx, hint=hint, h1=h1)
+    K = ed_oracle_util._static_kernel(ev, w, fx.beta)
+    n_i = len(channels)
+    ops_by_q = []
+    for qi in range(fx.L):
+        built = []
+        for (R, a, b) in channels:
+            op = np.zeros((fx.dim, fx.dim), dtype=complex)
+            for j in range(fx.L):
+                ph = np.exp(2j * np.pi * qi * j / fx.L)
+                op += ph * (CD[fx.mode((j + R) % fx.L, a, 0)]
+                            @ C[fx.mode(j, b, 1)])
+            built.append(V.conj().T @ op @ V)
+        ops_by_q.append(built)
+    out = np.zeros((fx.L, n_i, n_i), dtype=complex)
+    for qi in range(fx.L):
+        for i in range(n_i):
+            A = ops_by_q[qi][i]
+            avgA = (w * np.diag(A)).sum()
+            for j in range(n_i):
+                B = ops_by_q[qi][j]
+                avgB = (w * np.diag(B)).sum()
+                val = (K * A * np.conj(B)).sum()
+                val -= fx.beta * avgA * np.conj(avgB)
+                out[qi, i, j] = val
+    return out / fx.L
+
+
+class TestTask6ProductionPipelineGranules(unittest.TestCase):
+    """The ED granule campaign for the PRODUCTION bond-resolved transverse
+    pipeline (``RPA._run_transverse_bond_pipeline``, spec "Phase W -- ED
+    granules"). Every granule below drives that entry directly (anti-
+    vacuity). fx5T (spec, verbatim): L=5 spinful ring, norb=1,
+    t=0.7*e^{0.3i}, beta=2, mu=0.2.
+
+    CRITICAL: a FAIL on any of these is a genuine mismatch between the
+    (now spec-amended) production pipeline and exact diagonalization --
+    STOP, do not commit, report verbatim (the discrepancy protocol, #151:
+    re-derive before patching; never bend production or the oracle to force
+    a PASS). The multi-orbital off-site CoulombInter granule below is a
+    PERMANENT regression pin for the 2026-08-16 cross-family placement fix
+    (see the module docstring above) -- it must stay green untouched."""
+
+    @staticmethod
+    def _fx5t():
+        return ed_oracle_util.EDFixture(
+            L=5, norb=1, t={(0, 0): 0.7 * np.exp(0.3j)}, eps=(0.0,), T=0.5,
+            mu=0.2)
+
+    def test_granule_multiorbital_offsite_coulombinter_regression(self):
+        """THE REGRESSION PIN (spec, "Cross family", 2026-08-16 amendment;
+        this module's own coordinator-adjudicated finding): the orbital
+        indexing guard -- L=3, norb=2, off-site CoulombInter at R=+1 with
+        a=0 != b=1, real coupling C=0.55 (single-direction declaration).
+        The ONLY fixture class that can see the m<->reverse[m] cross-family
+        placement swap (at a == b the two placements coincide -- this is
+        exactly why Gate W0's norb=1 CoulombInter/Ising granules could
+        never have caught it).
+
+        HISTORY: this granule's FIRST run (against the DRAFT placement,
+        target1=reverse[m] with (a,b) unchanged, target2=m with (b,a)
+        swapped) FAILED at O(1): status=FAIL, 220 failing cells,
+        max_signal=0.119 vs tol=5.6e-04 (a ~0.12 absolute residual at the
+        worst cell). Orientation sweep (recorded in
+        .superpowers/sdd/2026-08-16-bond-transverse-phase-w/
+        task-6-report.md): the SAME topology declaration matches ED under
+        the ED-side relabeling (a=1,b=0,R=+1) or (a=0,b=1,R=-1) -- the
+        SAME physical bond, confirming the vertex's target cells were
+        placed at the WRONG channel/orbital pair, not that the ED-side
+        term builder was wrong. Cross-checked against the ALREADY
+        ED-validated longitudinal ``bare_bond_vertices`` Fock-diagonal rule
+        (``I=(m,l1,l2)`` gets ``Re(v_bond[m][l1,l2])`` DIRECTLY, no
+        ``reverse[]`` swap) -- the "direct placement" hypothesis reproduced
+        ED to 5.6e-05 (inside tol), confirming the diagnosis. The
+        coordinator CONFIRMED this finding and AMENDED the spec (see the
+        module docstring above); ``W_pm_bond`` and ``w_expected_from_
+        records`` were corrected identically (DIRECT placement: content at
+        the channel carrying the declared coefficient, matching the
+        longitudinal rule).
+
+        POST-FIX measurement (this test, run against the corrected
+        production code): status=PASS, delta_rich=3.4e-06,
+        delta_nmat=5.6e-05, tol=5.6e-04, max_signal=1.19e-01 -- this
+        granule is now a PERMANENT regression pin (must stay green
+        untouched; a future re-introduction of the channel swap would fail
+        it immediately and visibly, at O(1))."""
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=2,
+            t={(0, 0): 0.5 + 0.2j, (1, 1): 0.35 - 0.15j,
+               (0, 1): 0.1 + 0.05j, (1, 0): 0.1 + 0.05j},
+            eps=(0.05, -0.03), T=0.45, mu=0.1)
+        Cc = 0.55 + 0.0j
+
+        def topo_of_v(v):
+            return bond_channels.resolve_transverse_topology(
+                {"CoulombInter": {((1, 0, 0), (0, 1)): v * Cc}},
+                np.eye(3), 2)
+
+        def terms_of_v(v):
+            return ed_oracle_util.canonical_density_terms(
+                fx, [(0, 1, 1, v * Cc)])
+
+        rec = _task6_adjudicate_bond_direction(
+            fx, 2, terms_of_v, topo_of_v,
+            "task6/multiorb_coulombinter_REGRESSION")
+        self.assertEqual(
+            rec["status"], "PASS",
+            "REGRESSION: the multi-orbital off-site CoulombInter orbital-"
+            "indexing guard FAILED -- status={} (delta_rich={:.3e} "
+            "tol={:.3e} max_signal={:.3e} first_failures={}). This granule "
+            "adjudicated the 2026-08-16 cross-family placement fix; a FAIL "
+            "here means that fix has regressed -- STOP, do not commit, "
+            "report verbatim.".format(
+                rec["status"], rec["delta_rich"], rec["tol"],
+                rec["max_signal"], rec["failures"][:5]))
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -2449,9 +2449,18 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         self.assertLess(peak_old, cap_gb * 1.0e9)
         self.assertGreater(peak_new, cap_gb * 1.0e9)
 
-        solver.transverse_bond_memory_cap_gb = cap_gb
+        # The rejection must fire through the PUBLIC solve() entry of a
+        # fresh, equivalent solver (the first solver above only derived
+        # the boundary): a private-method call here would not catch a
+        # wiring/call-order regression that stops solve() from applying
+        # the updated estimate.
+        solver2, gi2, out2 = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': cap_gb,
+                              'coeff_tail': 1.0},
+            interactions=self.ACTIVE)
         with self.assertRaises(ValueError) as cm:
-            solver._transverse_bond_resource_preflight(topo)
+            solver2.solve(gi2, out2)
         self.assertIn("memory_cap_gb", str(cm.exception))
 
     def test_op_count_warns_not_refuses(self):

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -2311,7 +2311,9 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         Nmat = solver.nmat
         K_solve = 3
         solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
-        bubble_bytes = 16 * Nq * (2 * ND ** 2 + 2 * Nmat * P * (P + 1))
+        prep_bytes = 16 * Nq * (ND ** 2 + 4 * P * (Nmat + 2))
+        pair_bytes = 16 * Nq * (2 * ND ** 2 + 3 * Nmat * P ** 2 + 2 * Nmat * P)
+        bubble_bytes = max(prep_bytes, pair_bytes)
         want_peak = max(bubble_bytes, solve_bytes)
 
         solver.transverse_bond_memory_cap_gb = (want_peak * 0.999) / 1.0e9
@@ -2349,7 +2351,9 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         K_solve = 3
 
         def bubble_bytes_of(nmat):
-            return 16 * Nq * (2 * ND ** 2 + 2 * nmat * P * (P + 1))
+            prep = 16 * Nq * (ND ** 2 + 4 * P * (nmat + 2))
+            pair = 16 * Nq * (2 * ND ** 2 + 3 * nmat * P ** 2 + 2 * nmat * P)
+            return max(prep, pair)
 
         solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
         peak_small = max(bubble_bytes_of(Nmat_small), solve_bytes)
@@ -2759,17 +2763,158 @@ class TestAggregateCoulombTransverseTopology(ApproxTestCase):
                 "provenance key {!r} differs between the aggregate-Coulomb "
                 "and explicit-CoulombInter routes".format(key))
 
-        assert_approx_array(
-            data_agg["chiq_pm_bond_static"],
-            data_exp["chiq_pm_bond_static"], rel=0, abs=1.0e-12,
-            msg="chiq_pm_bond_static must be numerically identical "
-                "between the aggregate-Coulomb and explicit-CoulombInter "
-                "routes")
-        assert_approx_array(
-            data_agg["chiq_pm_static"], data_exp["chiq_pm_static"],
-            rel=0, abs=1.0e-12,
-            msg="chiq_pm_static must be numerically identical between "
-                "the aggregate-Coulomb and explicit-CoulombInter routes")
+        # Bitwise pin (review fix, should_fix): both routes run the exact
+        # same arithmetic on the exact same Hamiltonian content -- the
+        # measured distance is 0.0, not merely "close" -- so pin with
+        # np.array_equal rather than a tolerance, with a max-|diff|
+        # diagnostic on failure.
+        diff_bond = np.max(np.abs(
+            data_agg["chiq_pm_bond_static"] - data_exp["chiq_pm_bond_static"]))
+        self.assertTrue(
+            np.array_equal(data_agg["chiq_pm_bond_static"],
+                            data_exp["chiq_pm_bond_static"]),
+            "chiq_pm_bond_static must be bitwise identical between the "
+            "aggregate-Coulomb and explicit-CoulombInter routes "
+            "(max|diff|={:.3e})".format(diff_bond))
+        diff_pm = np.max(np.abs(
+            data_agg["chiq_pm_static"] - data_exp["chiq_pm_static"]))
+        self.assertTrue(
+            np.array_equal(data_agg["chiq_pm_static"],
+                            data_exp["chiq_pm_static"]),
+            "chiq_pm_static must be bitwise identical between the "
+            "aggregate-Coulomb and explicit-CoulombInter routes "
+            "(max|diff|={:.3e})".format(diff_pm))
+
+
+def _make_mixed_case_agg_coulomb_ising_fixture(*, canonical_case, Lx=4,
+                                                Ly=4, Nmat=8, T=2.0,
+                                                filling=0.5, U=2.0, V=0.4,
+                                                J=0.3):
+    """norb=1, 2D (``Lx x Ly``) fixture declaring an aggregate Coulomb
+    table (on-site ``U`` + off-site ``V`` along x, R=+-1) AND a SEPARATE
+    off-site ``Ising`` declaration along y (J, R=+-1) -- two DIFFERENT
+    transverse-active types contributing to two DISJOINT shells, so the
+    resolved topology is only complete (B=5: origin + 2 x-shells + 2
+    y-shells) if BOTH are actually read.
+
+    ``canonical_case=True`` declares the two interaction file-selection
+    keys as ``'Coulomb'``/``'Ising'``; ``canonical_case=False`` declares
+    them lowercased (``'coulomb'``/``'ising'``) -- ``read_input_k``'s
+    ``CaseInsensitiveDict``-based reader accepts either (see
+    ``QLMSkInput.__init__``: interaction files are dispatched on
+    ``k.lower()`` and stored under the caller's own case, ``self.
+    ham_param[k] = tbl``), so ``self.ham_info.param_ham`` genuinely ends
+    up holding a lowercase ``'ising'`` key in the mixed-case run -- the
+    exact condition the review fix (``CaseInsensitiveDict`` copy instead
+    of a plain ``dict`` copy in ``_validate_transverse_bond_prereqs``'s
+    aggregate-Coulomb merge) has to survive.
+
+    Does NOT call ``solve()``. Returns ``(solver, green_info, out_dir)``.
+    """
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    d = tempfile.mkdtemp(prefix="rpa_mixedcase_agg_")
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n1\n0.0 0.0 0.0\n")
+    _write_w90_entries(
+        os.path.join(d, "transfer.dat"),
+        [(1, 0, 0, 1, 1, 0.5, 0.0), (-1, 0, 0, 1, 1, 0.5, 0.0),
+         (0, 1, 0, 1, 1, 0.5, 0.0), (0, -1, 0, 1, 1, 0.5, 0.0)])
+    _write_w90_entries(
+        os.path.join(d, "extern.dat"), [(0, 0, 0, 1, 1, 1.0, 0.0)])
+    _write_w90_entries(
+        os.path.join(d, "coulomb.dat"),
+        [(0, 0, 0, 1, 1, U, 0.0),
+         (1, 0, 0, 1, 1, V, 0.0), (-1, 0, 0, 1, 1, V, 0.0)])
+    _write_w90_entries(
+        os.path.join(d, "ising.dat"),
+        [(0, 1, 0, 1, 1, J, 0.0), (0, -1, 0, 1, 1, J, 0.0)])
+
+    coulomb_key = "Coulomb" if canonical_case else "coulomb"
+    ising_key = "Ising" if canonical_case else "ising"
+    inter = {"path_to_input": d, "Geometry": "geom.dat",
+              "Transfer": "transfer.dat", "Extern": "extern.dat",
+              coulomb_key: "coulomb.dat", ising_key: "ising.dat"}
+
+    param = {"T": T, "filling": filling, "CellShape": [Lx, Ly, 1],
+             "SubShape": [1, 1, 1], "Nmat": Nmat,
+             "transverse_bond_channels": True}
+    info_mode = {"mode": "RPA", "param": param,
+                 "calc_scheme": "general", "calc_type": "ring+ladder"}
+    info_input = {"path_to_input": d, "interaction": inter}
+
+    read_io = read_input_k.QLMSkInput(info_input)
+    ham_info = read_io.get_param("ham")
+    solver = rpa_mod.RPA(ham_info, {}, info_mode)
+    green_info = read_io.get_param("green")
+    out_dir = tempfile.mkdtemp(prefix="rpa_mixedcase_agg_out_")
+    return solver, green_info, out_dir
+
+
+class TestAggregateCoulombCaseInsensitiveMerge(ApproxTestCase):
+    """Review fix (must_fix): ``_validate_transverse_bond_prereqs``'s
+    aggregate-``Coulomb``-split merge used to copy ``interactions`` into
+    a plain ``dict`` (``interactions = dict(interactions)``), downgrading
+    the ``CaseInsensitiveDict`` semantics ``_make_ham_inter`` relies on
+    for every OTHER key -- a lowercase ``'ising'``/``'exchange'``
+    declaration coexisting with an aggregate ``'Coulomb'`` table would
+    silently vanish from ``resolve_transverse_topology``'s canonical-cased
+    ``interactions.get('Ising', {})`` lookup, even though ``_make_ham_
+    inter`` still built it into the Hamiltonian."""
+
+    def test_lowercase_ising_survives_the_aggregate_coulomb_merge(self):
+        solver_lc, gi_lc, out_lc = _make_mixed_case_agg_coulomb_ising_fixture(
+            canonical_case=False)
+        solver_cc, gi_cc, out_cc = _make_mixed_case_agg_coulomb_ising_fixture(
+            canonical_case=True)
+
+        solver_lc.solve(gi_lc, out_lc)
+        solver_cc.solve(gi_cc, out_cc)
+
+        topo_lc = solver_lc._transverse_bond_topo
+        topo_cc = solver_cc._transverse_bond_topo
+
+        # Both the aggregate-Coulomb-derived x-shells AND the
+        # Ising-derived y-shells must be present: B=5 (origin + 2 x + 2
+        # y), not B=3 (only one of the two types read).
+        self.assertEqual(len(topo_cc.delta_r), 5,
+                          "canonical-case fixture sanity: both types "
+                          "must contribute distinct shells")
+        self.assertEqual(
+            len(topo_lc.delta_r), 5,
+            "lowercase 'ising' must survive the aggregate-Coulomb "
+            "CaseInsensitiveDict merge and still contribute its "
+            "off-site shells to the topology (got B={}, expected 5 -- "
+            "a plain dict() copy would silently drop it, leaving only "
+            "the 3 Coulomb-derived shells)".format(len(topo_lc.delta_r)))
+        self.assertTrue(np.array_equal(topo_lc.delta_r, topo_cc.delta_r))
+        self.assertTrue(np.array_equal(topo_lc.reverse, topo_cc.reverse))
+
+        solver_lc.save_results(
+            {'path_to_output': out_lc, 'chiq': 'chiq.npz'}, gi_lc)
+        solver_cc.save_results(
+            {'path_to_output': out_cc, 'chiq': 'chiq.npz'}, gi_cc)
+        data_lc = np.load(os.path.join(out_lc, 'chiq.npz'),
+                           allow_pickle=True)
+        data_cc = np.load(os.path.join(out_cc, 'chiq.npz'),
+                           allow_pickle=True)
+
+        diff_bond = np.max(np.abs(
+            data_lc["chiq_pm_bond_static"] - data_cc["chiq_pm_bond_static"]))
+        self.assertTrue(
+            np.array_equal(data_lc["chiq_pm_bond_static"],
+                            data_cc["chiq_pm_bond_static"]),
+            "chiq_pm_bond_static must be bitwise identical between the "
+            "lowercase-key and canonical-case-key routes "
+            "(max|diff|={:.3e})".format(diff_bond))
+        diff_pm = np.max(np.abs(
+            data_lc["chiq_pm_static"] - data_cc["chiq_pm_static"]))
+        self.assertTrue(
+            np.array_equal(data_lc["chiq_pm_static"],
+                            data_cc["chiq_pm_static"]),
+            "chiq_pm_static must be bitwise identical between the "
+            "lowercase-key and canonical-case-key routes "
+            "(max|diff|={:.3e})".format(diff_pm))
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -1583,8 +1583,20 @@ class TestCollapseRule(ApproxTestCase):
         # mutation check targets: with norb=2 the two groupings read
         # DIFFERENT cells whenever a != c or b != d, e.g. (a,b,c,d) =
         # (0,1,0,0): correct row=a*norb+c=0, col=b*norb+d=2; the (a,b)/
-        # (c,d) grouping would read row=a*norb+b=1, col=c*norb+d=0.
-        self.assertNotEqual(0 * norb + 0, 0 * norb + 1)
+        # (c,d) grouping would read row=a*norb+b=1, col=c*norb+d=0. A
+        # REAL runtime discrimination check (the previous version here
+        # only compared the two literal integers 0 and 1, which holds
+        # unconditionally and exercises neither the fixture nor the
+        # array -- vacuous): read BOTH candidate cells from the actual
+        # random ``chi_pm_bond`` fixture at q=0 and require them to
+        # differ, so this test would genuinely fail to discriminate a
+        # collapse-index mutation if the fixture ever degenerated (e.g.
+        # an accidentally symmetric array) rather than passing no
+        # matter what.
+        a_ex, b_ex, c_ex, d_ex = 0, 1, 0, 0
+        correct_cell = chi_pm_bond[0, a_ex * norb + c_ex, b_ex * norb + d_ex]
+        wrong_cell = chi_pm_bond[0, a_ex * norb + b_ex, c_ex * norb + d_ex]
+        self.assertNotEqual(correct_cell, wrong_cell)
 
 
 class TestGateW1OnsiteReduction(ApproxTestCase):

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -2637,5 +2637,140 @@ class _CollectingHandler(logging.Handler):
         self.records.append(record)
 
 
+def _write_w90_entries(path, entries):
+    """Write a minimal "wannier90-like" sparse interaction file (H-wave's
+    own convention -- unit degeneracy throughout, see
+    ``wan90.read_w90``'s docstring): ``entries`` is a list of
+    ``(Rx, Ry, Rz, a1, b1, re, im)`` tuples with 1-based orbital indices
+    (matching every other on-disk fixture in this module, e.g.
+    ``_make_max_shells_fixture``)."""
+    n = len(entries)
+    with open(path, "w") as f:
+        f.write("hdr\n1\n{}\n{}\n".format(n, " ".join(["1"] * n)))
+        for (rx, ry, rz, a1, b1, re, im) in entries:
+            f.write(" {} {} {} {} {} {:.12f} {:.12f}\n".format(
+                rx, ry, rz, a1, b1, re, im))
+
+
+def _make_aggregate_coulomb_fixture(*, use_aggregate, Lx=4, Nmat=16, T=2.0,
+                                     filling=0.5, U=2.0, V=0.4):
+    """norb=1 ring+ladder fixture declaring an on-site ``U`` and an
+    off-site ``V`` at ``R = +-1`` along x, either (``use_aggregate=True``)
+    through the single aggregate ``Coulomb`` keyword or
+    (``use_aggregate=False``) through the explicit ``CoulombIntra`` +
+    ``CoulombInter`` pair -- the two on-disk routes
+    ``wan90.split_coulomb`` is supposed to make equivalent everywhere in
+    the pipeline, including the transverse-bond gate's topology (review
+    fix, should_fix: the gate's ``resolve_transverse_topology`` call
+    previously only ever read the explicit keys).
+
+    Does NOT call ``solve()``. Returns ``(solver, green_info, out_dir)``.
+    """
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    d = tempfile.mkdtemp(prefix="rpa_agg_coulomb_")
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n1\n0.0 0.0 0.0\n")
+    _write_w90_entries(
+        os.path.join(d, "transfer.dat"),
+        [(1, 0, 0, 1, 1, 0.5, 0.0), (-1, 0, 0, 1, 1, 0.5, 0.0)])
+    _write_w90_entries(
+        os.path.join(d, "extern.dat"), [(0, 0, 0, 1, 1, 1.0, 0.0)])
+
+    onsite = [(0, 0, 0, 1, 1, U, 0.0)]
+    offsite = [(1, 0, 0, 1, 1, V, 0.0), (-1, 0, 0, 1, 1, V, 0.0)]
+
+    inter = {"path_to_input": d, "Geometry": "geom.dat",
+              "Transfer": "transfer.dat", "Extern": "extern.dat"}
+    if use_aggregate:
+        _write_w90_entries(
+            os.path.join(d, "coulomb.dat"), onsite + offsite)
+        inter["Coulomb"] = "coulomb.dat"
+    else:
+        _write_w90_entries(os.path.join(d, "coulombintra.dat"), onsite)
+        _write_w90_entries(os.path.join(d, "coulombinter.dat"), offsite)
+        inter["CoulombIntra"] = "coulombintra.dat"
+        inter["CoulombInter"] = "coulombinter.dat"
+
+    param = {"T": T, "filling": filling, "CellShape": [Lx, 1, 1],
+             "SubShape": [1, 1, 1], "Nmat": Nmat,
+             "transverse_bond_channels": True}
+    info_mode = {"mode": "RPA", "param": param,
+                 "calc_scheme": "general", "calc_type": "ring+ladder"}
+    info_input = {"path_to_input": d, "interaction": inter}
+
+    read_io = read_input_k.QLMSkInput(info_input)
+    ham_info = read_io.get_param("ham")
+    solver = rpa_mod.RPA(ham_info, {}, info_mode)
+    green_info = read_io.get_param("green")
+    out_dir = tempfile.mkdtemp(prefix="rpa_agg_coulomb_out_")
+    return solver, green_info, out_dir
+
+
+class TestAggregateCoulombTransverseTopology(ApproxTestCase):
+    """Review fix (should_fix): an off-site inter-orbital-category term
+    (``CoulombInter``-type physics: R != 0) declared ONLY through the
+    aggregate ``Coulomb`` keyword must reach
+    ``_validate_transverse_bond_prereqs``'s topology resolution exactly
+    like the same physics declared through the explicit
+    ``CoulombInter`` key -- the Hamiltonian (``_make_ham_inter``) and the
+    on-site vertex (``_build_ham_pm_onsite``) already apply
+    ``wan90.split_coulomb`` themselves; the gate's topology previously
+    did not."""
+
+    def test_aggregate_and_explicit_coulomb_give_identical_topology_and_chiq(
+            self):
+        solver_agg, gi_agg, out_agg = _make_aggregate_coulomb_fixture(
+            use_aggregate=True)
+        solver_exp, gi_exp, out_exp = _make_aggregate_coulomb_fixture(
+            use_aggregate=False)
+
+        solver_agg.solve(gi_agg, out_agg)
+        solver_exp.solve(gi_exp, out_exp)
+
+        topo_agg = solver_agg._transverse_bond_topo
+        topo_exp = solver_exp._transverse_bond_topo
+        self.assertTrue(np.array_equal(topo_agg.delta_r, topo_exp.delta_r))
+        self.assertTrue(np.array_equal(topo_agg.reverse, topo_exp.reverse))
+        self.assertGreater(
+            len(topo_agg.delta_r), 1,
+            "the off-site declaration must have actually produced a "
+            "bond-enlarged (B > 1) topology, or this test would pass "
+            "vacuously")
+
+        solver_agg.save_results(
+            {'path_to_output': out_agg, 'chiq': 'chiq.npz'}, gi_agg)
+        solver_exp.save_results(
+            {'path_to_output': out_exp, 'chiq': 'chiq.npz'}, gi_exp)
+        data_agg = np.load(os.path.join(out_agg, 'chiq.npz'),
+                            allow_pickle=True)
+        data_exp = np.load(os.path.join(out_exp, 'chiq.npz'),
+                            allow_pickle=True)
+
+        # Topology provenance keys: identical B/shell structure regardless
+        # of which of the two on-disk routes declared it.
+        for key in ("transverse_bond_delta_r", "transverse_bond_reverse",
+                    "transverse_bond_index_order",
+                    "transverse_bond_max_shells",
+                    "transverse_spatial_shape", "transverse_q_convention",
+                    "transverse_spin_mode", "transverse_normalization"):
+            self.assertTrue(
+                np.array_equal(data_agg[key], data_exp[key]),
+                "provenance key {!r} differs between the aggregate-Coulomb "
+                "and explicit-CoulombInter routes".format(key))
+
+        assert_approx_array(
+            data_agg["chiq_pm_bond_static"],
+            data_exp["chiq_pm_bond_static"], rel=0, abs=1.0e-12,
+            msg="chiq_pm_bond_static must be numerically identical "
+                "between the aggregate-Coulomb and explicit-CoulombInter "
+                "routes")
+        assert_approx_array(
+            data_agg["chiq_pm_static"], data_exp["chiq_pm_static"],
+            rel=0, abs=1.0e-12,
+            msg="chiq_pm_static must be numerically identical between "
+                "the aggregate-Coulomb and explicit-CoulombInter routes")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -2312,7 +2312,8 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         K_solve = 3
         solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
         prep_bytes = 16 * Nq * (ND ** 2 + 4 * P * (Nmat + 2))
-        pair_bytes = 16 * Nq * (2 * ND ** 2 + 3 * Nmat * P ** 2 + 2 * Nmat * P)
+        pair_bytes = 16 * Nq * (
+            2 * ND ** 2 + 3 * Nmat * P ** 2 + 2 * Nmat * P + 8 * P)
         bubble_bytes = max(prep_bytes, pair_bytes)
         want_peak = max(bubble_bytes, solve_bytes)
 
@@ -2352,7 +2353,8 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
 
         def bubble_bytes_of(nmat):
             prep = 16 * Nq * (ND ** 2 + 4 * P * (nmat + 2))
-            pair = 16 * Nq * (2 * ND ** 2 + 3 * nmat * P ** 2 + 2 * nmat * P)
+            pair = 16 * Nq * (
+                2 * ND ** 2 + 3 * nmat * P ** 2 + 2 * nmat * P + 8 * P)
             return max(prep, pair)
 
         solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
@@ -2385,6 +2387,72 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         self.assertTrue("bubble" in msg.lower() or "GB" in msg,
                          "rejection should name the bubble phase or an "
                          "estimate value: {}".format(msg))
+
+    def test_tail_carrier_boundary_regression(self):
+        """Boundary regression pin (review fix, must_fix): ``pair_bytes``
+        omitted the four tail-correction arrays (``fwd0_p``/``rev0_p``/
+        ``jump_f``/``jump_r_rev``) that ``prepped`` keeps resident for
+        the ENTIRE pair loop even though ``_iter_transverse_bond_channel_
+        pairs`` only ever views single blocks of them -- a genuine
+        ``+8*P`` (``P = norb**2``) omission. On a tail-ENABLED
+        (``coeff_tail != 0``, so these four arrays are actually
+        allocated at runtime -- confirmed below) ``norb=1`` fixture, a
+        cap strictly between the OLD (pre-fix) and NEW pair-loop
+        estimates must REJECT through the public ``solve()`` entry.
+
+        Verified as a genuine regression (not just a formula check) by
+        temporarily removing the ``+ 8 * P`` term from
+        ``_transverse_bond_resource_preflight``'s ``pair_bytes`` and
+        rerunning this test: it failed (the same cap no longer raised),
+        then passed again once restored -- i.e. the cap picked here truly
+        sits between what the OLD and NEW code compute."""
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': 1.0e6,
+                              'coeff_tail': 1.0},
+            interactions=self.ACTIVE)
+        solver.solve(gi, out)
+        topo = solver._transverse_bond_topo
+
+        # Sanity: this fixture genuinely allocates the four retained
+        # tail carriers at runtime (green0_tail's zero-frequency slice
+        # is nonzero) -- not merely "coeff_tail is set but happens to be
+        # a no-op".
+        import numpy as _np
+        gt = solver.green0_tail
+        self.assertIsNotNone(gt)
+        self.assertTrue(bool(_np.any(
+            gt.reshape(gt.shape[0], gt.shape[1], -1)[:, 0] != 0)))
+
+        B = len(topo.delta_r)
+        norb = solver.norb
+        P = norb ** 2
+        ND = B * P
+        Nq = solver.lattice.nvol
+        Nmat = solver.nmat
+        K_solve = 3
+
+        solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
+        prep_bytes = 16 * Nq * (ND ** 2 + 4 * P * (Nmat + 2))
+        pair_bytes_old = 16 * Nq * (      # pre-fix: missing +8*P
+            2 * ND ** 2 + 3 * Nmat * P ** 2 + 2 * Nmat * P)
+        pair_bytes_new = 16 * Nq * (      # this fix
+            2 * ND ** 2 + 3 * Nmat * P ** 2 + 2 * Nmat * P + 8 * P)
+        peak_old = max(prep_bytes, pair_bytes_old, solve_bytes)
+        peak_new = max(prep_bytes, pair_bytes_new, solve_bytes)
+        self.assertGreater(
+            peak_new, peak_old,
+            "fixture must be chosen so the retained tail carriers are "
+            "the binding term, or this test would pass vacuously")
+
+        cap_gb = ((peak_old + peak_new) / 2.0) / 1.0e9
+        self.assertLess(peak_old, cap_gb * 1.0e9)
+        self.assertGreater(peak_new, cap_gb * 1.0e9)
+
+        solver.transverse_bond_memory_cap_gb = cap_gb
+        with self.assertRaises(ValueError) as cm:
+            solver._transverse_bond_resource_preflight(topo)
+        self.assertIn("memory_cap_gb", str(cm.exception))
 
     def test_op_count_warns_not_refuses(self):
         solver, gi, out = _make_bond_gate_fixture(

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -537,6 +537,32 @@ class TestResolveTransverseTopology(ApproxTestCase):
         with self.assertRaises(ValueError):
             resolve_transverse_topology(interactions, np.eye(3), norb=1)
 
+    @unittest.skipIf(np.finfo(np.longdouble).nmant
+                     <= np.finfo(np.float64).nmant,
+                     "longdouble is float64 on this platform")
+    def test_longdouble_fractional_rejected_at_native_precision(self):
+        # A fractional longdouble whose value would round to an INTEGRAL
+        # float64 must still be rejected: the check runs at native
+        # precision, never through a float() narrowing.
+        frac = np.longdouble(1) + np.finfo(np.longdouble).eps
+        self.assertEqual(float(frac), 1.0)  # narrows to integral float64
+        interactions = {"CoulombInter": {((frac, 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    @unittest.skipIf(np.finfo(np.longdouble).nmant
+                     <= np.finfo(np.float64).nmant,
+                     "longdouble is float64 on this platform")
+    def test_longdouble_just_above_2p53_rejected(self):
+        # 2**53 + 1 is exactly representable in extended precision but
+        # narrows onto the accepted 2**53 boundary in float64 -- it must
+        # be rejected at native precision.
+        val = np.longdouble(2) ** 53 + np.longdouble(1)
+        self.assertNotEqual(val, np.longdouble(2) ** 53)
+        interactions = {"CoulombInter": {((val, 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
 
 # =============================================================================
 # iter_reversal_orbits

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -2304,10 +2304,15 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         solver.solve(gi, out)
         topo = solver._transverse_bond_topo
         B = len(topo.delta_r)
-        ND = B * solver.norb ** 2
+        norb = solver.norb
+        P = norb ** 2
+        ND = B * P
         Nq = solver.lattice.nvol
+        Nmat = solver.nmat
         K_solve = 3
-        want_peak = (3 + K_solve) * Nq * ND ** 2 * 16
+        solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
+        bubble_bytes = 16 * Nq * (2 * ND ** 2 + 2 * Nmat * P * (P + 1))
+        want_peak = max(bubble_bytes, solve_bytes)
 
         solver.transverse_bond_memory_cap_gb = (want_peak * 0.999) / 1.0e9
         with self.assertRaises(ValueError):
@@ -2315,6 +2320,67 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
 
         solver.transverse_bond_memory_cap_gb = (want_peak * 1.001) / 1.0e9
         solver._transverse_bond_resource_preflight(topo)  # must not raise
+
+    def test_nmat_sensitivity_bubble_phase_dominates(self):
+        """Regression pin (review fix, must_fix): the OLD preflight
+        formula was solve-phase-only and had NO ``Nmat`` dependence at
+        all, so a cap chosen between two ``Nmat`` values' true peaks would
+        never have distinguished them. With B/Nq/norb held fixed, a small
+        ``Nmat`` must pass a cap that a large ``Nmat`` exceeds, driven
+        through the PUBLIC ``solve()`` entry (not the private preflight
+        method directly), and the rejection must name the bubble-phase
+        contribution."""
+        Nmat_small, Nmat_large = 8, 4096
+
+        # Establish B/norb/Nq once (Nmat-independent: the topology and
+        # lattice do not depend on Nmat) via a throwaway solve with a
+        # cap large enough to pass regardless of Nmat.
+        ref_solver, ref_gi, ref_out = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': 1.0e6},
+            interactions=self.ACTIVE, Nmat=Nmat_small)
+        ref_solver.solve(ref_gi, ref_out)
+        topo = ref_solver._transverse_bond_topo
+        B = len(topo.delta_r)
+        norb = ref_solver.norb
+        P = norb ** 2
+        ND = B * P
+        Nq = ref_solver.lattice.nvol
+        K_solve = 3
+
+        def bubble_bytes_of(nmat):
+            return 16 * Nq * (2 * ND ** 2 + 2 * nmat * P * (P + 1))
+
+        solve_bytes = (3 + K_solve) * Nq * ND ** 2 * 16
+        peak_small = max(bubble_bytes_of(Nmat_small), solve_bytes)
+        peak_large = max(bubble_bytes_of(Nmat_large), solve_bytes)
+        self.assertGreater(
+            peak_large, peak_small,
+            "fixture must be chosen so the large-Nmat bubble estimate "
+            "actually dominates the small-Nmat one")
+
+        cap_gb = ((peak_small + peak_large) / 2.0) / 1.0e9
+        self.assertLess(peak_small, cap_gb * 1.0e9)
+        self.assertGreater(peak_large, cap_gb * 1.0e9)
+
+        solver_small, gi_small, out_small = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': cap_gb},
+            interactions=self.ACTIVE, Nmat=Nmat_small)
+        solver_small.solve(gi_small, out_small)  # must not raise
+        self.assertIn("chiq_pm_bond_static", gi_small)
+
+        solver_large, gi_large, out_large = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': cap_gb},
+            interactions=self.ACTIVE, Nmat=Nmat_large)
+        with self.assertRaises(ValueError) as cm:
+            solver_large.solve(gi_large, out_large)
+        msg = str(cm.exception)
+        self.assertIn("memory_cap_gb", msg)
+        self.assertTrue("bubble" in msg.lower() or "GB" in msg,
+                         "rejection should name the bubble phase or an "
+                         "estimate value: {}".format(msg))
 
     def test_op_count_warns_not_refuses(self):
         solver, gi, out = _make_bond_gate_fixture(

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -11,11 +11,18 @@ against the invariants of
 master transverse topology", "Canonical orbit rule", "Construction domain
 (binding for steps 2-3)").
 
-This module covers TOPOLOGY-ONLY ground: no ``W_pm_bond`` vertex and no
-bond bubble exist yet (Phase W Tasks 3/4) -- the ordered-record vertex
-equations themselves were already numerically validated against ED by gate
-W0 in ``tests/test_bond_transverse_ed.py`` (Task 1) and are NOT
-re-adjudicated here.
+Also (Phase W, Task 3, appended below the Task-2 topology classes):
+production tests for ``hwave.solver.bond_channels.W_pm_bond``, the
+bond-resolved transverse vertex built from ``TransverseTopology`` per the
+spec's "The vertex -- element equations" (steps 1-3, the AMENDED
+2026-08-16 flip-family assignment). The ordered-record equations
+themselves were already numerically validated against ED by Gate W0 in
+``tests/test_bond_transverse_ed.py`` (Task 1) -- NOT re-adjudicated here;
+this module instead CROSS-PINS the production ``W_pm_bond`` against Gate
+W0's test-local oracle reference, ``w_expected_from_records`` (imported
+module-qualified from that module), on the same three W0 ED granule
+fixtures, plus structural (Hermiticity, per-entry, B=1 reduction, q-phase
+convention) and validation tests.
 
 Includes the carried Task-1-review finding's Hamiltonian-level normalization
 pin (``TestHamiltonianLevelNormalizationPin``): the topology's FILE ->
@@ -34,15 +41,19 @@ import unittest
 
 import numpy as np
 
+from hwave import sc as _sc
 from hwave.solver.bond_channels import (
     TransverseTopology,
     resolve_transverse_topology,
+    resolve_interactions,
     iter_reversal_orbits,
     validate_topology_against_mesh,
     transverse_effective_activity,
+    W_pm_bond,
 )
 from tests import ed_oracle_util
-from tests.approx_util import ApproxTestCase
+from tests import test_bond_transverse_ed as _ted
+from tests.approx_util import ApproxTestCase, assert_approx_array
 
 
 def _topo(delta_r, reverse, coeffs=None, norb=1):
@@ -817,6 +828,323 @@ class TestHamiltonianLevelNormalizationPin(ApproxTestCase):
             H_topo = _h_from_topology(fx, topo, "Ising")
             H_raw = _h_from_raw(fx, raw, [((1, 0, 0), 0, 0)])
         self.assertApproxArray(H_topo, H_raw, rel=0, abs=1e-13)
+
+
+# =============================================================================
+# W_pm_bond (Phase W, Task 3)
+# =============================================================================
+#
+# Production tests for hwave.solver.bond_channels.W_pm_bond -- the
+# bond-resolved transverse vertex built from a TransverseTopology per the
+# spec's "The vertex -- element equations" (steps 1-3, the AMENDED
+# 2026-08-16 flip-family assignment). The ordered-record equations
+# themselves were already numerically validated against ED by Gate W0
+# (tests/test_bond_transverse_ed.py, Task 1, imported module-qualified
+# below as ``_ted``); this section cross-pins the PRODUCTION function
+# against that gate's oracle, plus structural/validation coverage.
+
+def _closed_coeffs(B, norb, reverse, declared):
+    """Build a Hermitian-closed ``(B, norb, norb)`` complex coeffs array
+    from a SINGLE-DIRECTION declaration dict ``{m: (norb, norb) array}``
+    -- exactly the shape gate W0's granule fixtures declare (tests/
+    test_bond_transverse_ed.py's ``TestW0Granules``/
+    ``w_expected_from_records``): every declared channel's mirror partner
+    ``reverse[m]`` is synthesized as ``conj(block).T``, the same
+    single-direction synthesis ``resolve_transverse_topology`` performs
+    (``_close_offsite_hermitian``) -- reproduced directly here (not via
+    that resolver) so a ``TransverseTopology`` can be hand-built on the
+    EXACT ``_TopoLike`` channel layout gate W0 used, with ``coeffs``
+    satisfying the closure invariant :class:`TransverseTopology`'s own
+    constructor enforces. Missing channels stay exactly zero (the
+    ``TransverseTopology`` on-site-channel-0-is-zero invariant is
+    automatic here since gate W0's declarations dicts never key on
+    ``m == 0`` -- "coeffs carry OFF-SITE channels only", spec)."""
+    arr = np.zeros((B, norb, norb), dtype=complex)
+    for m, block in declared.items():
+        block = np.asarray(block, dtype=complex)
+        arr[m] = block
+        mr = int(reverse[m])
+        if mr != m:
+            arr[mr] = np.conj(block).T
+    return arr
+
+
+def _topo_from_topolike(topo_like, norb, declarations):
+    """Build a production :class:`TransverseTopology` on the EXACT channel
+    layout of a gate-W0 ``_TopoLike`` (tests/test_bond_transverse_ed.py),
+    with ``coeffs`` closed from the SAME single-direction declarations
+    dict a W0 granule used (``declarations["CoulombInter"]``/``["Ising"]``/
+    ``["Exchange"]``, each ``{m: (norb, norb) array}``; a missing type key
+    is treated as "declares nothing off-site", matching
+    ``w_expected_from_records``'s own ``declarations.get(kind, {})``
+    contract)."""
+    delta_r = np.asarray(topo_like.delta_r)
+    reverse = np.asarray(topo_like.reverse)
+    B = delta_r.shape[0]
+    coeffs = {}
+    for type_name in ("CoulombInter", "Ising", "Exchange"):
+        declared = declarations.get(type_name, {})
+        coeffs[type_name] = _closed_coeffs(B, norb, reverse, declared)
+    return TransverseTopology(delta_r=delta_r, reverse=reverse, coeffs=coeffs)
+
+
+class TestWPmBondCrossPinAgainstW0Oracle(ApproxTestCase):
+    """THE TASK'S CENTERPIECE: production ``W_pm_bond`` matches Gate W0's
+    ED-validated test-local oracle, ``w_expected_from_records`` (tests/
+    test_bond_transverse_ed.py, Task 1, imported module-qualified as
+    ``_ted``), at ``rel=0, abs=1e-13``, on ALL THREE W0 ED granule
+    fixtures -- (a) multi-orbital off-site Exchange (complex J,
+    non-self-inverse q, both orientations), (b) complex off-site
+    CoulombInter (g1/g2 shells), (c) off-site Ising (g1/g2 shells).
+
+    The topology layout (``delta_r``/``reverse``), declared coefficients
+    and ``q_mesh`` are copied VERBATIM from ``_ted.TestW0Granules``'s
+    three granule bodies -- the pure numeric inputs those granules PASSED
+    Gate W0's ED adjudication with (the ED machinery itself -- ``fx``,
+    Richardson, ``SectorED`` -- is NOT re-run here; this class exercises
+    only the production ``W_pm_bond`` vs. the oracle formula, both fed the
+    identical topology/coefficients/mesh)."""
+
+    def _run_cross_pin(self, topo_like, norb, declarations, q_mesh):
+        topo = _topo_from_topolike(topo_like, norb, declarations)
+        onsite = np.asarray(declarations["onsite_ham_pm"], dtype=complex)
+        nvol = q_mesh[0] * q_mesh[1] * q_mesh[2]
+        onsite_nvol = np.broadcast_to(
+            onsite[None, ...], (nvol,) + onsite.shape).copy()
+        got = W_pm_bond(topo, onsite_nvol, spatial_shape=q_mesh)
+        expected = _ted.w_expected_from_records(
+            topo_like, declarations, q_mesh)
+        assert_approx_array(got, expected, rel=0, abs=1e-13)
+
+    def test_granule_a_multiorbital_offsite_exchange(self):
+        # Verbatim data from
+        # _ted.TestW0Granules.test_granule_a_multiorbital_offsite_exchange:
+        # L=3, norb=2, off-site Exchange at R=1 with a=0 != b=1 and a
+        # genuinely complex J; two directions ("real"/"imag" phase).
+        norb = 2
+        topo_like = _ted._TopoLike(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]]),
+            reverse=np.array([0, 2, 1]))
+        q_mesh = (3, 1, 1)
+        onsite_ham_pm = np.zeros((2, 2, 2, 2), dtype=complex)
+        a, b = 0, 1
+        for phase in (1.0 + 0.0j, 0.0 + 1.0j):
+            block = np.zeros((2, 2), dtype=complex)
+            block[a, b] = phase
+            declarations = {"onsite_ham_pm": onsite_ham_pm,
+                             "Exchange": {1: block}}
+            self._run_cross_pin(topo_like, norb, declarations, q_mesh)
+
+    def test_granule_b_complex_offsite_coulomb_inter(self):
+        # Verbatim data from
+        # _ted.TestW0Granules.test_granule_b_complex_offsite_coulomb_inter:
+        # L=5, norb=1, off-site CoulombInter, g1 (R=+1) and g2 (R=+2).
+        norb = 1
+        topo_like = _ted._TopoLike(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0],
+                               [2, 0, 0], [-2, 0, 0]]),
+            reverse=np.array([0, 2, 1, 4, 3]))
+        q_mesh = (5, 1, 1)
+        onsite_ham_pm = np.zeros((1, 1, 1, 1), dtype=complex)
+        C = 0.6 + 0.0j
+        for m_pos in (1, 3):
+            declarations = {
+                "onsite_ham_pm": onsite_ham_pm,
+                "CoulombInter": {m_pos: np.array([[C]], dtype=complex)},
+            }
+            self._run_cross_pin(topo_like, norb, declarations, q_mesh)
+
+    def test_granule_c_offsite_ising(self):
+        # Verbatim data from _ted.TestW0Granules.test_granule_c_offsite_ising:
+        # L=5, norb=1, off-site Ising, g1 (R=+1) and g2 (R=+2).
+        norb = 1
+        topo_like = _ted._TopoLike(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0],
+                               [2, 0, 0], [-2, 0, 0]]),
+            reverse=np.array([0, 2, 1, 4, 3]))
+        q_mesh = (5, 1, 1)
+        onsite_ham_pm = np.zeros((1, 1, 1, 1), dtype=complex)
+        for m_pos in (1, 3):
+            declarations = {
+                "onsite_ham_pm": onsite_ham_pm,
+                "Ising": {m_pos: np.array([[1.0 + 0j]], dtype=complex)},
+            }
+            self._run_cross_pin(topo_like, norb, declarations, q_mesh)
+
+
+class TestWPmBondStructural(ApproxTestCase):
+    """Structural pins independent of the ED cross-pin above: Hermiticity
+    at every q (including a Hermitian-closed COMPLEX CoulombInter +-i*eps
+    pair -- the W0 blind spot the Task-1 review flagged: a bug that stored
+    the raw complex coefficient instead of ``Re(.)`` on the bond-diagonal
+    would put a genuinely complex value on a MATRIX DIAGONAL, breaking
+    Hermiticity), the two Exchange records pinned individually at a
+    non-self-inverse q with a genuinely complex J, and the B=1 on-site
+    reduction (spec step 1's algebraic basis for gate W1)."""
+
+    def _offsite_topo(self, norb, coeffs):
+        delta_r = np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]])
+        reverse = np.array([0, 2, 1])
+        full = {}
+        for type_name in ("CoulombInter", "Ising", "Exchange"):
+            full[type_name] = coeffs.get(
+                type_name, np.zeros((3, norb, norb), dtype=complex))
+        return TransverseTopology(
+            delta_r=delta_r, reverse=reverse, coeffs=full)
+
+    def test_hermitian_at_every_q_including_complex_coulomb_inter(self):
+        norb = 1
+        V, eps = 0.4, 1.0e-3
+        ci = np.zeros((3, 1, 1), dtype=complex)
+        ci[1, 0, 0] = V + 1j * eps    # channel m=1, R=(1,0,0), declared
+        ci[2, 0, 0] = V - 1j * eps    # channel m=2 = reverse[1], R=(-1,0,0)
+        ex = np.zeros((3, 1, 1), dtype=complex)
+        ex[1, 0, 0] = 0.5 - 0.2j
+        ex[2, 0, 0] = np.conj(ex[1, 0, 0])
+        ising = np.zeros((3, 1, 1), dtype=complex)
+        ising[1, 0, 0] = 0.2
+        ising[2, 0, 0] = 0.2
+        topo = self._offsite_topo(
+            norb, {"CoulombInter": ci, "Exchange": ex, "Ising": ising})
+        Nx = 5
+        onsite = np.zeros((Nx, 1, 1, 1, 1), dtype=complex)
+        W = W_pm_bond(topo, onsite, spatial_shape=(Nx, 1, 1))
+        got_dagger = np.conj(np.transpose(W, (0, 2, 1)))
+        self.assertApproxArray(got_dagger, W, rel=0, abs=1e-12)
+
+    def test_exchange_entries_pinned_individually(self):
+        norb = 2
+        J = 0.6 - 0.35j
+        ex = np.zeros((3, 2, 2), dtype=complex)
+        ex[1, 0, 1] = J
+        ex[2, 1, 0] = np.conj(J)
+        topo = self._offsite_topo(norb, {"Exchange": ex})
+        Nx = 5
+        onsite = np.zeros((Nx, 2, 2, 2, 2), dtype=complex)
+        W = W_pm_bond(topo, onsite, spatial_shape=(Nx, 1, 1))
+        kx = 2.0 * np.pi * np.arange(Nx) / Nx
+        q_idx = 1                      # q = 2*pi/5, non-self-inverse (L odd)
+        q = kx[q_idx]
+        phase = np.exp(1j * q * 1.0)   # R = delta_r[1] = (1, 0, 0)
+        idx_aa, idx_bb = 0, 3           # channel 0, (0,0) and (1,1)
+        self.assertApproxArray(
+            np.array([W[q_idx, idx_aa, idx_bb]]),
+            np.array([-np.conj(J) * np.conj(phase)]), rel=0, abs=1e-13)
+        self.assertApproxArray(
+            np.array([W[q_idx, idx_bb, idx_aa]]),
+            np.array([-J * phase]), rel=0, abs=1e-13)
+
+    def test_b1_reduction_equals_broadcast_onsite_ham_pm(self):
+        norb = 2
+        nd = norb * norb
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0]]), reverse=np.array([0]),
+            coeffs={"CoulombInter": np.zeros((1, norb, norb), dtype=complex)})
+        onsite_2d = _ted._h2_ham_pm_expected("CoulombIntra", 1.3, norb=norb)
+        onsite_4d = onsite_2d.reshape(norb, norb, norb, norb)
+        nvol = 6
+        onsite_nvol = np.broadcast_to(
+            onsite_4d[None, :, :, :, :], (nvol,) + onsite_4d.shape).copy()
+        W = W_pm_bond(topo, onsite_nvol, spatial_shape=(3, 2, 1))
+        expected = np.broadcast_to(onsite_2d[None, :, :], (nvol, nd, nd))
+        self.assertApproxArray(W, expected, rel=0, abs=1e-15)
+
+
+class TestWPmBondQPhaseCrossPin(ApproxTestCase):
+    """Pins ``W_pm_bond``'s q-phase convention against
+    ``sc._build_bond_m0_blocks``'s own phase composition (spec: "the SAME
+    convention sc._build_bond_m0_blocks' phase uses") on a SHARED fixture:
+    a single-direction off-site declaration at R=(1,0,0), (a,b)=(0,1),
+    norb=2. Fed to ``_build_bond_m0_blocks`` as a real CoulombInter
+    coefficient (whose Hartree ``(00,11)`` matrix element is driven by
+    that builder's OWN ``exp(-i q.R)`` phase, extracted directly from its
+    real numeric output -- not assumed) and to ``W_pm_bond`` as an
+    Exchange coefficient at the SAME R (whose flip-family record carries
+    ``exp(-i q.R)`` on the ``(0,0,0),(0,1,1)`` element, spec step 3). Both
+    consumers see the IDENTICAL ``kx_array``/``ky_array``/``kz_array``
+    mesh (``np.linspace(0, 2*pi, N, endpoint=False)`` -- the same
+    construction ``hwave/sc.py``'s own q-grid setup uses ahead of calling
+    ``_build_bond_m0_blocks``, e.g. around its ``calc_eliashberg`` driver),
+    so this comparison genuinely exercises the SAME q.R value on both
+    sides via a REAL call to the shared builder, not two independently
+    assumed formulas."""
+
+    def test_qr_matches_build_bond_m0_blocks_phase(self):
+        norb = 2
+        Nx, Ny, Nz = 5, 1, 1
+        kx_array = np.linspace(0.0, 2.0 * np.pi, Nx, endpoint=False)
+        ky_array = np.linspace(0.0, 2.0 * np.pi, Ny, endpoint=False)
+        kz_array = np.linspace(0.0, 2.0 * np.pi, Nz, endpoint=False)
+
+        C = 0.6 + 0.0j
+        bond_set = resolve_interactions(
+            {((1, 0, 0), (0, 1)): C}, np.eye(3), norb)
+        _S0, C0 = _sc._build_bond_m0_blocks(
+            bond_set, {}, {}, norb, kx_array, ky_array, kz_array)
+        # Hartree (aa,bb) = (00,11) slot: C0[..., 0, 3] == 2*V_q[0, 1], and
+        # V_q[0, 1] is driven ONLY by the declared channel m=R=(1,0,0)'s
+        # own [0, 1] matrix entry -- the synthesized reverse partner only
+        # populates [1, 0], never [0, 1] -- so C0[q_idx,0,0,0,3] ==
+        # 2*C*exp(-i q.R) exactly (C real).
+        q_idx = 1
+        phase_from_builder = C0[q_idx, 0, 0, 0, 3] / (2.0 * C)
+
+        J = 0.35 - 0.2j
+        reverse = np.array([0, 2, 1])
+        block = np.zeros((norb, norb), dtype=complex)
+        block[0, 1] = J
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]]),
+            reverse=reverse,
+            coeffs={"Exchange": _closed_coeffs(3, norb, reverse, {1: block})})
+        onsite = np.zeros((Nx * Ny * Nz, norb, norb, norb, norb),
+                           dtype=complex)
+        W = W_pm_bond(topo, onsite, spatial_shape=(Nx, Ny, Nz))
+        idx_00, idx_11 = 0, 3
+        got = W[q_idx, idx_00, idx_11]
+        expected = -np.conj(J) * phase_from_builder
+        self.assertApprox(got, expected, rel=0, abs=1e-12)
+
+
+class TestWPmBondValidation(ApproxTestCase):
+    """Entry-point validation: mesh-injectivity is enforced (via
+    ``validate_topology_against_mesh``) and a malformed ``ham_pm_onsite``
+    shape is rejected -- both ``ValueError``, never a silent
+    misinterpretation."""
+
+    def test_mesh_collision_raises(self):
+        # +3 == -3 mod 6 -- the canonical even-mesh self-reversal alias.
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0], [3, 0, 0], [-3, 0, 0]]),
+            reverse=np.array([0, 2, 1]),
+            coeffs={"CoulombInter": np.zeros((3, 1, 1), dtype=complex)})
+        onsite = np.zeros((6 * 4 * 4, 1, 1, 1, 1), dtype=complex)
+        with self.assertRaises(ValueError):
+            W_pm_bond(topo, onsite, spatial_shape=(6, 4, 4))
+
+    def test_bad_onsite_ndim_rejected(self):
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0]]), reverse=np.array([0]),
+            coeffs={"CoulombInter": np.zeros((1, 2, 2), dtype=complex)})
+        bad = np.zeros((6, 2, 2, 2), dtype=complex)   # ndim=4, not 5
+        with self.assertRaises(ValueError):
+            W_pm_bond(topo, bad, spatial_shape=(3, 2, 1))
+
+    def test_bad_onsite_nvol_mismatch_rejected(self):
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0]]), reverse=np.array([0]),
+            coeffs={"CoulombInter": np.zeros((1, 2, 2), dtype=complex)})
+        bad = np.zeros((5, 2, 2, 2, 2), dtype=complex)  # nvol=5 != 6
+        with self.assertRaises(ValueError):
+            W_pm_bond(topo, bad, spatial_shape=(3, 2, 1))
+
+    def test_bad_onsite_non_square_orbital_axes_rejected(self):
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0]]), reverse=np.array([0]),
+            coeffs={"CoulombInter": np.zeros((1, 2, 2), dtype=complex)})
+        bad = np.zeros((6, 2, 2, 2, 3), dtype=complex)
+        with self.assertRaises(ValueError):
+            W_pm_bond(topo, bad, spatial_shape=(3, 2, 1))
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -498,6 +498,45 @@ class TestResolveTransverseTopology(ApproxTestCase):
         with self.assertRaises(ValueError):
             resolve_transverse_topology(interactions, np.eye(3), norb=1)
 
+    def test_numpy_bool_component_rejected(self):
+        # np.bool_ is not a Python bool subclass; the guard must reject
+        # it explicitly rather than let it pass as the integer 1.
+        interactions = {"CoulombInter": {((np.bool_(True), 0, 0),
+                                          (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_numeric_string_component_rejected(self):
+        # "1" must not coerce (no float()/int() round-trip on strings).
+        interactions = {"CoulombInter": {(("1", 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_non_scalar_component_rejected(self):
+        # A hashable non-scalar (a nested tuple) must be rejected with
+        # the guard's ValueError, not fall through to int() semantics.
+        interactions = {"CoulombInter": {(((1, 2), 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_large_exact_int_preserved_not_float_rounded(self):
+        # 2**53 + 1 is not representable in float64; an int()-via-float
+        # conversion would silently round it to 2**53. The exact-int
+        # path must preserve it bit for bit (it then fails no validation
+        # here: it is a legitimate -- if absurd -- displacement).
+        big = 2**53 + 1
+        interactions = {"CoulombInter": {((big, 0, 0), (0, 0)): 0.2},
+                        }
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        self.assertIn(big, set(int(r[0]) for r in topo.delta_r))
+
+    def test_huge_float_component_rejected(self):
+        # A float above the 2**53 contiguous-integer bound is ambiguous
+        # as an integer and must be rejected, not silently converted.
+        interactions = {"CoulombInter": {((2.0**60, 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
 
 # =============================================================================
 # iter_reversal_orbits
@@ -2458,10 +2497,12 @@ class TestPairHopOffsiteWarning(ApproxTestCase):
             solver_on, gi_on = self._build_variant(
                 d_on, include_offsite=False)
 
-            out_off = tempfile.mkdtemp(prefix="rpa_pairhop_off_")
-            out_on = tempfile.mkdtemp(prefix="rpa_pairhop_on_")
-            solver_off.solve(gi_off, out_off)
-            solver_on.solve(gi_on, out_on)
+            with tempfile.TemporaryDirectory(
+                    prefix="rpa_pairhop_off_") as out_off, \
+                    tempfile.TemporaryDirectory(
+                        prefix="rpa_pairhop_on_") as out_on:
+                solver_off.solve(gi_off, out_off)
+                solver_on.solve(gi_on, out_on)
 
             self.assertTrue(np.array_equal(gi_off["chiq"], gi_on["chiq"]))
 

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -37,6 +37,7 @@ consumes its output.
 Tests must be run from the repository root.
 """
 
+import logging
 import os
 import tempfile
 import types
@@ -45,6 +46,7 @@ from unittest import mock
 
 import numpy as np
 
+import hwave.qlmsio.read_input_k as read_input_k
 from hwave import sc as _sc
 from hwave.solver import bubble as bubble_mod
 from hwave.solver import rpa as rpa_mod
@@ -1678,6 +1680,496 @@ class TestRunTransverseBondPipelineValidation(ApproxTestCase):
         with self.assertRaises(ValueError):
             solver._run_transverse_bond_pipeline(
                 bad_green, bad_tail, beta, topo)
+
+
+
+# =============================================================================
+# Phase W, Task 7: the experimental gate (transverse_bond_channels),
+# provenance, preflight, and the PairHop off-site warning.
+#
+# Config key names, rejection wording sources, provenance keys, and the
+# config matrix are per docs/superpowers/specs/2026-08-15-bond-transverse-
+# design.md "Production surface (experimental gate)"; the wiring pattern
+# (config parsing site, prereq validator, resource preflight, npz block,
+# stale-option warnings) mirrors sc.py's [eliashberg] bond_channels gate
+# (_read_bond_config / _validate_bond_prereqs / _bond_resource_preflight)
+# for its transverse sibling. Every test below drives the PUBLIC entry
+# (the RPA(...) constructor / solve() / save_results()), never a private
+# helper directly, except where a helper IS the object under test
+# (_transverse_bond_resource_preflight's own formula).
+# =============================================================================
+
+def _make_bond_gate_fixture(*, transverse_bond_channels=None,
+                             calc_type="ring+ladder", calc_scheme="general",
+                             interactions=None, param_overrides=None,
+                             Lx=4, Ly=4, Nmat=32, T=2.0, filling=0.75,
+                             input_path='tests/rpa/input'):
+    """norb=1 RPA fixture built via the PUBLIC ``RPA(...)`` constructor
+    from ``tests/rpa/input``'s existing Wannier90-format files -- the
+    SAME fixture family ``tests/test_rpa_ladder.py``'s ``_run_rpa`` (and
+    its ``test_offsite_two_body_is_rejected``) uses: on-site CoulombIntra
+    (U=4) and, by default, off-site CoulombInter (V=1 at
+    R=(+-1,0,0)/(0,+-1,0) -- an ACTIVE transverse-resolved off-site
+    declaration the bond gate can represent but the plain ladder's
+    representability check (``_check_transverse_representable``)
+    rejects) plus Extern (forces ``solver.spin_mode == 'spin-diag'``,
+    which the bond pipeline's up/down Green blocks require).
+
+    Does NOT call ``solve()`` -- callers decide (so rejection tests can
+    ``assertRaises`` around ``solve()`` itself, the public entry point).
+
+    Returns ``(solver, green_info, out_dir)``.
+    """
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    if interactions is None:
+        interactions = {'CoulombIntra': 'coulombintra.dat',
+                         'CoulombInter': 'coulombinter.dat',
+                         'Extern': 'extern.dat'}
+    interaction_dict = {
+        'path_to_input': input_path,
+        'Geometry': 'geom.dat',
+        'Transfer': 'transfer.dat',
+    }
+    interaction_dict.update(interactions)
+
+    param = {'T': T, 'filling': filling, 'CellShape': [Lx, Ly, 1],
+             'SubShape': [1, 1, 1], 'Nmat': Nmat}
+    if transverse_bond_channels is not None:
+        param['transverse_bond_channels'] = transverse_bond_channels
+    if param_overrides:
+        param.update(param_overrides)
+
+    info_mode = {'mode': 'RPA', 'param': param,
+                 'calc_scheme': calc_scheme, 'calc_type': calc_type}
+    info_input = {'path_to_input': input_path,
+                  'interaction': interaction_dict}
+
+    read_io = read_input_k.QLMSkInput(info_input)
+    ham_info = read_io.get_param("ham")
+    solver = rpa_mod.RPA(ham_info, {}, info_mode)
+    green_info = read_io.get_param("green")
+    out_dir = tempfile.mkdtemp(prefix="rpa_bond_gate_out_")
+    return solver, green_info, out_dir
+
+
+def _make_spinful_bond_gate_fixture(T=0.5, mu=0.2, Lx=4, Nmat=32, U=0.3,
+                                     thop=0.7 + 0.3j, lso=0.35 + 0.15j):
+    """norb_phys=1 ``enable_spin_orbital`` ring+ladder fixture with a
+    genuine spin-mixing transfer term (off-diagonal generalized-index
+    hopping ``lso``), reaching ``solver.spin_mode == 'spinful'`` -- the
+    combination the bond gate's prereq validator must reject (spec
+    ``spin_mode="spinful"`` -> reject until Phase S). Mirrors
+    ``tests/test_rpa_spinful_vertex_exchange.py``'s ``TestVertexExtraction``
+    / ``_run_rpa`` construction pattern, the SAME fixture family that
+    already established this combination reaches ``spin_mode ==
+    'spinful'`` (that file's ``TestSpinConservingLimits`` pins it at
+    ``calc_type='ring'``; nothing about the H0 that sets ``spin_mode``
+    depends on ``calc_type``).
+
+    Does NOT call ``solve()``. Returns ``(solver, green_info, out_dir)``.
+    """
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    d = tempfile.mkdtemp(prefix="rpa_bond_gate_spinful_")
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n2\n")
+        f.write("0.0 0.0 0.0\n0.0 0.0 0.0\n")
+    with open(os.path.join(d, "transfer.dat"), "w") as f:
+        f.write("hdr\n2\n3\n1 1 1\n")
+        for i in (1, 2):
+            f.write(" 1 0 0 %d %d %.12f %.12f\n"
+                     % (i, i, thop.real, thop.imag))
+            f.write("-1 0 0 %d %d %.12f %.12f\n"
+                     % (i, i, np.conj(thop).real, np.conj(thop).imag))
+        f.write(" 0 0 0 1 2 %.12f %.12f\n" % (lso.real, lso.imag))
+        f.write(" 0 0 0 2 1 %.12f %.12f\n" % (lso.real, -lso.imag))
+    with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+        f.write("hdr\n1\n1\n1\n")
+        f.write(" 0 0 0 1 1 %.12f 0.0\n" % U)
+    inter = {"path_to_input": d, "Geometry": "geom.dat",
+             "Transfer": "transfer.dat", "CoulombIntra": "coulombintra.dat"}
+
+    param = {"T": T, "mu": mu, "CellShape": [Lx, 1, 1],
+             "SubShape": [1, 1, 1], "Nmat": Nmat, "coeff_tail": 1.0,
+             "transverse_bond_channels": True}
+    info_mode = {"mode": "RPA", "param": param,
+                 "enable_spin_orbital": True, "calc_scheme": "general",
+                 "calc_type": "ring+ladder"}
+    io = read_input_k.QLMSkInput({"path_to_input": d, "interaction": inter})
+    solver = rpa_mod.RPA(io.get_param("ham"), {}, info_mode)
+    green_info = io.get_param("green")
+    out_dir = tempfile.mkdtemp(prefix="rpa_bond_gate_spinful_out_")
+    return solver, green_info, out_dir
+
+
+class TestTransverseBondGateConfig(ApproxTestCase):
+    """``[mode.param] transverse_bond_channels`` config parsing (spec
+    "Production surface"): default false, parsed ONLY under
+    ``calc_type='ring+ladder'``, stale-option warnings, and type
+    validation -- mirroring sc.py's ``[eliashberg] bond_channels``
+    ``_read_bond_config`` pattern for the (eliashberg) longitudinal bond
+    gate."""
+
+    ONSITE_ONLY = {'CoulombIntra': 'coulombintra.dat', 'Extern': 'extern.dat'}
+
+    def test_absent_defaults_to_false(self):
+        solver, _gi, _out = _make_bond_gate_fixture(
+            transverse_bond_channels=None, interactions=self.ONSITE_ONLY)
+        self.assertIs(solver.transverse_bond_channels, False)
+
+    def test_gate_absent_equals_gate_false_bitwise(self):
+        """Config matrix (spec): "gate absent == gate false (bitwise-
+        identical run)"."""
+        solver_a, gi_a, out_a = _make_bond_gate_fixture(
+            transverse_bond_channels=None, interactions=self.ONSITE_ONLY)
+        solver_a.solve(gi_a, out_a)
+        solver_b, gi_b, out_b = _make_bond_gate_fixture(
+            transverse_bond_channels=False, interactions=self.ONSITE_ONLY)
+        solver_b.solve(gi_b, out_b)
+
+        self.assertTrue(np.array_equal(gi_a["chiq"], gi_b["chiq"]))
+        self.assertTrue(np.array_equal(gi_a["chiq_pm"], gi_b["chiq_pm"]))
+        self.assertNotIn("chiq_pm_bond_static", gi_a)
+        self.assertNotIn("chiq_pm_bond_static", gi_b)
+
+    def test_stale_under_calc_type_ring_warns(self):
+        with self.assertLogs("hwave.solver.rpa", level="WARNING") as cm:
+            solver, _gi, _out = _make_bond_gate_fixture(
+                calc_type="ring", transverse_bond_channels=True,
+                interactions=self.ONSITE_ONLY)
+        self.assertIs(solver.transverse_bond_channels, False)
+        self.assertTrue(any(
+            "transverse_bond_channels" in m and "calc_type" in m
+            for m in cm.output))
+
+    def test_stale_options_while_gate_false_warn(self):
+        with self.assertLogs("hwave.solver.rpa", level="WARNING") as cm:
+            _solver, _gi, _out = _make_bond_gate_fixture(
+                transverse_bond_channels=False,
+                param_overrides={'transverse_bond_max_shells': 1},
+                interactions=self.ONSITE_ONLY)
+        self.assertTrue(
+            any("transverse_bond_max_shells" in m for m in cm.output))
+
+    def test_flag_rejects_non_bool(self):
+        with self.assertRaises(ValueError):
+            _make_bond_gate_fixture(
+                param_overrides={'transverse_bond_channels': 1},
+                interactions=self.ONSITE_ONLY)
+
+    def test_max_shells_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            _make_bond_gate_fixture(
+                transverse_bond_channels=True,
+                param_overrides={'transverse_bond_max_shells': -1},
+                interactions=self.ONSITE_ONLY)
+
+    def test_max_shells_rejects_non_integral(self):
+        with self.assertRaises(ValueError):
+            _make_bond_gate_fixture(
+                transverse_bond_channels=True,
+                param_overrides={'transverse_bond_max_shells': 1.5},
+                interactions=self.ONSITE_ONLY)
+
+    def test_memory_cap_rejects_non_positive(self):
+        with self.assertRaises(ValueError):
+            _make_bond_gate_fixture(
+                transverse_bond_channels=True,
+                param_overrides={'transverse_bond_memory_cap_gb': 0.0},
+                interactions=self.ONSITE_ONLY)
+
+
+class TestTransverseBondGatePrereqs(ApproxTestCase):
+    """``_validate_transverse_bond_prereqs``'s REJECT list (spec
+    "Production surface"): no active off-site declaration,
+    ``spin_mode='spinful'``, and an externally supplied ``chi0q_init``.
+    Also proves the representability-check bypass is unreachable when
+    the gate is off (spec: "a config test proves the bypass is
+    unreachable when the gate is off"), and that it DOES engage on the
+    same input with the gate on."""
+
+    ACTIVE = {'CoulombIntra': 'coulombintra.dat',
+              'CoulombInter': 'coulombinter.dat', 'Extern': 'extern.dat'}
+    ONSITE_ONLY = {'CoulombIntra': 'coulombintra.dat', 'Extern': 'extern.dat'}
+
+    def test_no_active_declaration_rejected(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ONSITE_ONLY)
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("active off-site", str(cm.exception))
+
+    def test_bypass_engages_on_gate_and_solves(self):
+        """Gate on: off-site CoulombInter -- unrepresentable by the plain
+        vertex -- is REPRESENTED by the bond path instead of being
+        rejected."""
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE)
+        solver.solve(gi, out)
+        self.assertIn("chiq_pm_bond_static", gi)
+        self.assertIn("chiq_pm_static", gi)
+        self.assertNotIn("chiq_pm", gi)
+
+    def test_bypass_unreachable_with_gate_off(self):
+        """SAME off-site declaration, gate off:
+        ``_check_transverse_representable`` still runs and rejects it --
+        the bypass branch in ``solve()`` is unreachable when
+        ``transverse_bond_channels`` is false."""
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=False, interactions=self.ACTIVE)
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("does not support off-site", str(cm.exception))
+
+    def test_spinful_rejected(self):
+        solver, gi, out = _make_spinful_bond_gate_fixture()
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("spin_mode='spinful'", str(cm.exception))
+
+    def test_external_chi0q_init_rejected(self):
+        # Build a spin-free chi0q with a plain ring solve, then feed it
+        # back in as chi0q_init to a gate-on ring+ladder solver. The
+        # pre-existing spin-diag/external guard (rpa.py, "a same-instance
+        # green0 may belong to an OLDER bubble") does not fire for a
+        # spin-free chi0q, so this exercises the gate's OWN
+        # external-chi0q rejection specifically.
+        prep, gi0, out0 = _make_bond_gate_fixture(
+            calc_type="ring", transverse_bond_channels=None,
+            interactions={'CoulombIntra': 'coulombintra.dat',
+                          'CoulombInter': 'coulombinter.dat'})
+        prep.solve(gi0, out0)
+        self.assertEqual(prep.spin_mode, "spin-free")
+        prep.save_results(
+            {'path_to_output': out0, 'chi0q': 'chi0q.npz'}, gi0)
+
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            interactions={'CoulombIntra': 'coulombintra.dat',
+                          'CoulombInter': 'coulombinter.dat'})
+        gi.update(solver.read_init(
+            {'path_to_input': out0, 'chi0q_init': 'chi0q.npz'}))
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("externally supplied chi0q", str(cm.exception))
+
+
+class TestTransverseBondResourcePreflight(ApproxTestCase):
+    """``_transverse_bond_resource_preflight`` (spec "Phase W -- Budget
+    (stated, not deferred)"): the ``(3+K_solve)*Nq*ND**2*16`` byte
+    estimate against ``transverse_bond_memory_cap_gb`` (REFUSE above the
+    cap), and the ``Nq*ND**3 > 1e12`` op-count WARNING (never a
+    refusal)."""
+
+    ACTIVE = {'CoulombIntra': 'coulombintra.dat',
+              'CoulombInter': 'coulombinter.dat', 'Extern': 'extern.dat'}
+
+    def test_tiny_cap_refuses(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': 1e-12},
+            interactions=self.ACTIVE)
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("memory_cap_gb", str(cm.exception))
+
+    def test_default_cap_passes_for_tiny_fixture(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE)
+        solver.solve(gi, out)  # must not raise
+        self.assertIn("chiq_pm_bond_static", gi)
+
+    def test_formula_matches_documented_estimate(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE)
+        solver.solve(gi, out)
+        topo = solver._transverse_bond_topo
+        B = len(topo.delta_r)
+        ND = B * solver.norb ** 2
+        Nq = solver.lattice.nvol
+        K_solve = 3
+        want_peak = (3 + K_solve) * Nq * ND ** 2 * 16
+
+        solver.transverse_bond_memory_cap_gb = (want_peak * 0.999) / 1.0e9
+        with self.assertRaises(ValueError):
+            solver._transverse_bond_resource_preflight(topo)
+
+        solver.transverse_bond_memory_cap_gb = (want_peak * 1.001) / 1.0e9
+        solver._transverse_bond_resource_preflight(topo)  # must not raise
+
+    def test_op_count_warns_not_refuses(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE)
+        solver.solve(gi, out)
+        topo = solver._transverse_bond_topo
+
+        solver.transverse_bond_memory_cap_gb = 1.0e12  # never refuses here
+        orig_nvol = solver.lattice.nvol
+        solver.lattice.nvol = 10 ** 11  # pushes Nq*ND**3 well past 1e12
+        try:
+            with self.assertLogs("hwave.solver.rpa", level="WARNING") as cm:
+                solver._transverse_bond_resource_preflight(topo)
+        finally:
+            solver.lattice.nvol = orig_nvol
+        self.assertTrue(any("op-count" in m for m in cm.output))
+
+
+class TestTransverseBondGateOutput(ApproxTestCase):
+    """End-to-end smoke test on a tiny fixture (anti-vacuity): config
+    dict -> ``RPA(...)`` constructor -> ``solve()`` -> ``save_results()``
+    -> npz written; keys, shapes, schema metadata, and a value PINNED
+    against a direct ``_run_transverse_bond_pipeline`` call on the same
+    fixture (spec "Output (static-only)")."""
+
+    ACTIVE = {'CoulombIntra': 'coulombintra.dat',
+              'CoulombInter': 'coulombinter.dat', 'Extern': 'extern.dat'}
+
+    def test_npz_keys_shapes_schema_and_cross_pin(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE)
+        solver.solve(gi, out)
+        solver.save_results(
+            {'path_to_output': out, 'chiq': 'chiq.npz'}, gi)
+
+        data = np.load(os.path.join(out, 'chiq.npz'), allow_pickle=True)
+
+        self.assertNotIn("chiq_pm", data.files)
+        for key in ("chiq_pm_bond_static", "chiq_pm_static",
+                    "transverse_bond_schema_version",
+                    "transverse_output_kind",
+                    "transverse_bond_delta_r", "transverse_bond_reverse",
+                    "transverse_bond_index_order",
+                    "transverse_bond_max_shells",
+                    "transverse_spatial_shape", "transverse_q_convention",
+                    "transverse_spin_mode", "transverse_normalization"):
+            self.assertIn(key, data.files)
+
+        self.assertEqual(int(data["transverse_bond_schema_version"]), 1)
+        self.assertEqual(str(data["transverse_output_kind"]), "bond_static")
+        self.assertEqual(str(data["transverse_bond_index_order"]),
+                          "m*norb**2 + a*norb + b")
+        self.assertEqual(str(data["transverse_q_convention"]),
+                          "q_d = 2*pi*n_d/N_d, C-order flattening")
+        self.assertEqual(str(data["transverse_spin_mode"]), "spin-diag")
+        self.assertEqual(str(data["transverse_normalization"]),
+                          "per-site, 1/sqrt(Nvol) bilinears")
+        self.assertEqual(int(data["transverse_bond_max_shells"]), -1)
+
+        topo = solver._transverse_bond_topo
+        B = len(topo.delta_r)
+        ND = B * solver.norb ** 2
+        Nq = solver.lattice.nvol
+        self.assertEqual(tuple(data["chiq_pm_bond_static"].shape),
+                          (Nq, ND, ND))
+        self.assertEqual(tuple(data["chiq_pm_static"].shape),
+                          (Nq, solver.norb, solver.norb,
+                           solver.norb, solver.norb))
+        self.assertEqual(tuple(data["transverse_bond_delta_r"].shape),
+                          (B, 3))
+        self.assertEqual(tuple(data["transverse_bond_reverse"].shape),
+                          (B,))
+        self.assertTrue(np.array_equal(data["transverse_bond_delta_r"],
+                                       topo.delta_r))
+        self.assertTrue(np.array_equal(data["transverse_bond_reverse"],
+                                       topo.reverse))
+        self.assertTrue(np.array_equal(
+            data["transverse_spatial_shape"], np.array(solver.lattice.shape)))
+
+        # Cross-pin (anti-vacuity): the saved value equals a DIRECT
+        # _run_transverse_bond_pipeline call on the same fixture state.
+        beta = 1.0 / solver.T
+        chi_direct, chiq_direct = solver._run_transverse_bond_pipeline(
+            solver.green0, solver.green0_tail, beta, topo)
+        self.assertTrue(np.array_equal(
+            data["chiq_pm_bond_static"], chi_direct))
+        self.assertTrue(np.array_equal(
+            data["chiq_pm_static"], chiq_direct))
+        self.assertTrue(np.array_equal(
+            data["chiq_pm_bond_static"], gi["chiq_pm_bond_static"]))
+        self.assertTrue(np.array_equal(
+            data["chiq_pm_static"], gi["chiq_pm_static"]))
+
+
+class TestPairHopOffsiteWarning(ApproxTestCase):
+    """``_append_pairhop``'s silent off-site discard now warns, naming
+    the ORIGINAL user declarations (spec "Deferred (recorded)": "Off-site
+    PairHop physics (warning + tracking issue only).")."""
+
+    def _build(self, d):
+        with open(os.path.join(d, "geom.dat"), "w") as f:
+            f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n1\n"
+                     "0.0 0.0 0.0\n")
+        with open(os.path.join(d, "transfer.dat"), "w") as f:
+            f.write("hdr\n1\n2\n1 1\n"
+                     " 1 0 0 1 1 0.5 0.0\n-1 0 0 1 1 0.5 0.0\n")
+        with open(os.path.join(d, "pairhop.dat"), "w") as f:
+            # on-site (irvec=(0,0,0)) plus a Hermitian-closed off-site
+            # pair (R=+-1 x, both directions declared -- #93 requires
+            # Hermitian closure at the reader level).
+            f.write("hdr\n1\n3\n1 1 1\n"
+                     " 0 0 0 1 1 0.2 0.0\n"
+                     " 1 0 0 1 1 0.15 0.0\n"
+                     "-1 0 0 1 1 0.15 0.0\n")
+        inter = {"path_to_input": d, "Geometry": "geom.dat",
+                 "Transfer": "transfer.dat", "PairHop": "pairhop.dat"}
+        param = {"T": 1.0, "mu": 0.0, "CellShape": [4, 1, 1],
+                 "SubShape": [1, 1, 1], "Nmat": 8}
+        info_mode = {"mode": "RPA", "param": param,
+                     "calc_scheme": "general", "calc_type": "ring"}
+        io = read_input_k.QLMSkInput(
+            {"path_to_input": d, "interaction": inter})
+        return rpa_mod.RPA(io.get_param("ham"), {}, info_mode)
+
+    def test_offsite_pairhop_warns_naming_declarations(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertLogs("hwave.solver.rpa", level="WARNING") as cm:
+                self._build(d)
+        msgs = "\n".join(cm.output)
+        self.assertIn("PairHop", msgs)
+        self.assertIn("off-site", msgs)
+        # names the two dropped (pre-fold) declarations explicitly
+        self.assertIn("(1, 0, 0)", msgs)
+        self.assertIn("(-1, 0, 0)", msgs)
+        self.assertIn("0.15", msgs)
+
+    def test_onsite_only_pairhop_does_not_warn(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "geom.dat"), "w") as f:
+                f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n1\n"
+                         "0.0 0.0 0.0\n")
+            with open(os.path.join(d, "transfer.dat"), "w") as f:
+                f.write("hdr\n1\n2\n1 1\n"
+                         " 1 0 0 1 1 0.5 0.0\n-1 0 0 1 1 0.5 0.0\n")
+            with open(os.path.join(d, "pairhop.dat"), "w") as f:
+                f.write("hdr\n1\n1\n1\n 0 0 0 1 1 0.2 0.0\n")
+            inter = {"path_to_input": d, "Geometry": "geom.dat",
+                     "Transfer": "transfer.dat", "PairHop": "pairhop.dat"}
+            param = {"T": 1.0, "mu": 0.0, "CellShape": [4, 1, 1],
+                     "SubShape": [1, 1, 1], "Nmat": 8}
+            info_mode = {"mode": "RPA", "param": param,
+                         "calc_scheme": "general", "calc_type": "ring"}
+            io = read_input_k.QLMSkInput(
+                {"path_to_input": d, "interaction": inter})
+            logger = logging.getLogger("hwave.solver.rpa")
+            handler = _CollectingHandler()
+            logger.addHandler(handler)
+            try:
+                rpa_mod.RPA(io.get_param("ham"), {}, info_mode)
+            finally:
+                logger.removeHandler(handler)
+            self.assertFalse(any(
+                "PairHop declares" in r.getMessage()
+                for r in handler.records))
+
+
+class _CollectingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -37,12 +37,17 @@ consumes its output.
 Tests must be run from the repository root.
 """
 
+import os
+import tempfile
+import types
 import unittest
+from unittest import mock
 
 import numpy as np
 
 from hwave import sc as _sc
 from hwave.solver import bubble as bubble_mod
+from hwave.solver import rpa as rpa_mod
 from hwave.solver.bond_channels import (
     TransverseTopology,
     resolve_transverse_topology,
@@ -1361,6 +1366,306 @@ class TestTransverseBondBubbleStaticValidation(ApproxTestCase):
         with self.assertRaises(ValueError):
             bubble_mod.transverse_bond_bubble_static(
                 green_kw, None, 1.0, topo, spatial_shape=(4, 1, 1))
+
+
+# =============================================================================
+# RPA._run_transverse_bond_pipeline (Phase W, Task 5)
+# =============================================================================
+#
+# The dressing + collapse + the internal pipeline entry
+# (RPA._build_ham_pm_onsite / RPA._run_transverse_bond_pipeline in
+# rpa.py, appended for this task): on-site vertex assembly ->
+# W_pm_bond -> transverse_bond_bubble_static -> the EXISTING _solve_rpa
+# dressing -> the (m=0, m'=0) collapse. Anti-vacuity (spec "Phase W --
+# implementation + ED campaign"): this entry is called directly by every
+# test below, with NO prereq/fallback path.
+
+
+def _make_ring_ladder_solver(Lx=4, Ly=4, Nmat=8, hz=0.0, U=0.8, T=2.0,
+                              norb=2):
+    """Minimal ring+ladder RPA solver fixture: ON-SITE CoulombIntra ONLY
+    (no off-site declarations anywhere). An Extern field is ALWAYS
+    declared (forcing ``solver.spin_mode == "spin-diag"`` and giving
+    ``solver.green0`` the required ``nblock=2`` up/down blocks --
+    ``transverse_bond_bubble_static`` requires exactly that shape), but
+    the default ``hz=0.0`` makes its coefficient zero, so ``G_up ==
+    G_down`` EXACTLY (H1 = ham_extern_q * 0 = 0 -> Hnew[0] == Hnew[1]).
+    This is deliberate, not incidental: the bond pipeline's ``chi0``
+    (``transverse_bond_bubble_static``, fwd=down/rev=up, ``<S+;S+dagger>``)
+    and the production plain channel's ``chi0_+-``
+    (``_calc_chi0q_transverse``, fwd=up/rev=down, ``<S-;S-dagger>``) are
+    PROVABLY the same object only when ``G_up == G_down`` -- off that
+    line they are genuinely different physical objects whenever the
+    Green's function has off-diagonal orbital structure (a role-swap is
+    not a matrix transpose when the two matrices being swapped differ),
+    which is exactly what a nonzero ``hz`` combined with the ``norb=2``
+    mixing hop below was measured to trigger (diff ~4e-4, pure sign
+    flips at the off-diagonal-orbital cells) -- whether production's
+    Zeeman-split ``chiq_pm`` genuinely represents ``<S-;S-dagger>`` at
+    ``G_up != G_down`` is explicitly the Phase-H/W Task 6 "production
+    conjugate-pair granule"'s job, not this gate's. ``hz`` stays a
+    parameter (used by the mesh/nblock validation tests below, where
+    the value is immaterial) for the same construction to serve both.
+
+    ``norb=2`` (the default) ALSO declares a genuine on-site inter-
+    orbital hopping mix, so ``G[a,b]`` is non-diagonal in orbital space
+    and ``chiq_pm``'s ``(a,c,b,d)`` tensor is NOT symmetric under an
+    arbitrary axis relabelling -- ``norb=1`` cannot discriminate a
+    collapse-index mutation (every orbital axis is trivially size-1),
+    which is why the collapse mutation check (Task 5) needed this.
+
+    Extends the ``tests/test_bubble_kernel.py`` ``_make_rpa_solver``
+    construction pattern (temp Wannier90-like input files, including its
+    own ``norb=2`` mixing-hop convention) with ``calc_type=
+    'ring+ladder'`` baked into ``info_mode`` at construction time (that
+    shared fixture builds an UNSOLVED solver with no ``calc_type``
+    parameter, so it cannot drive the production ladder channel), and
+    then runs a real ``solver.solve(...)`` -- which populates
+    ``green_info["chiq_pm"]`` via the PRODUCTION plain
+    ``_build_transverse_channel`` + ``_solve_rpa`` path. Gate W1 compares
+    ``_run_transverse_bond_pipeline``'s collapsed output against exactly
+    that array.
+    """
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    t = 0.6 * np.exp(0.25j) if norb >= 2 else 0.6
+    mix = 0.35 * np.exp(-0.5j) if norb >= 2 else 0.0
+    n_mix = 2 if norb >= 2 else 0
+    nr = 2 * norb + n_mix
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "geom.dat"), "w") as f:
+            f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n")
+            f.write("{}\n".format(norb))
+            for _ in range(norb):
+                f.write("0.0 0.0 0.0\n")
+        with open(os.path.join(d, "transfer.dat"), "w") as f:
+            f.write("gate W1 fixture transfer\n")
+            f.write("{}\n{}\n".format(norb, nr))
+            f.write(("1 " * nr).strip() + "\n")
+            for orb in range(1, norb + 1):
+                to = t * orb    # distinct magnitude per orbital
+                f.write(" 1 0 0 {o} {o} {re:.12f} {im:.12f}\n".format(
+                    o=orb, re=to.real, im=to.imag))
+                f.write("-1 0 0 {o} {o} {re:.12f} {im:.12f}\n".format(
+                    o=orb, re=np.conj(to).real, im=np.conj(to).imag))
+            if norb >= 2:
+                f.write(" 0 0 0 1 2 {re:.12f} {im:.12f}\n".format(
+                    re=mix.real, im=mix.imag))
+                f.write(" 0 0 0 2 1 {re:.12f} {im:.12f}\n".format(
+                    re=np.conj(mix).real, im=np.conj(mix).imag))
+        with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+            f.write("gate W1 fixture CoulombIntra\n")
+            f.write("{}\n{}\n".format(norb, norb))
+            f.write(("1 " * norb).strip() + "\n")
+            for orb in range(1, norb + 1):
+                f.write(" 0 0 0 {o} {o} {u:.12f} 0.0\n".format(o=orb, u=U))
+        with open(os.path.join(d, "extern.dat"), "w") as f:
+            f.write("gate W1 fixture Extern\n")
+            f.write("{}\n{}\n".format(norb, norb))
+            f.write(("1 " * norb).strip() + "\n")
+            for orb in range(1, norb + 1):
+                f.write(" 0 0 0 {o} {o} 1.0 0.0\n".format(o=orb))
+
+        interaction = {
+            'path_to_input': d,
+            'Geometry': 'geom.dat',
+            'Transfer': 'transfer.dat',
+            'CoulombIntra': 'coulombintra.dat',
+            'Extern': 'extern.dat',
+        }
+        param = {'T': T, 'mu': 0.0, 'CellShape': [Lx, Ly, 1],
+                 'SubShape': [1, 1, 1], 'Nmat': Nmat,
+                 'coeff_extern': hz}
+        info_input = {'path_to_input': d, 'interaction': interaction}
+        info_mode = {'mode': 'RPA', 'param': param,
+                     'calc_scheme': 'general', 'calc_type': 'ring+ladder'}
+
+        read_io = read_input_k.QLMSkInput(info_input)
+        ham_info = read_io.get_param("ham")
+        solver = rpa_mod.RPA(ham_info, {}, info_mode)
+        green_info = read_io.get_param("green")
+
+        out_dir = tempfile.mkdtemp(prefix="rpa_gate_w1_")
+        solver.solve(green_info, out_dir)
+    return solver, green_info
+
+
+class TestDressingDirectFiniteMatrix(ApproxTestCase):
+    """Implementation-independent pin on ``_solve_rpa`` -- exactly the
+    call ``_run_transverse_bond_pipeline``'s dressing step makes
+    (``_solve_rpa(chi0.reshape(1, nvol, ND, ND), W)``) -- against a
+    PLAIN ``numpy.linalg.solve(I + chi0[q] @ W[q], chi0[q])`` reference
+    built per q with NO call to ``_solve_rpa`` (spec "The dressing
+    (static)"). Random NONSYMMETRIC complex matrices: the ``I + chi0.ham``
+    convention has no reason to require symmetry, and a wrong transpose
+    orientation would only show up on a nonsymmetric fixture."""
+
+    def test_dressing_matches_plain_solve_per_q(self):
+        rng = np.random.default_rng(11)
+        nvol, ND = 3, 4
+        chi0 = (rng.normal(size=(nvol, ND, ND))
+                + 1j * rng.normal(size=(nvol, ND, ND)))
+        W = (rng.normal(size=(nvol, ND, ND))
+             + 1j * rng.normal(size=(nvol, ND, ND)))
+
+        solver = object.__new__(rpa_mod.RPA)
+        solver.lattice = types.SimpleNamespace(nvol=nvol)
+
+        sol = solver._solve_rpa(chi0.reshape(1, nvol, ND, ND), W)
+        got = sol[0]
+
+        eye = np.eye(ND, dtype=complex)
+        want = np.zeros_like(chi0)
+        for q in range(nvol):
+            want[q] = np.linalg.solve(eye + chi0[q] @ W[q], chi0[q])
+
+        assert_approx_array(got, want, rel=0, abs=1e-12)
+
+
+class TestCollapseRule(ApproxTestCase):
+    """Elementwise pin on the collapse step (spec "Collapse rule
+    (exact)"): ``chiq_pm_static[q, a, c, b, d] = chi_pm_bond[q, (0, a,
+    c), (0, b, d)]``. ``W_pm_bond``/``transverse_bond_bubble_static``/
+    ``_solve_rpa`` are mocked out so the dressed bond object
+    (``chi_pm_bond``) is a FULLY CONTROLLED, non-degenerate random array
+    -- the expected collapse is built by DIRECT per-index selection
+    (never via a ``.reshape``/``.transpose`` call), so this test does not
+    validate production against itself."""
+
+    def test_collapse_picks_m0_subblock_by_direct_indexing(self):
+        norb, B, nvol = 2, 2, 3
+        nd = norb * norb
+        ND = B * nd
+        rng = np.random.default_rng(23)
+        chi_pm_bond = (rng.normal(size=(nvol, ND, ND))
+                       + 1j * rng.normal(size=(nvol, ND, ND)))
+
+        solver = object.__new__(rpa_mod.RPA)
+        solver.lattice = types.SimpleNamespace(nvol=nvol, shape=(nvol, 1, 1))
+        solver.norb = norb
+        solver.fft_workers = 1
+
+        dummy_onsite = np.zeros((nvol, norb, norb, norb, norb),
+                                 dtype=complex)
+        dummy_topo = object()
+
+        with mock.patch.object(
+                rpa_mod.RPA, "_build_ham_pm_onsite",
+                return_value=dummy_onsite), \
+             mock.patch.object(
+                rpa_mod.bond_channels, "W_pm_bond",
+                return_value=np.zeros((nvol, ND, ND), dtype=complex)), \
+             mock.patch.object(
+                rpa_mod.bubble, "transverse_bond_bubble_static",
+                return_value=np.zeros((nvol, ND, ND), dtype=complex)), \
+             mock.patch.object(
+                rpa_mod.RPA, "_solve_rpa",
+                return_value=chi_pm_bond.reshape(1, nvol, ND, ND)):
+            chi_bond_out, collapsed = solver._run_transverse_bond_pipeline(
+                green_kw=None, green0_tail=None, beta=1.0, topo=dummy_topo)
+
+        assert_approx_array(chi_bond_out, chi_pm_bond, rel=0, abs=0)
+
+        expected = np.zeros((nvol, norb, norb, norb, norb), dtype=complex)
+        for q in range(nvol):
+            for a in range(norb):
+                for c in range(norb):
+                    for b in range(norb):
+                        for d in range(norb):
+                            row = a * norb + c    # channel m=0 offset 0
+                            col = b * norb + d
+                            expected[q, a, c, b, d] = chi_pm_bond[q, row, col]
+
+        assert_approx_array(collapsed, expected, rel=0, abs=0)
+
+        # Self-check that the fixture genuinely discriminates the
+        # (a,c)/(b,d) grouping from the (a,b)/(c,d) one this test's
+        # mutation check targets: with norb=2 the two groupings read
+        # DIFFERENT cells whenever a != c or b != d, e.g. (a,b,c,d) =
+        # (0,1,0,0): correct row=a*norb+c=0, col=b*norb+d=2; the (a,b)/
+        # (c,d) grouping would read row=a*norb+b=1, col=c*norb+d=0.
+        self.assertNotEqual(0 * norb + 0, 0 * norb + 1)
+
+
+class TestGateW1OnsiteReduction(ApproxTestCase):
+    """**Gate W1** (spec "Gate W1 (on-site reduction, exact scope)"):
+    with ONLY on-site declarations, ``_run_transverse_bond_pipeline``'s
+    collapsed static output must equal the Omega=0 slice
+    (``l = nmat // 2``) of today's PLAIN ``chiq_pm`` (the production
+    ``_build_transverse_channel`` + ``_solve_rpa`` result), at
+    ``assert_approx_array(rel=1e-12, abs=1e-13)``. Both sides solve the
+    SAME physics through DIFFERENT code paths (the plain path builds its
+    on-site vertex/bubble from the FULL solver machinery in one shot;
+    the bond pipeline builds ``ham_pm_onsite`` from filtered pre-fold
+    declarations and the bubble via the bond-channel machinery with
+    B=1), so agreement here is the load-bearing algebraic check that the
+    bond lift reduces exactly to the existing plain channel when there
+    is nothing off-site to represent.
+
+    Uses the DEFAULT ``_make_ring_ladder_solver`` fixture (``hz=0.0``,
+    ``G_up == G_down``): the two sides' bubbles are provably the SAME
+    object only on that line (see the fixture's own docstring) -- off it
+    they diverge by a measured ~4e-4 that is a genuine convention
+    difference between ``<S+;S+dagger>`` and ``<S-;S-dagger>``, not a
+    defect gate W1 is scoped to catch (that adjudication is Task 6's
+    production conjugate-pair granule)."""
+
+    def test_collapsed_output_matches_plain_chiq_pm_at_omega_zero(self):
+        solver, green_info = _make_ring_ladder_solver()
+        beta = 1.0 / solver.T
+
+        # B=1 topology: resolve_transverse_topology reads OFF-SITE
+        # content only (on-site entries are ignored -- on-site content
+        # is represented exclusively through ham_pm_onsite), and this
+        # fixture declares none, so every type's coeffs are all-zero at
+        # the single mandatory channel 0.
+        topo = resolve_transverse_topology(
+            solver.ham_info.param_ham, np.eye(3), solver.norb)
+        self.assertEqual(len(topo.delta_r), 1)
+
+        chi_pm_bond_static, chiq_pm_static = (
+            solver._run_transverse_bond_pipeline(
+                solver.green0, solver.green0_tail, beta, topo))
+
+        chiq_pm_plain = green_info["chiq_pm"]
+        nmat = chiq_pm_plain.shape[0]
+        want = chiq_pm_plain[nmat // 2]
+
+        assert_approx_array(chiq_pm_static, want, rel=1e-12, abs=1e-13)
+
+        # Report the measured margin (spec: "measured margin reported").
+        margin = float(np.max(np.abs(chiq_pm_static - want)))
+        print("Gate W1 measured max-abs margin: {:.3e}".format(margin))
+
+
+class TestRunTransverseBondPipelineValidation(ApproxTestCase):
+    """Entry-point validation: both failure modes PROPAGATE as
+    ``ValueError`` from the underlying calls -- ``_run_transverse_bond_
+    pipeline`` adds no guards of its own (no prereq fallback)."""
+
+    def test_mesh_colliding_topology_raises(self):
+        solver, _green_info = _make_ring_ladder_solver()
+        beta = 1.0 / solver.T
+        # +2 == -2 mod 4 -- solver.lattice.shape is (4, 4, 1) by default.
+        bad_topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0], [2, 0, 0], [-2, 0, 0]]),
+            reverse=np.array([0, 2, 1]),
+            coeffs={"CoulombInter": np.zeros(
+                (3, solver.norb, solver.norb), dtype=complex)})
+        with self.assertRaises(ValueError):
+            solver._run_transverse_bond_pipeline(
+                solver.green0, solver.green0_tail, beta, bad_topo)
+
+    def test_nblock_not_two_raises(self):
+        solver, _green_info = _make_ring_ladder_solver()
+        beta = 1.0 / solver.T
+        topo = resolve_transverse_topology(
+            solver.ham_info.param_ham, np.eye(3), solver.norb)
+        bad_green = solver.green0[:1]          # nblock=1, not 2
+        bad_tail = solver.green0_tail[:1]
+        with self.assertRaises(ValueError):
+            solver._run_transverse_bond_pipeline(
+                bad_green, bad_tail, beta, topo)
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+
+"""Production-side unit/structural tests for the master transverse bond
+topology (Phase W, Task 2 of
+``docs/superpowers/plans/2026-08-16-bond-transverse-phase-w.md``): pins
+``hwave.solver.bond_channels.TransverseTopology``,
+``resolve_transverse_topology``, ``iter_reversal_orbits``,
+``validate_topology_against_mesh`` and ``transverse_effective_activity``
+against the invariants of
+``docs/superpowers/specs/2026-08-15-bond-transverse-design.md`` ("The
+master transverse topology", "Canonical orbit rule", "Construction domain
+(binding for steps 2-3)").
+
+This module covers TOPOLOGY-ONLY ground: no ``W_pm_bond`` vertex and no
+bond bubble exist yet (Phase W Tasks 3/4) -- the ordered-record vertex
+equations themselves were already numerically validated against ED by gate
+W0 in ``tests/test_bond_transverse_ed.py`` (Task 1) and are NOT
+re-adjudicated here.
+
+Includes the carried Task-1-review finding's Hamiltonian-level normalization
+pin (``TestHamiltonianLevelNormalizationPin``): the topology's FILE ->
+COEFFS normalization is exercised independently of the (already-validated)
+vertex equations, because the "double-declaration trap" for density-density
+(commuting) operators -- declaring both ``C`` at ``R`` and ``conj(C)`` at
+``-R`` describes the SAME physical operator sum TWICE, so the correct total
+is ``2*Re(C)``, not ``C`` or ``2*C`` -- is a property of
+``resolve_transverse_topology`` alone, not of the vertex construction that
+consumes its output.
+
+Tests must be run from the repository root.
+"""
+
+import unittest
+
+import numpy as np
+
+from hwave.solver.bond_channels import (
+    TransverseTopology,
+    resolve_transverse_topology,
+    iter_reversal_orbits,
+    validate_topology_against_mesh,
+    transverse_effective_activity,
+)
+from tests import ed_oracle_util
+from tests.approx_util import ApproxTestCase
+
+
+def _topo(delta_r, reverse, coeffs=None, norb=1):
+    """Small helper: build a TransverseTopology directly (bypassing
+    resolve_transverse_topology) for tests that only care about the
+    NamedTuple's own invariants/consumers, not the resolver."""
+    B = len(delta_r)
+    if coeffs is None:
+        coeffs = {"CoulombInter": np.zeros((B, norb, norb), dtype=complex)}
+    return TransverseTopology(
+        delta_r=np.array(delta_r, dtype=int),
+        reverse=np.array(reverse, dtype=int),
+        coeffs=coeffs,
+    )
+
+
+# =============================================================================
+# TransverseTopology: construction-time invariants
+# =============================================================================
+
+class TestTransverseTopologyConstruction(ApproxTestCase):
+
+    def test_valid_construction_round_trips(self):
+        t = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1])
+        self.assertEqual(t.delta_r.shape, (3, 3))
+        self.assertEqual(t.reverse.tolist(), [0, 2, 1])
+        self.assertIn("CoulombInter", t.coeffs)
+
+    def test_delta_r_and_reverse_are_int_dtype(self):
+        t = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1])
+        self.assertTrue(np.issubdtype(t.delta_r.dtype, np.integer))
+        self.assertTrue(np.issubdtype(t.reverse.dtype, np.integer))
+
+    def test_arrays_are_read_only(self):
+        t = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1])
+        self.assertFalse(t.delta_r.flags.writeable)
+        self.assertFalse(t.reverse.flags.writeable)
+        for arr in t.coeffs.values():
+            self.assertFalse(arr.flags.writeable)
+        with self.assertRaises(ValueError):
+            t.delta_r[0, 0] = 5
+        with self.assertRaises(ValueError):
+            t.reverse[0] = 1
+        with self.assertRaises(ValueError):
+            t.coeffs["CoulombInter"][0, 0, 0] = 1.0
+
+    def test_alias_safety_input_mutation_does_not_leak(self):
+        dr = np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]])
+        rv = np.array([0, 2, 1])
+        co_arr = np.zeros((3, 1, 1), dtype=complex)
+        co = {"CoulombInter": co_arr}
+        t = TransverseTopology(delta_r=dr, reverse=rv, coeffs=co)
+        dr[1, 0] = 999
+        rv[1] = 0
+        co_arr[1, 0, 0] = 42.0
+        co["Ising"] = np.zeros((3, 1, 1), dtype=complex)  # mutate the dict
+        self.assertEqual(t.delta_r[1].tolist(), [1, 0, 0])
+        self.assertEqual(int(t.reverse[1]), 2)
+        self.assertApprox(t.coeffs["CoulombInter"][1, 0, 0], 0.0, abs=0)
+        self.assertNotIn("Ising", t.coeffs)
+
+    def test_channel_zero_must_be_origin(self):
+        with self.assertRaises(ValueError):
+            _topo([[1, 0, 0], [0, 0, 0]], [1, 0])
+
+    def test_reverse_must_be_involution(self):
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 1, 1])
+
+    def test_reverse_zero_must_be_zero(self):
+        # A hand-crafted, otherwise-involutive reverse array with
+        # reverse[0] != 0 must still be rejected -- channel 0 is defined to
+        # be its own reversal partner.
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [1, 0, 2])
+
+    def test_reverse_out_of_range_rejected(self):
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 5, 1])
+
+    def test_reverse_geometrically_inconsistent_with_delta_r_rejected(self):
+        # reverse[1] = 1 (involution-consistent, reverse[0]=0) but
+        # delta_r[1] = (1,0,0) so -delta_r[1] = (-1,0,0) != delta_r[1].
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 1, 2])
+
+    def test_closure_violation_rejected(self):
+        bad = {"CoulombInter": np.array(
+            [[[0]], [[1 + 2j]], [[9 + 9j]]], dtype=complex)}
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1], coeffs=bad)
+
+    def test_closure_holds_exactly_for_a_consistent_pair(self):
+        c = 0.4 - 0.3j
+        good = {"CoulombInter": np.array(
+            [[[0]], [[c]], [[np.conj(c)]]], dtype=complex)}
+        t = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1], coeffs=good)
+        self.assertApprox(
+            t.coeffs["CoulombInter"][t.reverse[1]][0, 0],
+            np.conj(t.coeffs["CoulombInter"][1][0, 0]), rel=0, abs=0)
+
+    def test_offsite_coeffs_nonzero_at_channel_zero_rejected(self):
+        bad = {"CoulombInter": np.array(
+            [[[5.0]], [[1.0]], [[1.0]]], dtype=complex)}
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1], coeffs=bad)
+
+    def test_channel_zero_coeffs_must_be_exactly_zero_not_just_small(self):
+        bad = {"CoulombInter": np.array(
+            [[[1e-30]], [[1.0]], [[1.0]]], dtype=complex)}
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1], coeffs=bad)
+
+    def test_non_integral_delta_r_rejected(self):
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1.5, 0, 0]], [0, 1])
+
+    def test_complex_delta_r_rejected(self):
+        with self.assertRaises(ValueError):
+            TransverseTopology(
+                delta_r=np.array([[0, 0, 0], [1j, 0, 0]]),
+                reverse=np.array([0, 1]), coeffs={})
+
+    def test_coeffs_wrong_channel_count_rejected(self):
+        bad = {"CoulombInter": np.zeros((2, 1, 1), dtype=complex)}
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1], coeffs=bad)
+
+    def test_coeffs_norb_mismatch_across_types_rejected(self):
+        bad = {
+            "CoulombInter": np.zeros((3, 1, 1), dtype=complex),
+            "Ising": np.zeros((3, 2, 2), dtype=complex),
+        }
+        with self.assertRaises(ValueError):
+            _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1], coeffs=bad)
+
+    def test_minimal_b1_topology_is_valid(self):
+        t = _topo([[0, 0, 0]], [0], coeffs={
+            "CoulombInter": np.zeros((1, 2, 2), dtype=complex)})
+        self.assertEqual(t.delta_r.shape, (1, 3))
+
+
+# =============================================================================
+# resolve_transverse_topology
+# =============================================================================
+
+class TestResolveTransverseTopology(ApproxTestCase):
+
+    def test_no_interactions_gives_b1_zero_topology(self):
+        topo = resolve_transverse_topology({}, np.eye(3), norb=2)
+        self.assertEqual(topo.delta_r.shape, (1, 3))
+        self.assertEqual(topo.delta_r[0].tolist(), [0, 0, 0])
+        self.assertEqual(sorted(topo.coeffs.keys()),
+                          ["CoulombInter", "Exchange", "Ising"])
+        for arr in topo.coeffs.values():
+            self.assertTrue(np.all(arr == 0))
+
+    def test_hund_and_pairlift_contribute_no_shells(self):
+        interactions = {
+            "Hund": {((1, 0, 0), (0, 0)): 0.7},
+            "PairLift": {((1, 0, 0), (0, 0)): 0.3},
+        }
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        self.assertEqual(topo.delta_r.shape, (1, 3))
+        self.assertFalse(transverse_effective_activity(topo))
+
+    def test_missing_type_key_treated_as_empty(self):
+        # Only CoulombInter present; Ising/Exchange absent entirely.
+        interactions = {"CoulombInter": {((1, 0, 0), (0, 0)): 0.2}}
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        self.assertIn("Ising", topo.coeffs)
+        self.assertIn("Exchange", topo.coeffs)
+        self.assertTrue(np.all(topo.coeffs["Ising"] == 0))
+        self.assertTrue(np.all(topo.coeffs["Exchange"] == 0))
+
+    def test_onsite_entries_of_active_types_are_ignored(self):
+        # On-site (R=0) CoulombInter/Ising/Exchange declarations never
+        # become a topology channel (spec: "coeffs carry OFF-SITE channels
+        # only").
+        interactions = {
+            "CoulombInter": {((0, 0, 0), (0, 0)): 5.0},
+            "Ising": {((0, 0, 0), (0, 0)): 3.0},
+        }
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        self.assertEqual(topo.delta_r.shape, (1, 3))
+
+    def test_union_of_shells_across_types(self):
+        # CoulombInter declares a +/-x shell only; Ising declares a
+        # DIFFERENT +/-y shell only; the union must carry BOTH, and each
+        # type's coeffs must be zero on the shell it didn't declare.
+        interactions = {
+            "CoulombInter": {((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2},
+            "Ising": {((0, 1, 0), (0, 0)): 0.5, ((0, -1, 0), (0, 0)): 0.5},
+        }
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        self.assertEqual(topo.delta_r.shape, (5, 3))  # 0 + 2 (+-x) + 2 (+-y)
+        drs = [tuple(int(x) for x in r) for r in topo.delta_r]
+        for m, dr in enumerate(drs):
+            ci = topo.coeffs["CoulombInter"][m, 0, 0]
+            ising = topo.coeffs["Ising"][m, 0, 0]
+            if dr in ((1, 0, 0), (-1, 0, 0)):
+                self.assertApprox(ci, 0.2, rel=0, abs=1e-13)
+                self.assertApprox(ising, 0.0, rel=0, abs=0)
+            elif dr in ((0, 1, 0), (0, -1, 0)):
+                self.assertApprox(ci, 0.0, rel=0, abs=0)
+                self.assertApprox(ising, 0.5, rel=0, abs=1e-13)
+            else:
+                self.assertApprox(ci, 0.0, rel=0, abs=0)
+                self.assertApprox(ising, 0.0, rel=0, abs=0)
+
+    def test_channel_ordering_zero_first_then_shells_by_length_then_lex(self):
+        interactions = {
+            "CoulombInter": {
+                ((2, 0, 0), (0, 0)): 0.1, ((-2, 0, 0), (0, 0)): 0.1,
+                ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2,
+            },
+        }
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        drs = [tuple(int(x) for x in r) for r in topo.delta_r]
+        self.assertEqual(drs[0], (0, 0, 0))
+        # shell 1 (length 1) before shell 2 (length 2); within a shell,
+        # lexicographic irvec order (matching resolve_interactions).
+        self.assertEqual(drs, [(0, 0, 0), (-1, 0, 0), (1, 0, 0),
+                                (-2, 0, 0), (2, 0, 0)])
+
+    def test_max_shells_truncates_whole_shells(self):
+        interactions = {
+            "CoulombInter": {
+                ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2,
+                ((2, 0, 0), (0, 0)): 0.1, ((-2, 0, 0), (0, 0)): 0.1,
+            },
+        }
+        topo = resolve_transverse_topology(
+            interactions, np.eye(3), norb=1, max_shells=1)
+        self.assertEqual(topo.delta_r.shape, (3, 3))  # 0 + 1 shell (+-x, len1)
+        drs = {tuple(int(x) for x in r) for r in topo.delta_r}
+        self.assertEqual(drs, {(0, 0, 0), (1, 0, 0), (-1, 0, 0)})
+
+    def test_max_shells_zero_keeps_only_channel_zero(self):
+        interactions = {"CoulombInter": {((1, 0, 0), (0, 0)): 0.2}}
+        topo = resolve_transverse_topology(
+            interactions, np.eye(3), norb=1, max_shells=0)
+        self.assertEqual(topo.delta_r.shape, (1, 3))
+        self.assertFalse(transverse_effective_activity(topo))
+
+    def test_max_shells_negative_rejected(self):
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology({}, np.eye(3), norb=1, max_shells=-1)
+
+    def test_max_shells_non_integral_rejected(self):
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology({}, np.eye(3), norb=1, max_shells=1.5)
+
+    def test_mirrored_declaration_consistent_projects_to_conjugate_average(self):
+        c1 = 0.4 + 0.1j
+        c2 = np.conj(c1)  # exactly consistent mirrored pair
+        interactions = {"CoulombInter": {
+            ((1, 0, 0), (0, 0)): c1, ((-1, 0, 0), (0, 0)): c2}}
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        m1 = [i for i, r in enumerate(topo.delta_r)
+              if tuple(int(x) for x in r) == (1, 0, 0)][0]
+        self.assertApprox(topo.coeffs["CoulombInter"][m1, 0, 0], c1,
+                           rel=0, abs=1e-13)
+
+    def test_mirrored_declaration_inconsistent_raises(self):
+        interactions = {"CoulombInter": {
+            ((1, 0, 0), (0, 0)): 1.0 + 0.0j,
+            ((-1, 0, 0), (0, 0)): -1.0 + 0.0j,  # not conj(1.0) = 1.0
+        }}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_single_direction_declaration_synthesizes_conjugate_partner(self):
+        c = 0.25 - 0.15j
+        interactions = {"CoulombInter": {((1, 0, 0), (0, 0)): c}}
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        m_pos = [i for i, r in enumerate(topo.delta_r)
+                  if tuple(int(x) for x in r) == (1, 0, 0)][0]
+        m_neg = int(topo.reverse[m_pos])
+        self.assertApprox(topo.coeffs["CoulombInter"][m_pos, 0, 0], c,
+                           rel=0, abs=1e-13)
+        self.assertApprox(topo.coeffs["CoulombInter"][m_neg, 0, 0],
+                           np.conj(c), rel=0, abs=1e-13)
+
+    def test_coeffs_additive_under_pre_summed_declaration(self):
+        # "duplicate accumulation": a caller that pre-sums two logical
+        # contributions into ONE dict entry (the only way a duplicate
+        # (irvec, orbvec) key can arise -- a plain dict cannot hold two
+        # entries under the identical key) must see the topology's coeffs
+        # equal the LINEAR sum of what each contribution alone would give
+        # (resolve_transverse_topology's closure is linear in the declared
+        # value; this pins that no int-truncation/dedup logic sneaks in).
+        v1, v2 = 0.11 + 0.02j, -0.05 + 0.07j
+        topo1 = resolve_transverse_topology(
+            {"CoulombInter": {((1, 0, 0), (0, 0)): v1}}, np.eye(3), norb=1)
+        topo2 = resolve_transverse_topology(
+            {"CoulombInter": {((1, 0, 0), (0, 0)): v2}}, np.eye(3), norb=1)
+        topo_sum = resolve_transverse_topology(
+            {"CoulombInter": {((1, 0, 0), (0, 0)): v1 + v2}},
+            np.eye(3), norb=1)
+        self.assertApproxArray(
+            topo_sum.coeffs["CoulombInter"],
+            topo1.coeffs["CoulombInter"] + topo2.coeffs["CoulombInter"],
+            rel=0, abs=1e-13)
+
+    def test_multi_orbital_shape(self):
+        interactions = {"Exchange": {((1, 0, 0), (0, 1)): 0.3 + 0.1j}}
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=2)
+        self.assertEqual(topo.coeffs["Exchange"].shape, (3, 2, 2))
+
+    def test_norb_must_be_positive(self):
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology({}, np.eye(3), norb=0)
+
+
+# =============================================================================
+# iter_reversal_orbits
+# =============================================================================
+
+class TestIterReversalOrbits(ApproxTestCase):
+
+    def test_singleton_orbit_at_onsite_diagonal(self):
+        topo = _topo([[0, 0, 0]], [0], coeffs={
+            "CoulombInter": np.zeros((1, 1, 1), dtype=complex)})
+        orbits = iter_reversal_orbits(topo)
+        self.assertEqual(orbits, [(0, 0, 0)])
+
+    def test_onsite_off_diagonal_pairs(self):
+        topo = _topo([[0, 0, 0]], [0], coeffs={
+            "CoulombInter": np.zeros((1, 2, 2), dtype=complex)})
+        orbits = set(iter_reversal_orbits(topo))
+        # (0,0,0) and (0,1,1) singletons; (0,0,1)/(0,1,0) one representative.
+        self.assertIn((0, 0, 0), orbits)
+        self.assertIn((0, 1, 1), orbits)
+        self.assertEqual(len(orbits & {(0, 0, 1), (0, 1, 0)}), 1)
+        self.assertEqual(len(orbits), 3)
+
+    def test_offsite_orbit_representative_is_tuple_minimum(self):
+        topo = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1],
+                      coeffs={"CoulombInter": np.zeros((3, 1, 1), dtype=complex)})
+        orbits = iter_reversal_orbits(topo)
+        self.assertIn((1, 0, 0), orbits)
+        self.assertNotIn((2, 0, 0), orbits)
+
+    def test_offsite_multi_orbital_orbit_count(self):
+        # B=3 (0, +1, -1), norb=2: total (m,a,b) triples = 3*4=12; orbits =
+        # 12/2 (every off-site pair is non-singleton since m != reverse[m]
+        # there) except channel 0's 4 own (m,a,b) entries collapse to
+        # 2 singletons ((0,0,0),(0,1,1)) + 1 pair -- 3 orbits there, plus
+        # (12-4)/2 = 4 off-site orbits => 7 total.
+        topo = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1],
+                      coeffs={"CoulombInter": np.zeros((3, 2, 2), dtype=complex)})
+        orbits = iter_reversal_orbits(topo)
+        self.assertEqual(len(orbits), 7)
+        self.assertEqual(len(orbits), len(set(orbits)))
+
+    def test_covers_every_channel_orbital_pair_exactly_once(self):
+        topo = _topo([[0, 0, 0], [1, 0, 0], [-1, 0, 0]], [0, 2, 1],
+                      coeffs={"CoulombInter": np.zeros((3, 2, 2), dtype=complex)})
+        reverse = topo.reverse
+        seen = set()
+        for (m, a, b) in iter_reversal_orbits(topo):
+            key1, key2 = (m, a, b), (int(reverse[m]), b, a)
+            self.assertNotIn(key1, seen)
+            self.assertNotIn(key2, seen)
+            seen.add(key1)
+            seen.add(key2)
+        self.assertEqual(len(seen), 3 * 2 * 2)
+
+    def test_empty_coeffs_raises(self):
+        t = TransverseTopology(
+            delta_r=np.array([[0, 0, 0]]), reverse=np.array([0]), coeffs={})
+        with self.assertRaises(ValueError):
+            iter_reversal_orbits(t)
+
+    def test_deterministic_and_matches_resolver_output(self):
+        interactions = {"CoulombInter": {
+            ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2}}
+        topo = resolve_transverse_topology(interactions, np.eye(3), norb=1)
+        orbits_a = iter_reversal_orbits(topo)
+        orbits_b = iter_reversal_orbits(topo)
+        self.assertEqual(orbits_a, orbits_b)
+
+
+# =============================================================================
+# validate_topology_against_mesh
+# =============================================================================
+
+class TestValidateTopologyAgainstMesh(ApproxTestCase):
+
+    def _topo_1d(self, r_list):
+        """B-channel topology on a 1D chain (y=z=0), delta_r = [(0,0,0)] +
+        [(r,0,0) for r in r_list], with a valid reverse permutation
+        (assumes r_list is already closed under negation, distinct)."""
+        delta_r = [(0, 0, 0)] + [(r, 0, 0) for r in r_list]
+        index_of = {dr: i for i, dr in enumerate(delta_r)}
+        reverse = [index_of[(-dr[0], 0, 0)] for dr in delta_r]
+        return _topo(delta_r, reverse, coeffs={
+            "CoulombInter": np.zeros((len(delta_r), 1, 1), dtype=complex)})
+
+    def test_valid_shape_passes(self):
+        topo = self._topo_1d([1, -1])
+        validate_topology_against_mesh(topo, (5, 5, 5))  # no raise
+
+    def test_spatial_shape_wrong_length_rejected(self):
+        topo = self._topo_1d([1, -1])
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(topo, (5, 5))
+
+    def test_spatial_shape_non_positive_rejected(self):
+        topo = self._topo_1d([1, -1])
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(topo, (5, 0, 5))
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(topo, (-1, 5, 5))
+
+    def test_spatial_shape_non_integral_rejected(self):
+        topo = self._topo_1d([1, -1])
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(topo, (5.5, 5, 5))
+
+    def test_spatial_shape_not_a_sequence_rejected(self):
+        topo = self._topo_1d([1, -1])
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(topo, 5)
+
+    def test_rectangular_mesh_no_collision(self):
+        # delta_r along x only; Ny, Nz irrelevant to the x-axis wrap.
+        topo = self._topo_1d([1, -1])
+        validate_topology_against_mesh(topo, (8, 3, 2))  # no raise
+
+    def test_r_vs_r_plus_l_collision_across_shells(self):
+        # R=1 (shell length 1) and R=6 (shell length 6) collide mod L=5 on
+        # the x-axis -- a genuine cross-shell alias.
+        topo = self._topo_1d([1, -1, 6, -6])
+        with self.assertRaises(ValueError) as cm:
+            validate_topology_against_mesh(topo, (5, 5, 5))
+        msg = str(cm.exception)
+        self.assertIn("5, 5, 5", msg)
+
+    def test_even_mesh_self_reversal_collision_within_shell(self):
+        # R=+3 and R=-3 (SAME shell, length 3) alias on an even mesh Nx=6
+        # only if 3 == -3 mod 6, i.e. 3 == 3 -- true; this is the
+        # canonical "+L/2 == -L/2" alias.
+        topo = self._topo_1d([3, -3])
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(topo, (6, 4, 4))
+
+    def test_even_mesh_self_reversal_does_not_collide_off_the_edge(self):
+        # The SAME +/-3 pair does NOT alias on an odd/larger mesh.
+        topo = self._topo_1d([3, -3])
+        validate_topology_against_mesh(topo, (8, 4, 4))  # no raise
+
+    def test_valid_noncolliding_reverse_pair_multiple_shells(self):
+        topo = self._topo_1d([1, -1, 2, -2])
+        validate_topology_against_mesh(topo, (9, 9, 9))  # no raise
+
+    def test_error_names_both_channels_and_mesh(self):
+        topo = self._topo_1d([1, -1, 6, -6])
+        with self.assertRaises(ValueError) as cm:
+            validate_topology_against_mesh(topo, (5, 5, 5))
+        msg = str(cm.exception)
+        # both offending raw delta_r values must be named
+        self.assertIn("(1, 0, 0)", msg)
+        self.assertIn("(6, 0, 0)", msg)
+
+    def test_arrays_nvol_mismatch_rejected(self):
+        # mesh (5, 3, 4): large enough on x that +/-1 does not itself alias
+        # (unlike (2, 3, 4), where Nx=2 would trigger the even-mesh
+        # self-reversal collision this test is not about).
+        topo = self._topo_1d([1, -1])
+        good = np.zeros((5 * 3 * 4, 5))
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(
+                topo, (5, 3, 4), arrays={"green": np.zeros((99, 5))})
+        validate_topology_against_mesh(
+            topo, (5, 3, 4), arrays={"green": good})  # no raise
+
+    def test_stale_topology_alias_revalidated(self):
+        # Directly poke a topology's coeffs dict (mutable container, even
+        # though its arrays are read-only) to break the closure invariant,
+        # then confirm validate_topology_against_mesh -- as a consumer
+        # boundary -- catches it rather than trusting the alias.
+        topo = self._topo_1d([1, -1])
+        broken = dict(topo.coeffs)
+        broken["CoulombInter"] = np.array(
+            [[[0]], [[1 + 2j]], [[9 + 9j]]], dtype=complex)
+        bad_topo = topo._replace(coeffs=broken)
+        with self.assertRaises(ValueError):
+            validate_topology_against_mesh(bad_topo, (5, 5, 5))
+
+
+# =============================================================================
+# transverse_effective_activity
+# =============================================================================
+
+class TestTransverseEffectiveActivity(ApproxTestCase):
+
+    def test_all_zero_topology_is_inactive(self):
+        topo = resolve_transverse_topology({}, np.eye(3), norb=2)
+        self.assertFalse(transverse_effective_activity(topo))
+
+    def test_nonzero_coulomb_inter_is_active(self):
+        topo = resolve_transverse_topology(
+            {"CoulombInter": {((1, 0, 0), (0, 0)): 0.1}}, np.eye(3), norb=1)
+        self.assertTrue(transverse_effective_activity(topo))
+
+    def test_nonzero_ising_is_active(self):
+        topo = resolve_transverse_topology(
+            {"Ising": {((1, 0, 0), (0, 0)): 0.1}}, np.eye(3), norb=1)
+        self.assertTrue(transverse_effective_activity(topo))
+
+    def test_nonzero_exchange_is_active(self):
+        topo = resolve_transverse_topology(
+            {"Exchange": {((1, 0, 0), (0, 0)): 0.1 + 0.05j}}, np.eye(3), norb=1)
+        self.assertTrue(transverse_effective_activity(topo))
+
+    def test_only_hund_pairlift_is_inactive(self):
+        topo = resolve_transverse_topology(
+            {"Hund": {((1, 0, 0), (0, 0)): 0.7},
+             "PairLift": {((1, 0, 0), (0, 0)): 0.3}}, np.eye(3), norb=1)
+        self.assertFalse(transverse_effective_activity(topo))
+
+    def test_mirrored_pair_that_cancels_to_zero_real_part_is_inactive(self):
+        # C at R and -conj(C) at -R (an ANTI-Hermitian-style declared pair)
+        # is rejected by the resolver's consistency check UNLESS the
+        # resulting Re() genuinely vanishes; use a purely-imaginary C whose
+        # conjugate pair is consistent AND whose closed representative
+        # happens to be pinned at a value with zero real part by
+        # construction of THIS test (declare only one direction with a
+        # purely real coefficient of 0.0 explicitly, the simplest exact
+        # zero case distinct from "not declared at all").
+        topo = resolve_transverse_topology(
+            {"CoulombInter": {((1, 0, 0), (0, 0)): 0.0}}, np.eye(3), norb=1)
+        self.assertFalse(transverse_effective_activity(topo))
+
+
+# =============================================================================
+# Hamiltonian-level normalization pin (carried Task-1 review finding)
+# =============================================================================
+
+def _manual_physical_coeff(raw, irvec, a, b):
+    """Independent (no topology/resolver code involved) computation of the
+    TRUE physical Hamiltonian coefficient of the single Hermitian
+    density-density operator class {(irvec, a, b), (-irvec, b, a)} from
+    raw file-format declarations -- the "double-declaration trap" the
+    carried Task-1 review finding describes: n_{j,a} n_{j+irvec,b} summed
+    over j is IDENTICAL, as an operator, to n_{j,b} n_{j-irvec,a} summed
+    over j (density operators commute; re-index j' = j - irvec), so a
+    declared pair (C at irvec, C' at -irvec with swapped orbitals) both
+    multiply the SAME operator and their physical total is C + C' (which
+    reduces to C + conj(C) = 2*Re(C) when only one direction is declared
+    and the other is implied by Hermiticity)."""
+    neg = tuple(-x for x in irvec)
+    c_fwd = raw.get((irvec, (a, b)))
+    c_bwd = raw.get((neg, (b, a)))
+    if c_fwd is not None and c_bwd is not None:
+        return c_fwd + c_bwd
+    if c_fwd is not None:
+        return c_fwd + np.conj(c_fwd)
+    if c_bwd is not None:
+        return c_bwd + np.conj(c_bwd)
+    return 0.0 + 0.0j
+
+
+def _h_from_topology(fx, topo, type_name):
+    """Build the exact many-body H that `topo.coeffs[type_name]` implies,
+    via `iter_reversal_orbits` (restricted to the off-site domain, per the
+    spec's "Construction domain") and `canonical_density_terms`. Every
+    off-site orbit contributes `2*Re(coeffs[m][a,b])` on its single
+    Hermitian operator class, matching `bare_bond_vertices`'s own
+    documented "V_ab(R_m) + V_ba(-R_m) == 2*Re(v_bond[m][a,b])" derivation
+    (this module's Finding-1 comment, reproduced structurally for the
+    transverse coeffs)."""
+    pairs = []
+    for (m, a, b) in iter_reversal_orbits(topo):
+        if m == 0:
+            continue
+        coeff = 2.0 * np.real(topo.coeffs[type_name][m, a, b])
+        if coeff == 0.0:
+            continue
+        R = int(topo.delta_r[m][0])
+        pairs.append((a, b, R, coeff))
+    terms = ed_oracle_util.canonical_density_terms(fx, pairs)
+    return ed_oracle_util.h_int_from_terms(fx, terms)
+
+
+def _h_from_raw(fx, raw, irvec_ab_pairs):
+    """Build the SAME many-body H directly from raw declarations, via
+    `_manual_physical_coeff` (independent of the topology/resolver code
+    under test)."""
+    pairs = []
+    for (irvec, a, b) in irvec_ab_pairs:
+        coeff = _manual_physical_coeff(raw, irvec, a, b)
+        R = irvec[0]
+        pairs.append((a, b, R, coeff))
+    terms = ed_oracle_util.canonical_density_terms(fx, pairs)
+    return ed_oracle_util.h_int_from_terms(fx, terms)
+
+
+class TestHamiltonianLevelNormalizationPin(ApproxTestCase):
+    """Pins resolve_transverse_topology's FILE -> COEFFS normalization at
+    the exact many-body Hamiltonian level, per the carried Task-1 review
+    finding: build a tiny fixture's exact H from raw declarations two
+    ways -- via the topology's coeffs reconstruction
+    (`_h_from_topology`) and via an independent direct construction
+    (`_h_from_raw`) -- and assert equality. Covers mirrored-pair
+    declarations, single-direction declarations and duplicate
+    accumulation, for CoulombInter (density-density/cross-family) and
+    Ising (also density-density)."""
+
+    def _fixture(self):
+        # L=2, norb=2 chain -- the SAME fixture shape
+        # test_offsite_exchange_term_builder_matches_dense_hamiltonian uses
+        # (tests/test_bond_transverse_ed.py), so this pin sits on an
+        # independently-established-tractable dense (dim=256) footing.
+        return ed_oracle_util.EDFixture(
+            L=2, norb=2,
+            t={(0, 0): 0.3, (1, 1): 0.2, (0, 1): 0.1, (1, 0): 0.1},
+            eps=(0.05, -0.02), T=0.5, mu=0.1)
+
+    def test_single_direction_declaration(self):
+        fx = self._fixture()
+        c = 0.3 + 0.2j
+        raw = {((1, 0, 0), (0, 1)): c}
+        topo = resolve_transverse_topology(
+            {"CoulombInter": raw}, np.eye(3), norb=2)
+        with np.errstate(all="ignore"):
+            H_topo = _h_from_topology(fx, topo, "CoulombInter")
+            H_raw = _h_from_raw(fx, raw, [((1, 0, 0), 0, 1)])
+        self.assertApproxArray(H_topo, H_raw, rel=0, abs=1e-13)
+        # sanity: genuinely nonzero (not a PASS-ZERO false positive)
+        self.assertGreater(float(np.max(np.abs(H_topo))), 1e-6)
+
+    def test_mirrored_pair_declaration_consistent(self):
+        fx = self._fixture()
+        c1 = 0.3 + 0.2j
+        c2 = np.conj(c1)
+        raw = {((1, 0, 0), (0, 1)): c1, ((-1, 0, 0), (1, 0)): c2}
+        topo = resolve_transverse_topology(
+            {"CoulombInter": raw}, np.eye(3), norb=2)
+        with np.errstate(all="ignore"):
+            H_topo = _h_from_topology(fx, topo, "CoulombInter")
+            H_raw = _h_from_raw(fx, raw, [((1, 0, 0), 0, 1)])
+        self.assertApproxArray(H_topo, H_raw, rel=0, abs=1e-13)
+
+    def test_mirrored_pair_null_direction_epsilon(self):
+        # The historical Finding-1 regression pattern: a near-Hermitian
+        # +-i*eps closed pair meant to represent ONE real coupling V; the
+        # diagonal must carry Re(.) only, never leak the imaginary part.
+        V, eps = 0.4, 1e-3
+        fx = self._fixture()
+        raw = {((1, 0, 0), (0, 0)): V + 1j * eps,
+               ((-1, 0, 0), (0, 0)): V - 1j * eps}
+        topo = resolve_transverse_topology(
+            {"CoulombInter": raw}, np.eye(3), norb=2)
+        with np.errstate(all="ignore"):
+            H_topo = _h_from_topology(fx, topo, "CoulombInter")
+            H_raw = _h_from_raw(fx, raw, [((1, 0, 0), 0, 0)])
+        self.assertApproxArray(H_topo, H_raw, rel=0, abs=1e-13)
+        # The stored per-channel coeff need not itself be real (it equals
+        # the exactly-self-consistent declared value V+i*eps here, same as
+        # resolve_interactions' v_bond) -- what must hold is that its
+        # DOWNSTREAM physical reconstruction (2*Re(.), what
+        # bare_bond_vertices/_h_from_topology actually use) is the real
+        # 2V, with eps never leaking into it.
+        m1 = [i for i, r in enumerate(topo.delta_r)
+              if tuple(int(x) for x in r) == (1, 0, 0)][0]
+        self.assertApprox(
+            2.0 * np.real(topo.coeffs["CoulombInter"][m1, 0, 0]), 2.0 * V,
+            rel=0, abs=1e-13)
+
+    def test_duplicate_accumulation_presummed_declaration(self):
+        # "duplicate accumulation": the raw dict entry already carries the
+        # SUM of two logical contributions (the only way a duplicate
+        # (irvec, orbvec) key can arise at all -- see
+        # resolve_transverse_topology's own docstring / carried finding).
+        v1, v2 = 0.11 + 0.02j, -0.05 + 0.07j
+        fx = self._fixture()
+        raw_summed = {((1, 0, 0), (0, 1)): v1 + v2}
+        topo = resolve_transverse_topology(
+            {"CoulombInter": raw_summed}, np.eye(3), norb=2)
+        with np.errstate(all="ignore"):
+            H_topo = _h_from_topology(fx, topo, "CoulombInter")
+            H_raw = _h_from_raw(fx, raw_summed, [((1, 0, 0), 0, 1)])
+            # cross-check: separately declaring v1 and v2 and summing the
+            # two resulting Hamiltonians independently reproduces the SAME
+            # H (the "duplicate" really did accumulate additively).
+            H_v1 = _h_from_raw(fx, {((1, 0, 0), (0, 1)): v1},
+                                [((1, 0, 0), 0, 1)])
+            H_v2 = _h_from_raw(fx, {((1, 0, 0), (0, 1)): v2},
+                                [((1, 0, 0), 0, 1)])
+        self.assertApproxArray(H_topo, H_raw, rel=0, abs=1e-13)
+        self.assertApproxArray(H_raw, H_v1 + H_v2, rel=0, abs=1e-13)
+
+    def test_ising_single_direction_declaration(self):
+        fx = self._fixture()
+        v = 0.37
+        raw = {((1, 0, 0), (0, 0)): v}
+        topo = resolve_transverse_topology(
+            {"Ising": raw}, np.eye(3), norb=2)
+        with np.errstate(all="ignore"):
+            H_topo = _h_from_topology(fx, topo, "Ising")
+            H_raw = _h_from_raw(fx, raw, [((1, 0, 0), 0, 0)])
+        self.assertApproxArray(H_topo, H_raw, rel=0, abs=1e-13)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -42,6 +42,7 @@ import unittest
 import numpy as np
 
 from hwave import sc as _sc
+from hwave.solver import bubble as bubble_mod
 from hwave.solver.bond_channels import (
     TransverseTopology,
     resolve_transverse_topology,
@@ -1211,6 +1212,155 @@ class TestWPmBondValidation(ApproxTestCase):
         bad = np.zeros((6, 2, 2, 2, 3), dtype=complex)
         with self.assertRaises(ValueError):
             W_pm_bond(topo, bad, spatial_shape=(3, 2, 1))
+
+
+# =============================================================================
+# transverse_bond_bubble_static (Phase W, Task 4)
+# =============================================================================
+#
+# Production tests for hwave.solver.bubble.transverse_bond_bubble_static:
+# the static (Omega=0) cross-block bond bubble with the amended
+# fwd=block1(down)/rev=block0(up) role contract. The load-bearing pin is
+# the V=0 near-machine comparison against tests/test_bond_transverse_ed.py's
+# H3 test-local free transverse bond bubble (_transverse_bond_bubble_free,
+# imported module-qualified as `_ted`): both sides compose the SAME
+# production primitives (bubble._prepare_dense / bubble._bond_pair_full_block)
+# with the SAME committed block roles, so agreement is expected at
+# near-machine precision (not merely Richardson-extrapolated ED precision,
+# which is what H3 itself measures against the ED oracle).
+
+
+def _transverse_topo_1d(delta_r_1d, reverse, norb):
+    """Build a TransverseTopology whose delta_r is the 1-D ring list
+    ``delta_r_1d`` (y=z=0 for every channel), for feeding
+    ``transverse_bond_bubble_static`` -- only ``delta_r``/``reverse``
+    matter to the bubble (``coeffs`` belongs to the VERTEX, W_pm_bond,
+    not the bubble); zero-filled coeffs trivially satisfy
+    TransverseTopology's Hermitian-closure invariant."""
+    B = len(delta_r_1d)
+    delta_r = np.zeros((B, 3), dtype=int)
+    delta_r[:, 0] = delta_r_1d
+    coeffs = {"CoulombInter": np.zeros((B, norb, norb), dtype=complex)}
+    return TransverseTopology(
+        delta_r=delta_r, reverse=np.array(reverse, dtype=int),
+        coeffs=coeffs)
+
+
+class TestTransverseBondBubbleStaticVZeroPin(ApproxTestCase):
+    """The V=0 near-machine pin (spec: "The bond bubble (static)"; plan
+    Task 4): ``transverse_bond_bubble_static`` must reproduce
+    ``tests/test_bond_transverse_ed.py``'s ``_transverse_bond_bubble_free``
+    -- the Phase-H test-local free transverse bond bubble that committed
+    the SAME fwd=down/rev=up roles -- at
+    ``assert_approx_array(rel=1e-12, abs=1e-13)``, INCLUDING off-diagonal
+    ``(m, m')`` cells (both fixtures use the full channel grid, not just
+    the diagonal) and the Zeeman-split case (``G_up != G_dn`` -- both
+    fixtures below carry a nonzero ``hz``, the same requirement H3's own
+    docstring states: a spin-symmetric fixture cannot distinguish the two
+    role conventions)."""
+
+    def _check(self, fx, hz, delta_r_1d, reverse, norb, nmat=32):
+        green_kw = _ted._h3_free_two_block_green(fx, hz, nmat)
+        spatial_shape = (fx.L, 1, 1)
+        want = _ted._transverse_bond_bubble_free(
+            green_kw, fx.beta, delta_r_1d, norb, spatial_shape)
+        topo = _transverse_topo_1d(delta_r_1d, reverse, norb)
+        got = bubble_mod.transverse_bond_bubble_static(
+            green_kw, None, fx.beta, topo, spatial_shape=spatial_shape)
+        assert_approx_array(got, want, rel=1e-12, abs=1e-13)
+        return got, want
+
+    def test_norb1_odd_ring_full_channel_grid(self):
+        """L=5 ring (odd), norb=1, complex hopping, Zeeman split;
+        channels R in {0, +-1, +-2} -- the full 5x5 channel grid,
+        exercising every off-diagonal (m, m') cell on an odd ring where R
+        and -R are genuinely distinct wrapped channels (mirrors H3's own
+        norb=1 fixture)."""
+        t = 0.7 * np.exp(0.3j)
+        fx = ed_oracle_util.EDFixture(
+            L=5, norb=1, t={(0, 0): t}, eps=(0.0,), T=0.5, mu=0.2)
+        Rs = [0, 1, -1, 2, -2]
+        reverse = [0, 2, 1, 4, 3]
+        self._check(fx, 0.15, Rs, reverse, 1)
+
+    def test_norb2_orbital_swap(self):
+        """L=3 ring (odd; see H3's scope note on ED tractability), norb=2,
+        genuine inter-orbital complex hop, Zeeman split; channels R in
+        {0, +-1} -- the multi-orbital off-diagonal (m, m') variant
+        (mirrors H3's own norb=2 fixture)."""
+        t = {(0, 0): 0.6 + 0.2j, (1, 1): 0.4 - 0.1j,
+             (0, 1): 0.15 + 0.05j, (1, 0): 0.15 + 0.05j}
+        fx = ed_oracle_util.EDFixture(
+            L=3, norb=2, t=t, eps=(0.05, -0.03), T=0.4, mu=0.1)
+        Rs = [0, 1, -1]
+        reverse = [0, 2, 1]
+        self._check(fx, 0.12, Rs, reverse, 2)
+
+
+class TestTransverseBondBubbleStaticTailEquivalence(ApproxTestCase):
+    """``green0_tail=None`` must be numerically equivalent to an explicit
+    all-zeros tail array of the same shape/dtype (mirrors
+    ``TestBubbleOldVsNewBondStatic``'s/the longitudinal path's own
+    None-vs-zeros pin in ``tests/test_bubble_kernel.py``) --
+    ``assert_approx_array(rel=0, abs=1e-15)``."""
+
+    def test_none_tail_matches_zero_tail_array(self):
+        fx = ed_oracle_util.EDFixture(
+            L=4, norb=1, t={(0, 0): 0.5 + 0.1j}, eps=(0.0,), T=0.6, mu=0.1)
+        nmat = 16
+        green_kw = _ted._h3_free_two_block_green(fx, 0.2, nmat)
+        spatial_shape = (fx.L, 1, 1)
+        topo = _transverse_topo_1d([0, 1, -1], [0, 2, 1], 1)
+
+        zero_tail = np.zeros_like(green_kw)
+        got_none = bubble_mod.transverse_bond_bubble_static(
+            green_kw, None, fx.beta, topo, spatial_shape=spatial_shape)
+        got_zero = bubble_mod.transverse_bond_bubble_static(
+            green_kw, zero_tail, fx.beta, topo, spatial_shape=spatial_shape)
+        assert_approx_array(got_zero, got_none, rel=0, abs=1e-15)
+
+
+class TestTransverseBondBubbleStaticValidation(ApproxTestCase):
+    """Entry-point validation: ``nblock != 2``, odd ``nmat``, and a
+    mesh-colliding topology are all rejected with ``ValueError`` before
+    any FFT work runs."""
+
+    def _small_green(self, nblock, nmat, L=4):
+        rng = np.random.default_rng(3)
+        shape = (nblock, nmat, L, 1, 1)
+        return (rng.normal(size=shape) + 1j * rng.normal(size=shape))
+
+    def test_rejects_nblock_1(self):
+        green_kw = self._small_green(1, 8)
+        topo = _transverse_topo_1d([0, 1, -1], [0, 2, 1], 1)
+        with self.assertRaises(ValueError):
+            bubble_mod.transverse_bond_bubble_static(
+                green_kw, None, 1.0, topo, spatial_shape=(4, 1, 1))
+
+    def test_rejects_nblock_3(self):
+        green_kw = self._small_green(3, 8)
+        topo = _transverse_topo_1d([0, 1, -1], [0, 2, 1], 1)
+        with self.assertRaises(ValueError):
+            bubble_mod.transverse_bond_bubble_static(
+                green_kw, None, 1.0, topo, spatial_shape=(4, 1, 1))
+
+    def test_rejects_odd_nmat(self):
+        green_kw = self._small_green(2, 7)
+        topo = _transverse_topo_1d([0, 1, -1], [0, 2, 1], 1)
+        with self.assertRaises(ValueError):
+            bubble_mod.transverse_bond_bubble_static(
+                green_kw, None, 1.0, topo, spatial_shape=(4, 1, 1))
+
+    def test_mesh_collision_raises(self):
+        # +2 == -2 mod 4 -- the canonical even-mesh self-reversal alias.
+        green_kw = self._small_green(2, 8, L=4)
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0], [2, 0, 0], [-2, 0, 0]]),
+            reverse=np.array([0, 2, 1]),
+            coeffs={"CoulombInter": np.zeros((3, 1, 1), dtype=complex)})
+        with self.assertRaises(ValueError):
+            bubble_mod.transverse_bond_bubble_static(
+                green_kw, None, 1.0, topo, spatial_shape=(4, 1, 1))
 
 
 if __name__ == "__main__":

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -445,6 +445,59 @@ class TestResolveTransverseTopology(ApproxTestCase):
         with self.assertRaises(ValueError):
             resolve_transverse_topology({}, np.eye(3), norb=0)
 
+    # -----------------------------------------------------------------
+    # Strict input validation (review fix): norb, irvec components and
+    # orbital indices used to pass silently through int(), so norb=1.5
+    # became 1 and a fractional irvec became the wrong channel; an
+    # out-of-range orbital index used to leak a bare IndexError instead
+    # of an actionable ValueError.
+    # -----------------------------------------------------------------
+
+    def test_norb_non_integral_rejected(self):
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology({}, np.eye(3), norb=1.5)
+
+    def test_norb_bool_rejected(self):
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology({}, np.eye(3), norb=True)
+
+    def test_norb_nan_rejected(self):
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology({}, np.eye(3), norb=float("nan"))
+
+    def test_irvec_non_integral_component_rejected(self):
+        interactions = {"CoulombInter": {((1.5, 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_irvec_wrong_length_rejected(self):
+        interactions = {"CoulombInter": {((1, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_orbvec_non_integral_component_rejected(self):
+        interactions = {"CoulombInter": {((1, 0, 0), (0.5, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_orbvec_wrong_length_rejected(self):
+        interactions = {"CoulombInter": {((1, 0, 0), (0, 0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_orbital_index_out_of_range_rejected(self):
+        # norb=1 -> only orbital index 0 is valid; index 1 used to leak
+        # a bare IndexError from the (norb, norb) array assignment
+        # instead of an actionable ValueError.
+        interactions = {"CoulombInter": {((1, 0, 0), (1, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
+    def test_orbital_index_negative_rejected(self):
+        interactions = {"CoulombInter": {((1, 0, 0), (-1, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(interactions, np.eye(3), norb=1)
+
 
 # =============================================================================
 # iter_reversal_orbits
@@ -2036,6 +2089,23 @@ class TestTransverseBondGatePrereqs(ApproxTestCase):
             solver.solve(gi, out)
         self.assertIn("spin_mode='spinful'", str(cm.exception))
 
+    def test_sublattice_rejected(self):
+        """A sublattice run (SubShape < CellShape, has_sublattice=True)
+        must be rejected at the gate: ``_validate_transverse_bond_prereqs``
+        resolves the topology from the PRE-FOLD ``param_ham_orig``
+        declarations but passes the FOLDED ``self.norb`` and the pipeline
+        then runs on the supercell mesh -- the original-cell (R, a, b)
+        records are never mapped to supercell coordinates, so a
+        sublattice run would silently compute the wrong vertices without
+        this guard (review fix)."""
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE,
+            param_overrides={'SubShape': [2, 1, 1]})
+        self.assertTrue(solver.lattice.has_sublattice)
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("sublattice", str(cm.exception))
+
     def test_external_chi0q_init_rejected(self):
         # Build a spin-free chi0q with a plain ring solve, then feed it
         # back in as chi0q_init to a gate-on ring+ladder solver. The
@@ -2117,6 +2187,26 @@ class TestTransverseBondMaxShellsThreading(ApproxTestCase):
         self.assertTrue(np.array_equal(
             data["transverse_bond_delta_r"], topo_trunc.delta_r))
 
+    def test_max_shells_dropping_declared_nonzero_content_raises_via_solve(
+            self):
+        """Public-entry pin (review fix) of the guard
+        ``resolve_transverse_topology``'s own truncation logic already
+        enforces (directly exercised by
+        ``TestResolveTransverseTopology.
+        test_max_shells_dropping_a_declared_nonzero_shell_raises``): the
+        SAME fixture family as
+        ``test_positive_max_shells_truncates_the_resolved_topology``, but
+        with ``max_shells=0`` -- which would drop the R=+-1 shell that
+        carries a genuinely NONZERO declared CoulombInter coefficient
+        (V1=0.4) -- must raise through the full ``solve()`` public entry
+        point, not merely when ``resolve_transverse_topology`` is called
+        directly."""
+        solver, gi, out = _make_max_shells_fixture(max_shells=0)
+        with self.assertRaises(ValueError) as cm:
+            solver.solve(gi, out)
+        self.assertIn("max_shells=0", str(cm.exception))
+        self.assertIn("declared nonzero", str(cm.exception))
+
 
 class TestTransverseBondResourcePreflight(ApproxTestCase):
     """``_transverse_bond_resource_preflight`` (spec "Phase W -- Budget
@@ -2176,6 +2266,23 @@ class TestTransverseBondResourcePreflight(ApproxTestCase):
         finally:
             solver.lattice.nvol = orig_nvol
         self.assertTrue(any("op-count" in m for m in cm.output))
+
+    def test_preflight_rejection_precedes_any_solve_call(self):
+        """Call-order pin (review fix): the resource preflight must run
+        BEFORE the (expensive) longitudinal solve, so a cap rejection
+        fires before ``_solve_rpa`` is ever invoked -- not merely before
+        the bond-resolved solve, but before the plain ring solve too."""
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=True,
+            param_overrides={'transverse_bond_memory_cap_gb': 1e-12},
+            interactions=self.ACTIVE)
+        with mock.patch.object(
+                rpa_mod.RPA, "_solve_rpa",
+                wraps=rpa_mod.RPA._solve_rpa) as spy:
+            with self.assertRaises(ValueError) as cm:
+                solver.solve(gi, out)
+        self.assertIn("memory_cap_gb", str(cm.exception))
+        spy.assert_not_called()
 
 
 class TestTransverseBondGateOutput(ApproxTestCase):
@@ -2295,6 +2402,68 @@ class TestPairHopOffsiteWarning(ApproxTestCase):
         self.assertIn("(1, 0, 0)", msgs)
         self.assertIn("(-1, 0, 0)", msgs)
         self.assertIn("0.15", msgs)
+
+    def _build_variant(self, d, *, include_offsite):
+        """SAME fixture as ``_build`` (transfer/geometry unchanged), but
+        with the off-site PairHop pair present or absent, so the two
+        variants can be solved and diffed numerically."""
+        with open(os.path.join(d, "geom.dat"), "w") as f:
+            f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n1\n"
+                     "0.0 0.0 0.0\n")
+        with open(os.path.join(d, "transfer.dat"), "w") as f:
+            f.write("hdr\n1\n2\n1 1\n"
+                     " 1 0 0 1 1 0.5 0.0\n-1 0 0 1 1 0.5 0.0\n")
+        with open(os.path.join(d, "pairhop.dat"), "w") as f:
+            if include_offsite:
+                f.write("hdr\n1\n3\n1 1 1\n"
+                         " 0 0 0 1 1 0.2 0.0\n"
+                         " 1 0 0 1 1 0.15 0.0\n"
+                         "-1 0 0 1 1 0.15 0.0\n")
+            else:
+                f.write("hdr\n1\n1\n1\n 0 0 0 1 1 0.2 0.0\n")
+        inter = {"path_to_input": d, "Geometry": "geom.dat",
+                 "Transfer": "transfer.dat", "PairHop": "pairhop.dat"}
+        param = {"T": 1.0, "mu": 0.0, "CellShape": [4, 1, 1],
+                 "SubShape": [1, 1, 1], "Nmat": 8}
+        info_mode = {"mode": "RPA", "param": param,
+                     "calc_scheme": "general", "calc_type": "ring"}
+        io = read_input_k.QLMSkInput(
+            {"path_to_input": d, "interaction": inter})
+        solver = rpa_mod.RPA(io.get_param("ham"), {}, info_mode)
+        green_info = io.get_param("green")
+        return solver, green_info
+
+    def test_default_path_offsite_pairhop_warns_but_output_is_unchanged(
+            self):
+        """Default-path regression pin (spec adjudication: the base
+        solver ALREADY silently discarded off-site PairHop before this
+        branch; the new warning is a log-only improvement that fires
+        unconditionally, on every path -- including with the
+        ``transverse_bond_channels`` gate entirely ABSENT). Proves both
+        halves at once: the warning fires, AND ``solve()`` succeeds with
+        numeric output BITWISE IDENTICAL to the same run with the
+        off-site PairHop declaration removed entirely -- i.e. the
+        discard semantics are exactly what they were before this branch,
+        only the logging changed."""
+        with tempfile.TemporaryDirectory() as d_off, \
+                tempfile.TemporaryDirectory() as d_on:
+            with self.assertLogs("hwave.solver.rpa", level="WARNING") as cm:
+                solver_off, gi_off = self._build_variant(
+                    d_off, include_offsite=True)
+            self.assertTrue(any(
+                "PairHop" in m and "off-site" in m for m in cm.output))
+            # gate absent (never set) == gate false
+            self.assertIs(solver_off.transverse_bond_channels, False)
+
+            solver_on, gi_on = self._build_variant(
+                d_on, include_offsite=False)
+
+            out_off = tempfile.mkdtemp(prefix="rpa_pairhop_off_")
+            out_on = tempfile.mkdtemp(prefix="rpa_pairhop_on_")
+            solver_off.solve(gi_off, out_off)
+            solver_on.solve(gi_on, out_on)
+
+            self.assertTrue(np.array_equal(gi_off["chiq"], gi_on["chiq"]))
 
     def test_onsite_only_pairhop_does_not_warn(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -1106,6 +1106,72 @@ class TestWPmBondQPhaseCrossPin(ApproxTestCase):
         self.assertApprox(got, expected, rel=0, abs=1e-12)
 
 
+class TestWPmBondChannelZeroEmbeddingPin(ApproxTestCase):
+    """Fix round 1 review finding (Task 3): the channel-0 embedding
+    (``W[:, 0:nd, 0:nd] = ham_pm_onsite.reshape(nvol, nd, nd)``) had NO
+    discriminating numeric pin -- every existing cross-pin fixture uses an
+    all-zero on-site block, and ``TestWPmBondStructural``'s B=1 reduction
+    test's only nonzero entry sits at the fully-degenerate ``(0,0,0,0)``
+    index. At that degenerate index the CORRECT ``(a,b)/(c,d)``
+    pair-flattening (row = ``a*norb+b``, col = ``c*norb+d``, exactly what
+    a bare ``.reshape(nvol, nd, nd)`` does to a contiguous
+    ``(nvol,a,b,c,d)`` tensor -- matching ``_solve_rpa``'s own
+    ``ham.reshape(nvol, ndx, ndx)`` consumer convention) is numerically
+    IDENTICAL to a WRONG ``(a,c)/(b,d)`` grouping (row = ``a*norb+c``, col
+    = ``b*norb+d`` -- what ``onsite.transpose(0,1,3,2,4)`` before reshape
+    would produce), so a reviewer-supplied mutant passed every committed
+    test.
+
+    This test uses a NON-DIAGONAL-DEGENERATE Hermitian on-site tensor
+    (nonzero ONLY at ``(a,b,c,d) = (0,0,1,1)`` and its Hermitian partner
+    ``(1,1,0,0)``) where the two groupings land the value at DIFFERENT
+    cells (``(0,3)`` vs. ``(1,1)`` -- verified by direct calculation, see
+    the module-level mutation-check note below) and compares
+    ``W_pm_bond``'s channel-0 block ELEMENTWISE against an expected matrix
+    built BY HAND via a plain per-index loop (never via ``.reshape`` --
+    validating production against itself would prove nothing)."""
+
+    def test_channel_zero_embedding_pairs_ab_cd_not_ac_bd(self):
+        norb = 2
+        nd = norb * norb
+        Nx, Ny, Nz = 3, 1, 1
+        nvol = Nx * Ny * Nz
+        V = 0.3 + 0.4j
+
+        onsite = np.zeros((nvol, norb, norb, norb, norb), dtype=complex)
+        onsite[:, 0, 0, 1, 1] = V
+        onsite[:, 1, 1, 0, 0] = np.conj(V)   # Hermitian partner:
+        # W[q,(a,b),(c,d)] must equal conj(W[q,(c,d),(a,b)]), i.e.
+        # onsite[a,b,c,d] == conj(onsite[c,d,a,b]).
+
+        # Expected: built by hand, one (a, b, c, d) cell at a time -- the
+        # definition of the (a,b)/(c,d) pair-flattening rule, independent
+        # of any reshape/transpose call.
+        expected = np.zeros((nvol, nd, nd), dtype=complex)
+        for a in range(norb):
+            for b in range(norb):
+                for c in range(norb):
+                    for d in range(norb):
+                        expected[:, a * norb + b, c * norb + d] = \
+                            onsite[:, a, b, c, d]
+
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0]]), reverse=np.array([0]),
+            coeffs={"CoulombInter": np.zeros((1, norb, norb), dtype=complex)})
+        W = W_pm_bond(topo, onsite, spatial_shape=(Nx, Ny, Nz))
+
+        assert_approx_array(W, expected, rel=0, abs=1e-15)
+
+        # Self-check that this fixture genuinely discriminates the two
+        # groupings (documents the mutant's actual behavior rather than
+        # merely asserting it): under (a,c)/(b,d) the SAME (0,0,1,1) entry
+        # would land at row=a*norb+c=0*2+1=1, col=b*norb+d=0*2+1=1 -- cell
+        # (1, 1) -- not (0, 3), so the correct/wrong mappings disagree at
+        # cell (0, 3) (V vs. 0) and at cell (1, 1) (0 vs. V).
+        self.assertApprox(expected[0, 0, 3], V, rel=0, abs=0)
+        self.assertApprox(expected[0, 1, 1], 0.0, rel=0, abs=0)
+
+
 class TestWPmBondValidation(ApproxTestCase):
     """Entry-point validation: mesh-injectivity is enforced (via
     ``validate_topology_against_mesh``) and a malformed ``ham_pm_onsite``

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -1803,6 +1803,58 @@ def _make_spinful_bond_gate_fixture(T=0.5, mu=0.2, Lx=4, Nmat=32, U=0.3,
     return solver, green_info, out_dir
 
 
+def _make_max_shells_fixture(*, transverse_bond_channels=True,
+                              max_shells=None, Lx=6, Nmat=8, T=2.0,
+                              filling=0.5):
+    """norb=1 ring+ladder fixture with off-site CoulombInter declared at
+    TWO distinct shells on a Lx=6 chain (``delta_r mod 6`` is injective
+    for ``{0, +-1, +-2}``, so no mesh collision): R=+-1 carries a
+    NONZERO coefficient (V1=0.4), R=+-2 is DECLARED but exactly zero
+    (V2=0.0) -- a truncation that drops only the zero shell is not
+    ambiguous (``resolve_transverse_topology`` only refuses a truncation
+    that would drop declared NONZERO content), so
+    ``transverse_bond_max_shells=1`` has an OBSERVABLE, non-rejected
+    effect: it keeps the R=+-1 shell (B=3) and drops the (identically
+    zero) R=+-2 shell that the default ``max_shells=None`` keeps (B=5).
+
+    Does NOT call ``solve()``. Returns ``(solver, green_info, out_dir)``.
+    """
+    import hwave.qlmsio.read_input_k as read_input_k
+
+    d = tempfile.mkdtemp(prefix="rpa_bond_gate_maxshells_")
+    with open(os.path.join(d, "geom.dat"), "w") as f:
+        f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n1\n0.0 0.0 0.0\n")
+    with open(os.path.join(d, "transfer.dat"), "w") as f:
+        f.write("hdr\n1\n2\n1 1\n"
+                 " 1 0 0 1 1 0.5 0.0\n-1 0 0 1 1 0.5 0.0\n")
+    with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+        f.write("hdr\n1\n1\n1\n 0 0 0 1 1 2.0 0.0\n")
+    with open(os.path.join(d, "coulombinter.dat"), "w") as f:
+        f.write("hdr\n1\n4\n1 1 1 1\n"
+                 " 1 0 0 1 1 0.4 0.0\n-1 0 0 1 1 0.4 0.0\n"
+                 " 2 0 0 1 1 0.0 0.0\n-2 0 0 1 1 0.0 0.0\n")
+    with open(os.path.join(d, "extern.dat"), "w") as f:
+        f.write("hdr\n1\n1\n1\n 0 0 0 1 1 1.0 0.0\n")
+
+    inter = {"path_to_input": d, "Geometry": "geom.dat",
+             "Transfer": "transfer.dat", "CoulombIntra": "coulombintra.dat",
+             "CoulombInter": "coulombinter.dat", "Extern": "extern.dat"}
+    param = {"T": T, "filling": filling, "CellShape": [Lx, 1, 1],
+             "SubShape": [1, 1, 1], "Nmat": Nmat}
+    if transverse_bond_channels is not None:
+        param["transverse_bond_channels"] = transverse_bond_channels
+    if max_shells is not None:
+        param["transverse_bond_max_shells"] = max_shells
+
+    info_mode = {"mode": "RPA", "param": param, "calc_scheme": "general",
+                 "calc_type": "ring+ladder"}
+    io = read_input_k.QLMSkInput({"path_to_input": d, "interaction": inter})
+    solver = rpa_mod.RPA(io.get_param("ham"), {}, info_mode)
+    green_info = io.get_param("green")
+    out_dir = tempfile.mkdtemp(prefix="rpa_bond_gate_maxshells_out_")
+    return solver, green_info, out_dir
+
+
 class TestTransverseBondGateConfig(ApproxTestCase):
     """``[mode.param] transverse_bond_channels`` config parsing (spec
     "Production surface"): default false, parsed ONLY under
@@ -1879,6 +1931,62 @@ class TestTransverseBondGateConfig(ApproxTestCase):
                 param_overrides={'transverse_bond_memory_cap_gb': 0.0},
                 interactions=self.ONSITE_ONLY)
 
+    # -----------------------------------------------------------------
+    # Case-insensitivity (CLAUDE.md rule; PR #128 had 6 silent-divergence
+    # sites in exactly this defect class): every new config key lookup
+    # must be case-robust, driven through the PUBLIC entry -- never by
+    # inspecting self.param_mod directly, since self.param_mod being a
+    # CaseInsensitiveDict is the implementation detail under test, not
+    # something the test may lean on as its own proof.
+    # -----------------------------------------------------------------
+
+    ACTIVE = {'CoulombIntra': 'coulombintra.dat',
+              'CoulombInter': 'coulombinter.dat', 'Extern': 'extern.dat'}
+
+    def test_mixed_case_gate_key_activates_through_public_entry(self):
+        solver_lower, gi_lower, out_lower = _make_bond_gate_fixture(
+            transverse_bond_channels=True, interactions=self.ACTIVE)
+        solver_lower.solve(gi_lower, out_lower)
+
+        solver_mixed, gi_mixed, out_mixed = _make_bond_gate_fixture(
+            transverse_bond_channels=None,
+            param_overrides={'Transverse_Bond_Channels': True},
+            interactions=self.ACTIVE)
+        self.assertIs(solver_mixed.transverse_bond_channels, True)
+        solver_mixed.solve(gi_mixed, out_mixed)
+
+        self.assertIn("chiq_pm_bond_static", gi_mixed)
+        self.assertNotIn("chiq_pm", gi_mixed)
+        self.assertTrue(np.array_equal(gi_lower["chiq"], gi_mixed["chiq"]))
+        self.assertTrue(np.array_equal(
+            gi_lower["chiq_pm_bond_static"], gi_mixed["chiq_pm_bond_static"]))
+        self.assertTrue(np.array_equal(
+            gi_lower["chiq_pm_static"], gi_mixed["chiq_pm_static"]))
+
+    def test_mixed_case_flag_absent_lowercase_present_does_not_confuse(self):
+        # An UPPER-cased false-y flag must behave exactly like the
+        # lowercase false-y flag (the documented default) -- guards
+        # against a defect where only the TRUE branch was made
+        # case-robust.
+        solver, _gi, _out = _make_bond_gate_fixture(
+            transverse_bond_channels=None,
+            param_overrides={'TRANSVERSE_BOND_CHANNELS': False},
+            interactions=self.ONSITE_ONLY)
+        self.assertIs(solver.transverse_bond_channels, False)
+
+    def test_mixed_case_max_shells_and_memory_cap_keys_thread_through(self):
+        solver, gi, out = _make_bond_gate_fixture(
+            transverse_bond_channels=None,
+            param_overrides={'TRANSVERSE_bond_channels': True,
+                              'Transverse_Bond_Max_Shells': 1,
+                              'transverse_bond_MEMORY_cap_gb': 2.5},
+            interactions=self.ACTIVE)
+        self.assertIs(solver.transverse_bond_channels, True)
+        self.assertEqual(solver.transverse_bond_max_shells, 1)
+        self.assertEqual(solver.transverse_bond_memory_cap_gb, 2.5)
+        solver.solve(gi, out)  # must not raise
+        self.assertIn("chiq_pm_bond_static", gi)
+
 
 class TestTransverseBondGatePrereqs(ApproxTestCase):
     """``_validate_transverse_bond_prereqs``'s REJECT list (spec
@@ -1953,6 +2061,61 @@ class TestTransverseBondGatePrereqs(ApproxTestCase):
         with self.assertRaises(ValueError) as cm:
             solver.solve(gi, out)
         self.assertIn("externally supplied chi0q", str(cm.exception))
+
+
+class TestTransverseBondMaxShellsThreading(ApproxTestCase):
+    """A positive ``transverse_bond_max_shells`` must thread end to end:
+    ``_init_transverse_bond_config`` -> ``self.transverse_bond_max_shells``
+    -> ``_validate_transverse_bond_prereqs``'s ``resolve_transverse_
+    topology(..., max_shells=...)`` call -- with an OBSERVABLE effect on
+    the resulting topology/B (not just the rejection paths and the
+    default-None case, which is all the earlier config tests covered)."""
+
+    def test_positive_max_shells_truncates_the_resolved_topology(self):
+        solver_trunc, gi_trunc, out_trunc = _make_max_shells_fixture(
+            max_shells=1)
+        solver_trunc.solve(gi_trunc, out_trunc)
+        self.assertEqual(solver_trunc.transverse_bond_max_shells, 1)
+        topo_trunc = solver_trunc._transverse_bond_topo
+        self.assertEqual(len(topo_trunc.delta_r), 3)  # onsite + R=+-1
+
+        # Matches a DIRECT resolve_transverse_topology call with the SAME
+        # max_shells on the solver's own (pre-fold) declarations.
+        has_sub = getattr(solver_trunc.lattice, "has_sublattice", False)
+        interactions = (solver_trunc.ham_info.param_ham_orig if has_sub
+                        else solver_trunc.ham_info.param_ham)
+        topo_direct = resolve_transverse_topology(
+            interactions, np.eye(3), solver_trunc.norb, max_shells=1)
+        self.assertTrue(np.array_equal(topo_trunc.delta_r,
+                                       topo_direct.delta_r))
+        self.assertTrue(np.array_equal(topo_trunc.reverse,
+                                       topo_direct.reverse))
+        for t in topo_trunc.coeffs:
+            self.assertTrue(np.array_equal(topo_trunc.coeffs[t],
+                                           topo_direct.coeffs[t]))
+
+        # DIFFERS from the default (max_shells=None, keep every shell):
+        # a value silently failing to thread through would produce the
+        # SAME (untruncated) B here as above.
+        solver_full, gi_full, out_full = _make_max_shells_fixture(
+            max_shells=None)
+        solver_full.solve(gi_full, out_full)
+        self.assertIsNone(solver_full.transverse_bond_max_shells)
+        topo_full = solver_full._transverse_bond_topo
+        self.assertEqual(len(topo_full.delta_r), 5)  # onsite + R=+-1,+-2
+        self.assertGreater(len(topo_full.delta_r), len(topo_trunc.delta_r))
+
+        # And through the npz output: the channel table + provenance key
+        # both reflect the truncated (not the default) topology.
+        solver_trunc.save_results(
+            {'path_to_output': out_trunc, 'chiq': 'chiq.npz'}, gi_trunc)
+        data = np.load(os.path.join(out_trunc, 'chiq.npz'),
+                       allow_pickle=True)
+        self.assertEqual(int(data["transverse_bond_max_shells"]), 1)
+        self.assertEqual(tuple(data["transverse_bond_delta_r"].shape),
+                          (3, 3))
+        self.assertTrue(np.array_equal(
+            data["transverse_bond_delta_r"], topo_trunc.delta_r))
 
 
 class TestTransverseBondResourcePreflight(ApproxTestCase):

--- a/tests/test_bond_transverse_w.py
+++ b/tests/test_bond_transverse_w.py
@@ -268,11 +268,14 @@ class TestResolveTransverseTopology(ApproxTestCase):
         self.assertEqual(drs, [(0, 0, 0), (-1, 0, 0), (1, 0, 0),
                                 (-2, 0, 0), (2, 0, 0)])
 
-    def test_max_shells_truncates_whole_shells(self):
+    def test_max_shells_truncates_whole_shells_when_dropped_shell_is_zero(self):
+        # The kept shell (|R|=1) is nonzero; the DROPPED shell (|R|=2) is
+        # declared but with an exactly-zero coefficient -- dropping only
+        # zero-coefficient content is fine, never an error.
         interactions = {
             "CoulombInter": {
                 ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2,
-                ((2, 0, 0), (0, 0)): 0.1, ((-2, 0, 0), (0, 0)): 0.1,
+                ((2, 0, 0), (0, 0)): 0.0, ((-2, 0, 0), (0, 0)): 0.0,
             },
         }
         topo = resolve_transverse_topology(
@@ -281,12 +284,78 @@ class TestResolveTransverseTopology(ApproxTestCase):
         drs = {tuple(int(x) for x in r) for r in topo.delta_r}
         self.assertEqual(drs, {(0, 0, 0), (1, 0, 0), (-1, 0, 0)})
 
-    def test_max_shells_zero_keeps_only_channel_zero(self):
+    def test_max_shells_dropping_a_declared_nonzero_shell_raises(self):
+        # max_shells=1 dropping a declared |R|=2 shell -> ValueError (the
+        # ambiguity guard, generalizing resolve_interactions's
+        # bond_max_shells=0 case to every truncation depth: dropping
+        # declared content is never silent).
+        interactions = {
+            "CoulombInter": {
+                ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2,
+                ((2, 0, 0), (0, 0)): 0.1, ((-2, 0, 0), (0, 0)): 0.1,
+            },
+        }
+        with self.assertRaises(ValueError) as cm:
+            resolve_transverse_topology(
+                interactions, np.eye(3), norb=1, max_shells=1)
+        msg = str(cm.exception)
+        self.assertIn("max_shells", msg)
+        self.assertIn("(2, 0, 0)", msg)
+
+    def test_max_shells_zero_with_declared_offsite_raises(self):
+        # max_shells=0 + declared off-site -> ValueError (the n_keep=0
+        # instance of the same guard).
         interactions = {"CoulombInter": {((1, 0, 0), (0, 0)): 0.2}}
+        with self.assertRaises(ValueError):
+            resolve_transverse_topology(
+                interactions, np.eye(3), norb=1, max_shells=0)
+
+    def test_max_shells_zero_with_only_zero_declared_offsite_is_ok(self):
+        # max_shells=0 with a declared-but-exactly-zero off-site value
+        # drops nothing of substance -- not ambiguous, no error.
+        interactions = {"CoulombInter": {((1, 0, 0), (0, 0)): 0.0}}
         topo = resolve_transverse_topology(
             interactions, np.eye(3), norb=1, max_shells=0)
         self.assertEqual(topo.delta_r.shape, (1, 3))
         self.assertFalse(transverse_effective_activity(topo))
+
+    def test_max_shells_zero_with_no_offsite_declared_is_ok(self):
+        topo = resolve_transverse_topology(
+            {}, np.eye(3), norb=1, max_shells=0)
+        self.assertEqual(topo.delta_r.shape, (1, 3))
+
+    def test_max_shells_keeping_all_declared_content_is_ok(self):
+        # max_shells=1 keeping ALL declared content (only one shell
+        # exists) -> OK, nothing dropped.
+        interactions = {
+            "CoulombInter": {
+                ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2,
+            },
+        }
+        topo = resolve_transverse_topology(
+            interactions, np.eye(3), norb=1, max_shells=1)
+        self.assertEqual(topo.delta_r.shape, (3, 3))
+        drs = {tuple(int(x) for x in r) for r in topo.delta_r}
+        self.assertEqual(drs, {(0, 0, 0), (1, 0, 0), (-1, 0, 0)})
+        self.assertApprox(
+            topo.coeffs["CoulombInter"][
+                [i for i, r in enumerate(topo.delta_r)
+                 if tuple(int(x) for x in r) == (1, 0, 0)][0], 0, 0],
+            0.2, rel=0, abs=1e-13)
+
+    def test_max_shells_drop_check_covers_every_active_type(self):
+        # The guard must fire for Ising/Exchange too, not just
+        # CoulombInter.
+        for type_name, value in (("Ising", 0.4), ("Exchange", 0.3 + 0.1j)):
+            interactions = {
+                type_name: {
+                    ((1, 0, 0), (0, 0)): 0.2, ((-1, 0, 0), (0, 0)): 0.2,
+                    ((2, 0, 0), (0, 0)): value, ((-2, 0, 0), (0, 0)): value,
+                },
+            }
+            with self.assertRaises(ValueError):
+                resolve_transverse_topology(
+                    interactions, np.eye(3), norb=1, max_shells=1)
 
     def test_max_shells_negative_rejected(self):
         with self.assertRaises(ValueError):

--- a/tests/test_bubble_kernel.py
+++ b/tests/test_bubble_kernel.py
@@ -2556,6 +2556,44 @@ class TestBubbleGpuParity(unittest.TestCase):
                 assert_approx_array(bk.to_host(gpu_out), cpu_out,
                                     rel=1e-10, abs=1e-12)
 
+    def test_transverse_bond_bubble_static(self):
+        """Per-cell CPU/GPU parity for
+        ``bubble.transverse_bond_bubble_static`` (Phase W Task 4, spec
+        "The bond bubble (static)"). Uses the SAME asymmetric (``hz !=
+        0``, ``nblock=2``) fixture as ``test_transverse_bubble`` above --
+        this entry point requires exactly 2 blocks (fwd=block1(down),
+        rev=block0(up)) for the identical reason. The topology's
+        ``coeffs`` are irrelevant to the bubble (only ``delta_r`` is
+        read; ``coeffs`` belongs to the vertex, ``W_pm_bond``), so a
+        small zero-filled, mesh-injective topology is enough for a pure
+        numeric-parity check."""
+        from hwave.solver import backend as bk
+        from hwave.solver.bond_channels import TransverseTopology
+
+        solver = _make_rpa_solver(coeff_tail=0.5, hz=0.4, norb=2,
+                                  complex_hop=True, Lx=4, Ly=4, Nmat=8)
+        solver._calc_epsilon_k({})
+        beta = 1.0 / solver.T
+        mu = solver.mu_value
+        green, tail = solver._calc_green(beta, mu)
+        spatial_shape = tuple(solver.lattice.shape)
+
+        topo = TransverseTopology(
+            delta_r=np.array([[0, 0, 0], [1, 0, 0], [-1, 0, 0]]),
+            reverse=np.array([0, 2, 1]),
+            coeffs={"CoulombInter": np.zeros((3, 2, 2), dtype=complex)})
+
+        green_gpu = self._to_device(green)
+        tail_gpu = self._to_device(tail)
+
+        cpu_out = bubble_mod.transverse_bond_bubble_static(
+            green, tail, beta, topo, spatial_shape=spatial_shape)
+        gpu_out = bubble_mod.transverse_bond_bubble_static(
+            green_gpu, tail_gpu, beta, topo, spatial_shape=spatial_shape)
+        self.assertIs(bk.array_module_of(gpu_out), self.cupy)
+        assert_approx_array(bk.to_host(gpu_out), cpu_out,
+                            rel=1e-10, abs=1e-12)
+
     def test_ir_bubble_reduced(self):
         from hwave.solver import backend as bk
         from tests.test_flex_ir import _make_solver


### PR DESCRIPTION
## Summary

This PR adds an experimental bond-resolved implementation of the transverse (spin-flip) susceptibility channel to the RPA solver, removing the on-site-only restriction of `calc_scheme = "ring+ladder"`: off-site CoulombInter, Ising, and Exchange declarations now enter the transverse vertex through an enlarged (orbital-pair) × (bond) space, following the same bond-channel lift already used on the longitudinal side.

New, behind the experimental switch `transverse_bond_channels` (in `[mode.param]`, RPA + `ring+ladder` only):

- `TransverseTopology` / `resolve_transverse_topology` — the master bond-channel topology (mandatory local channel, reversal closure, mesh-injectivity validation, optional `transverse_bond_max_shells` truncation with a guard against silently dropping declared content).
- `W_pm_bond` — the bond-resolved transverse vertex `W₊₋(q)`: the on-site block verbatim, plus the off-site cross family (CoulombInter/Ising, bond-diagonal direct placement) and the flip family (Exchange, two ordered q-dependent records).
- `transverse_bond_bubble_static` — the static bond-resolved transverse bubble on the shared bubble kernel (up/down propagator pair with bond phases; CPU/GPU agnostic).
- `RPA._run_transverse_bond_pipeline` — vertex assembly → bubble → the existing RPA dressing → collapse to the standard `chiq_pm` layout; results are written to the npz output as a versioned block (`transverse_bond_schema_version = 1`: the full bond-resolved static object plus its collapsed on-site slice).
- Preflight (memory estimate with a configurable cap) and strict prerequisite checks (rejects `enable_spin_orbital`/spinful transfer, external `chi0q_init`, sublattice runs (the folding map for off-site channels is future work), and configurations with no active transverse content). Off-site PairHop declarations are outside the current channel space and are dropped with an explicit warning (#157).

The default path is unchanged: with the switch absent or false, the solver runs exactly the previous code.

## Validation

- First-order comparison against exact diagonalization for every supported interaction type, including multi-orbital off-site cases, joint-declaration additivity rays, and pass-zero controls (Hund, PairHop); the campaign also cross-checks the production plain transverse channel against the ED side on a Zeeman-split (spin-asymmetric) fixture.
- The ED campaign was run against the implementation *before* it was written (oracle-first): it caught and corrected two derivation errors in the off-site vertex assignment that are invisible in single-orbital or spin-symmetric configurations.
- On-site reduction gate: with only on-site declarations the pipeline reproduces the existing `chiq_pm` to ~1e-18.
- GPU execution verified on an A100 (bare kernel and full gated solve, max relative deviation ~1e-15 against CPU); a device-transfer defect found by that run is fixed in this branch.
- Full test suites green under both runners (unittest 1596 OK, pytest 1979 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rB4iPJ7ZL21bJqhDi8VxF
