### PR TITLE
Solver: single-source the post-solve host-restore discipline

### DIFF
--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -416,7 +416,8 @@ class FLEX(RPA):
     def solve(self, green_info, path_to_output):
         """Solve the FLEX equations, restoring host-backed public state.
 
-        Thin wrapper around :meth:`_solve_impl` that guarantees the solver's
+        Thin wrapper around :meth:`_solve_restoring_host_attrs` that
+        guarantees the solver's
         public array attributes (``H0_eigenvalue``/``H0_eigenvector``, and the
         stored ``green0``/``green0_tail``) are NumPy-backed after the call --
         on normal completion AND after a GPU-path exception. Under GPU
@@ -424,12 +425,7 @@ class FLEX(RPA):
         ``finally`` a mid-solve error would leave a reused or inspected solver
         object holding device arrays (issue #63).
         """
-        try:
-            return self._solve_impl(green_info, path_to_output)
-        finally:
-            _bk.restore_host_attrs(
-                self, ("H0_eigenvalue", "H0_eigenvector",
-                       "green0", "green0_tail"))
+        return self._solve_restoring_host_attrs(green_info, path_to_output)
 
     def _solve_impl(self, green_info, path_to_output):
         """Solve the FLEX equations self-consistently.

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -1620,7 +1620,8 @@ class RPA:
     def solve(self, green_info, path_to_output):
         """Solve the RPA equation, restoring host-backed public state.
 
-        Thin wrapper around :meth:`_solve_impl` that guarantees the solver's
+        Thin wrapper around :meth:`_solve_restoring_host_attrs` that
+        guarantees the solver's
         public array attributes (``H0_eigenvalue``/``H0_eigenvector`` and the
         stored ``green0``/``green0_tail``) are NumPy-backed after the call --
         on normal completion AND after a GPU-path exception. Under GPU
@@ -1628,12 +1629,30 @@ class RPA:
         ``finally`` a mid-solve error would leave a reused or inspected solver
         object holding device arrays (issue #63).
         """
+        return self._solve_restoring_host_attrs(green_info, path_to_output)
+
+    #: The public array attributes a solve must leave NumPy-backed. Both
+    #: solvers restore exactly these, so the list lives here once: an
+    #: attribute added to one solver's restore set but not the other's
+    #: would reintroduce issue #63 on the solver that was missed.
+    _HOST_RESTORED_ATTRS = ("H0_eigenvalue", "H0_eigenvector",
+                            "green0", "green0_tail")
+
+    def _solve_restoring_host_attrs(self, green_info, path_to_output):
+        """Run ``_solve_impl`` and restore the public array attributes.
+
+        The body shared by ``RPA.solve`` and ``FLEX.solve``. Those remain
+        separate methods rather than one inherited method because each
+        carries its own docstring and, through ``@do_profile``, its own
+        entry in the performance report (``hwave.solver.rpa.solve`` vs
+        ``hwave.solver.flex.solve``); merging them would silently pool
+        the two solvers' timings. This helper is deliberately NOT
+        profiled, so delegating to it adds no second measurement.
+        """
         try:
             return self._solve_impl(green_info, path_to_output)
         finally:
-            _bk.restore_host_attrs(
-                self, ("H0_eigenvalue", "H0_eigenvector",
-                       "green0", "green0_tail"))
+            _bk.restore_host_attrs(self, self._HOST_RESTORED_ATTRS)
 
     def _solve_impl(self, green_info, path_to_output):
         """Solve the RPA equation to calculate susceptibility.

--- a/tests/test_flex_analytical.py
+++ b/tests/test_flex_analytical.py
@@ -1350,3 +1350,91 @@ class TestFLEXSpinSymmetry(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestSolveHostRestoreIsSingleSourced(unittest.TestCase):
+    """RPA and FLEX must restore the SAME public array attributes after a
+    solve, and must keep SEPARATE profiling identities while doing so.
+
+    Both solvers wrap ``_solve_impl`` in the same host-restore discipline
+    (issue #63: a mid-solve GPU error must not leave device arrays on a
+    reused solver object). That discipline used to be written out twice,
+    once per solver, with the attribute list repeated -- so an attribute
+    added to one restore set and not the other would have reintroduced
+    the leak on the solver that was missed, with nothing to catch it.
+
+    The two ``solve`` methods nevertheless stay separate: each carries
+    its own docstring, and ``@do_profile`` keys the performance report on
+    ``func.__module__ + '.' + func.__name__``, so collapsing them into
+    one inherited method would pool FLEX's timings into
+    ``hwave.solver.rpa.solve``. These assertions pin both halves.
+    """
+
+    def test_both_solvers_share_one_restore_list(self):
+        import hwave.solver.rpa as rpa_mod
+        import hwave.solver.flex as flex_mod
+
+        self.assertIs(rpa_mod.RPA._solve_restoring_host_attrs,
+                      flex_mod.FLEX._solve_restoring_host_attrs)
+        self.assertIs(rpa_mod.RPA._HOST_RESTORED_ATTRS,
+                      flex_mod.FLEX._HOST_RESTORED_ATTRS)
+        self.assertEqual(
+            rpa_mod.RPA._HOST_RESTORED_ATTRS,
+            ("H0_eigenvalue", "H0_eigenvector", "green0", "green0_tail"))
+
+    def test_both_solve_methods_route_through_the_shared_helper(self):
+        """The sharing above is only worth anything if ``solve`` actually
+        CALLS the helper. Asserting that the helper is shared does not
+        establish that: a solver that inlines its own try/finally with
+        its own attribute list still inherits the shared helper, so the
+        identity checks above pass while the leak they exist to prevent
+        is back. Drive each ``solve`` unbound over a recording stand-in
+        -- its whole body is the delegation, so no real solver is
+        needed -- and require the delegation to happen.
+        """
+        import hwave.solver.rpa as rpa_mod
+        import hwave.solver.flex as flex_mod
+
+        for solver_cls in (rpa_mod.RPA, flex_mod.FLEX):
+            with self.subTest(solver=solver_cls.__name__):
+                calls = []
+                sentinel = object()
+
+                class _Recorder:
+                    def _solve_restoring_host_attrs(self, green_info, path):
+                        calls.append((green_info, path))
+                        return sentinel
+
+                    def _solve_impl(self, green_info, path):
+                        raise AssertionError(
+                            "solve bypassed the shared restore helper and "
+                            "called _solve_impl directly")
+
+                got = solver_cls.solve(_Recorder(), "green", "out")
+                self.assertIs(got, sentinel)
+                self.assertEqual(calls, [("green", "out")])
+
+    def test_each_solver_keeps_its_own_profiling_identity(self):
+        import hwave.solver.rpa as rpa_mod
+        import hwave.solver.flex as flex_mod
+
+        # do_profile records under module + qualified name, so the two
+        # solve methods must remain distinct function objects living in
+        # their own modules.
+        self.assertIsNot(rpa_mod.RPA.solve, flex_mod.FLEX.solve)
+        self.assertEqual(
+            rpa_mod.RPA.solve.__module__ + "." + rpa_mod.RPA.solve.__name__,
+            "hwave.solver.rpa.solve")
+        self.assertEqual(
+            flex_mod.FLEX.solve.__module__ + "." + flex_mod.FLEX.solve.__name__,
+            "hwave.solver.flex.solve")
+
+    def test_the_shared_helper_is_not_itself_profiled(self):
+        # A profiled helper would add a second measurement per solve and
+        # double-count the wrapped time in the report.
+        import hwave.solver.rpa as rpa_mod
+
+        helper = rpa_mod.RPA._solve_restoring_host_attrs
+        self.assertFalse(
+            hasattr(helper, "__wrapped__"),
+            "the shared restore helper must not carry @do_profile")

--- a/tests/test_flex_analytical.py
+++ b/tests/test_flex_analytical.py
@@ -1348,10 +1348,6 @@ class TestFLEXSpinSymmetry(unittest.TestCase):
                 err_msg="Sigma_↑↑ != Sigma_↓↓ in full spin-orbital space")
 
 
-if __name__ == '__main__':
-    unittest.main()
-
-
 class TestSolveHostRestoreIsSingleSourced(unittest.TestCase):
     """RPA and FLEX must restore the SAME public array attributes after a
     solve, and must keep SEPARATE profiling identities while doing so.
@@ -1394,6 +1390,7 @@ class TestSolveHostRestoreIsSingleSourced(unittest.TestCase):
         """
         import hwave.solver.rpa as rpa_mod
         import hwave.solver.flex as flex_mod
+        from unittest import mock
 
         for solver_cls in (rpa_mod.RPA, flex_mod.FLEX):
             with self.subTest(solver=solver_cls.__name__):
@@ -1410,9 +1407,18 @@ class TestSolveHostRestoreIsSingleSourced(unittest.TestCase):
                             "solve bypassed the shared restore helper and "
                             "called _solve_impl directly")
 
-                got = solver_cls.solve(_Recorder(), "green", "out")
+                obj = _Recorder()
+                # The stand-in replaces the real helper, so ANY call to
+                # backend.restore_host_attrs during solve can only come
+                # from a restore inlined in solve itself -- delegation
+                # must be the ONLY restoration path, not merely one of
+                # them.
+                with mock.patch.object(
+                        rpa_mod._bk, "restore_host_attrs") as restore:
+                    got = solver_cls.solve(obj, "green", "out")
                 self.assertIs(got, sentinel)
                 self.assertEqual(calls, [("green", "out")])
+                restore.assert_not_called()
 
     def test_each_solver_keeps_its_own_profiling_identity(self):
         import hwave.solver.rpa as rpa_mod
@@ -1429,6 +1435,42 @@ class TestSolveHostRestoreIsSingleSourced(unittest.TestCase):
             flex_mod.FLEX.solve.__module__ + "." + flex_mod.FLEX.solve.__name__,
             "hwave.solver.flex.solve")
 
+    def test_the_shared_helper_restores_on_return_and_on_exception(self):
+        """Execute the REAL helper. The routing test above drives a
+        stand-in, so nothing in the gating runner would otherwise notice
+        the helper losing its ``finally`` -- the very discipline issue
+        #63 exists for: a mid-solve failure must still leave the public
+        attributes host-backed before the exception propagates.
+        """
+        import hwave.solver.rpa as rpa_mod
+        from unittest import mock
+
+        helper = rpa_mod.RPA._solve_restoring_host_attrs
+        attrs = rpa_mod.RPA._HOST_RESTORED_ATTRS
+
+        class _Impl:
+            _HOST_RESTORED_ATTRS = attrs
+
+            def __init__(self, boom):
+                self.boom = boom
+
+            def _solve_impl(self, green_info, path):
+                if self.boom:
+                    raise RuntimeError("mid-solve failure")
+                return "result"
+
+        obj = _Impl(boom=False)
+        with mock.patch.object(rpa_mod._bk, "restore_host_attrs") as restore:
+            got = helper(obj, "green", "out")
+        self.assertEqual(got, "result")
+        restore.assert_called_once_with(obj, attrs)
+
+        obj = _Impl(boom=True)
+        with mock.patch.object(rpa_mod._bk, "restore_host_attrs") as restore:
+            with self.assertRaises(RuntimeError):
+                helper(obj, "green", "out")
+        restore.assert_called_once_with(obj, attrs)
+
     def test_the_shared_helper_is_not_itself_profiled(self):
         # A profiled helper would add a second measurement per solve and
         # double-count the wrapped time in the report.
@@ -1438,3 +1480,7 @@ class TestSolveHostRestoreIsSingleSourced(unittest.TestCase):
         self.assertFalse(
             hasattr(helper, "__wrapped__"),
             "the shared restore helper must not carry @do_profile")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`RPA.solve` and `FLEX.solve` carried byte-identical bodies: the same `try`/`finally` around `_solve_impl`, and the same tuple of public array attributes to restore to NumPy afterwards. That restore exists because a GPU run converts those attributes to device arrays in place, so a mid-solve failure would otherwise leave a reused or inspected solver object holding them (#63).

Duplicating the attribute list meant an attribute added to one solver's list and not the other's would reintroduce that leak on whichever solver was missed, with nothing to catch it. The body now lives once, as `RPA._solve_restoring_host_attrs`, with the attribute tuple beside it.

The two `solve` methods are deliberately **not** collapsed into a single inherited method. Each carries its own docstring, and the profiling decorator keys the performance report on the module and function name, so one inherited method would pool FLEX's timings into the `hwave.solver.rpa.solve` entry — both entries are populated in real runs today. The shared helper is left unprofiled so the delegation adds no second measurement.

No behaviour changes: the restore set, the `finally` semantics, and both profiling entries are the same as before.

## Tests

Four new gated tests pin what the refactor is for: that both solvers share one restore list, that each `solve` actually routes through the shared helper and performs no additional inline restoration of its own, that the real helper restores both on normal return and while an exception propagates, and that each solver keeps its own profiling identity.

Each was checked against the mutation it exists to catch — a solver inlining its own restore list, one list gaining an attribute the other lacks, a solver delegating but also keeping an inline restore, `FLEX.solve` deleted in favour of inheritance, the helper losing its `finally`, and the helper gaining the profiling decorator — and fails in every case.

This is the first item of the consolidation sequence's final step, whose audit found that the remaining duplication between the solvers is much smaller than the step assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rB4iPJ7ZL21bJqhDi8VxF
