### PR TITLE
Build the spinful exchange crossing for the npz routes; record the #161 adjudication

### DIFF
--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -1062,17 +1062,25 @@ class Interaction:
         # orbitals, and reading ham_r[0, 0, 0] after folding would cross
         # off-site content that the ring-form resummation cannot
         # represent (round-1 review; the same trap the Fierz builder
-        # documents). Only built for spin-orbital runs -- no other mode
-        # consumes it.
-        # (getattr: tests drive _make_ham_inter on __new__-built stubs
-        # without __init__, the same pattern save_results documents)
-        onsite_r = (np.zeros((*(ns, norb) * 4,), dtype=np.complex128)
-                    if getattr(self, "enable_spin_orbital", False)
-                    else None)
+        # documents).
+        #
+        # Built for EVERY run (issue #174). It used to be gated on
+        # `enable_spin_orbital`, on the premise that "no other mode
+        # consumes it" -- that premise is false: `RPA._calc_epsilon_k`
+        # takes the spin-orbital branch UNCONDITIONALLY for the
+        # `trans_mod` / `green_init` npz routes, so a spin-mixing H0
+        # supplied through an npz reaches `spin_mode == 'spinful'` with
+        # `enable_spin_orbital = False`, and the gate left that solve
+        # falling back to the pre-#137 ring-only vertex with no warning
+        # (measured 1.7e-02, 12.2% relative in chiq, confined to the
+        # spin-flip pair slots; calc_scheme='auto' promotes INTO the
+        # path since #167). Building it unconditionally cannot move a
+        # non-spinful result: only the `spin_mode == 'spinful'` branch
+        # of the solve reads `ham_spinful_exchange`, while `spin-free`
+        # and `spin-diag` take `_fierz_long()` regardless.
+        onsite_r = np.zeros((*(ns, norb) * 4,), dtype=np.complex128)
 
         def _append_onsite_direct(type, tbl=None, pairhop=False):
-            if onsite_r is None:
-                return
             has_sub = getattr(self.lattice, "has_sublattice", False)
             if tbl is None:
                 if has_sub:
@@ -1281,13 +1289,12 @@ class Interaction:
         # spin-conserving limit X reproduces the adjudicated transverse
         # (ring+ladder) vertex; ED confirmed Gamma = D + X for CoulombIntra
         # (issue #137 reproduction).
-        if onsite_r is not None:
-            exch_onsite = -np.transpose(
-                onsite_r.reshape(*(nd,) * 4), (3, 1, 2, 0))
-            self.ham_spinful_exchange = (exch_onsite
-                                         if np.any(exch_onsite) else None)
-        else:
-            self.ham_spinful_exchange = None
+        exch_onsite = -np.transpose(
+            onsite_r.reshape(*(nd,) * 4), (3, 1, 2, 0))
+        # stays None when no on-site declaration sources the crossing:
+        # the structural pins read that as "nothing was crossed"
+        self.ham_spinful_exchange = (exch_onsite
+                                     if np.any(exch_onsite) else None)
 
 class RPA:
     """

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -669,6 +669,15 @@ class Interaction:
     """
     Construct Hamiltonian from input
     """
+
+    # Cache slot for the lazily materialized spinful exchange crossing
+    # (#174): None until `spinful_exchange()` is first called, and None
+    # afterwards too when no on-site declaration sources a crossing.
+    # Class-level so a stub built without _make_ham_inter still reads it.
+    ham_spinful_exchange = None
+    _spinful_exchange_built = False
+    _onsite_direct_calls = ()
+
     def __init__(self, lattice, param_ham, info_mode):
         logger.debug(">>> Interaction.__init__")
 
@@ -1064,49 +1073,36 @@ class Interaction:
         # represent (round-1 review; the same trap the Fierz builder
         # documents).
         #
-        # Built for EVERY run (issue #174). It used to be gated on
-        # `enable_spin_orbital`, on the premise that "no other mode
-        # consumes it" -- that premise is false: `RPA._calc_epsilon_k`
-        # takes the spin-orbital branch UNCONDITIONALLY for the
-        # `trans_mod` / `green_init` npz routes, so a spin-mixing H0
-        # supplied through an npz reaches `spin_mode == 'spinful'` with
-        # `enable_spin_orbital = False`, and the gate left that solve
-        # falling back to the pre-#137 ring-only vertex with no warning
-        # (measured 1.7e-02, 12.2% relative in chiq, confined to the
-        # spin-flip pair slots; calc_scheme='auto' promotes INTO the
-        # path since #167). Building it unconditionally cannot move a
-        # non-spinful result: only the `spin_mode == 'spinful'` branch
-        # of the solve reads `ham_spinful_exchange`, while `spin-free`
-        # and `spin-diag` take `_fierz_long()` regardless.
-        onsite_r = np.zeros((*(ns, norb) * 4,), dtype=np.complex128)
+        # NOT accumulated here (issue #174 round-2 review). The dense
+        # accumulator is (ns*norb)^4 complex128 -- 1.6 GB at norb = 50 --
+        # and `ham_spinful_exchange` keeps a transposed VIEW of it, so
+        # building it eagerly would pin that allocation for the lifetime
+        # of EVERY solver instance, including the spin-free and spin-diag
+        # solves that never read it. Instead the call sites below RECORD
+        # what would have been accumulated (a handful of sparse
+        # declaration tables), and `spinful_exchange()` replays the
+        # recording on first demand -- which happens only inside the
+        # `spin_mode == 'spinful'` solve branch.
+        #
+        # The gate this replaced was `enable_spin_orbital`, on the premise
+        # that "no other mode consumes it". That premise is false:
+        # `RPA._calc_epsilon_k` takes the spin-orbital branch
+        # UNCONDITIONALLY for the `trans_mod` / `green_init` npz routes, so
+        # a spin-mixing H0 supplied through an npz reaches
+        # `spin_mode == 'spinful'` with `enable_spin_orbital = False`, and
+        # the gate left that solve falling back to the pre-#137 ring-only
+        # vertex with no warning (measured 1.7e-02, 12.2% relative in
+        # chiq, confined to the spin-flip pair slots; calc_scheme='auto'
+        # promotes INTO the path since #167). Demand-driven materialization
+        # removes the asymmetry entirely: whoever consumes it gets it.
+        self._onsite_direct_calls = []
+        self.ham_spinful_exchange = None
+        self._spinful_exchange_built = False
 
         def _append_onsite_direct(type, tbl=None, pairhop=False):
-            has_sub = getattr(self.lattice, "has_sublattice", False)
-            if tbl is None:
-                if has_sub:
-                    tbl = self.param_ham_orig.get(type, {})
-                else:
-                    tbl = self.param_ham.get(type, {})
-            filtered = {}
-            for (irvec, orbvec), v in tbl.items():
-                if tuple(irvec) == (0, 0, 0):
-                    filtered[(irvec, orbvec)] = v
-            if not filtered:
-                return
-            if has_sub:
-                filtered = self._reshape_interaction(filtered, False)
-            filtered = _symmetrised(type, filtered)
-            spins = spin_table[type]
-            for (irvec, orbvec), v in filtered.items():
-                if tuple(irvec) != (0, 0, 0):
-                    continue
-                a, b = orbvec
-                for spinvec, w in spins.items():
-                    s1, s2, s3, s4 = spinvec
-                    # same slot layouts as the ham_r builders above
-                    orb = ((s4, b, s3, a, s1, a, s2, b) if pairhop
-                           else (s4, b, s3, b, s1, a, s2, a))
-                    onsite_r[orb] += v * w
+            # record only; see Interaction._accumulate_onsite_direct for
+            # the accumulation this defers (moved there verbatim)
+            self._onsite_direct_calls.append((type, tbl, pairhop))
 
         def _append_inter_cross(type, tbl=None):
             # Longitudinal cross-slot (Fierz) content, adjudicated against
@@ -1272,29 +1268,101 @@ class Interaction:
         else:
             self.ham_fierz_q = None
 
-        # Spinful exchange content (issue #137). The spinful general solve
-        # resums chi = [1 - chi0 W]^-1 chi0 with ONE vertex tensor; the
-        # physically complete first order is the ANTISYMMETRIZED bare
-        # particle-hole vertex Gamma = D + X, where X is the crossed
-        # (exchange) wiring of the same interaction. Re-pairing the on-site
-        # two-body term
-        #     W^{b b' a a'} c^+_a c_a' c^+_b' c_b
-        #       = - W^{b b' a a'} c^+_a c_b c^+_b' c_a' + (one-body)
-        # shows the crossed wiring is the direct wiring of the coefficient
-        # tensor with the b and a' slots swapped and negated:
-        #     X[b, b', a, a'] = - D[a', b', a, b]   (on-site block only).
-        # Off-site exchange depends on both fermionic momenta and cannot be
-        # written as W(q); it stays outside the ring-form resummation (the
-        # same limitation the non-spin-orbital ladder has). In the
-        # spin-conserving limit X reproduces the adjudicated transverse
-        # (ring+ladder) vertex; ED confirmed Gamma = D + X for CoulombIntra
-        # (issue #137 reproduction).
-        exch_onsite = -np.transpose(
-            onsite_r.reshape(*(nd,) * 4), (3, 1, 2, 0))
-        # stays None when no on-site declaration sources the crossing:
-        # the structural pins read that as "nothing was crossed"
-        self.ham_spinful_exchange = (exch_onsite
-                                     if np.any(exch_onsite) else None)
+    def _accumulate_onsite_direct(self):
+        """Replay the on-site direct declarations recorded by
+        ``_make_ham_inter`` into a dense (ns, norb)*4 accumulator.
+
+        The body is ``_make_ham_inter``'s former ``_append_onsite_direct``
+        closure, moved here verbatim so the arithmetic is unchanged; the
+        ``_symmetrised`` helper it calls is likewise the same reduction
+        (see that closure's comment for why the mean over the two
+        declarations of a bond is the physical coefficient).
+        """
+        nx, ny, nz = self.lattice.shape
+        norb = self.norb
+        ns = 2
+
+        def _symmetrised(type, tbl):
+            arr = np.zeros((nx, ny, nz, norb, norb), dtype=np.complex128)
+            for (irvec, orbvec), v in tbl.items():
+                arr[(irvec[0] % nx, irvec[1] % ny, irvec[2] % nz,
+                     *orbvec)] += v
+            sym = symmetrise_dense(arr, hermitian=(type == "PairHop"))
+            out = {}
+            for ix, iy, iz, a, b in zip(*np.nonzero(sym)):
+                out[((int(ix), int(iy), int(iz)), (int(a), int(b)))] = \
+                    sym[ix, iy, iz, a, b]
+            return out
+
+        onsite_r = np.zeros((*(ns, norb) * 4,), dtype=np.complex128)
+        for type, tbl, pairhop in getattr(self, "_onsite_direct_calls", []):
+            has_sub = getattr(self.lattice, "has_sublattice", False)
+            if tbl is None:
+                if has_sub:
+                    tbl = self.param_ham_orig.get(type, {})
+                else:
+                    tbl = self.param_ham.get(type, {})
+            filtered = {}
+            for (irvec, orbvec), v in tbl.items():
+                if tuple(irvec) == (0, 0, 0):
+                    filtered[(irvec, orbvec)] = v
+            if not filtered:
+                continue
+            if has_sub:
+                filtered = self._reshape_interaction(filtered, False)
+            filtered = _symmetrised(type, filtered)
+            spins = ring_spin_table(type)
+            for (irvec, orbvec), v in filtered.items():
+                if tuple(irvec) != (0, 0, 0):
+                    continue
+                a, b = orbvec
+                for spinvec, w in spins.items():
+                    s1, s2, s3, s4 = spinvec
+                    # same slot layouts as the ham_r builders
+                    orb = ((s4, b, s3, a, s1, a, s2, b) if pairhop
+                           else (s4, b, s3, b, s1, a, s2, a))
+                    onsite_r[orb] += v * w
+        return onsite_r
+
+    def spinful_exchange(self):
+        """Spinful exchange content (issue #137), materialized on demand.
+
+        The spinful general solve resums chi = [1 - chi0 W]^-1 chi0 with
+        ONE vertex tensor; the physically complete first order is the
+        ANTISYMMETRIZED bare particle-hole vertex Gamma = D + X, where X
+        is the crossed (exchange) wiring of the same interaction.
+        Re-pairing the on-site two-body term
+            W^{b b' a a'} c^+_a c_a' c^+_b' c_b
+              = - W^{b b' a a'} c^+_a c_b c^+_b' c_a' + (one-body)
+        shows the crossed wiring is the direct wiring of the coefficient
+        tensor with the b and a' slots swapped and negated:
+            X[b, b', a, a'] = - D[a', b', a, b]   (on-site block only).
+        Off-site exchange depends on both fermionic momenta and cannot be
+        written as W(q); it stays outside the ring-form resummation (the
+        same limitation the non-spin-orbital ladder has). In the
+        spin-conserving limit X reproduces the adjudicated transverse
+        (ring+ladder) vertex; ED confirmed Gamma = D + X for CoulombIntra
+        (issue #137 reproduction).
+
+        LAZY (issue #174 round-2 review): the tensor is (ns*norb)^4
+        complex128 -- 1.6 GB at norb = 50 -- and only the
+        ``spin_mode == 'spinful'`` solve branch consumes it, so it is
+        built on the first call and cached in ``ham_spinful_exchange``.
+        Until then that attribute is ``None`` for EVERY mode, and a
+        spin-free / spin-diag solve never calls this, so it never pays
+        the allocation. Returns ``None`` -- and caches ``None`` -- when no
+        on-site declaration sources a crossing; the structural pins read
+        that as "nothing was crossed".
+        """
+        if not getattr(self, "_spinful_exchange_built", False):
+            nd = self.norb * 2
+            exch_onsite = -np.transpose(
+                self._accumulate_onsite_direct().reshape(*(nd,) * 4),
+                (3, 1, 2, 0))
+            self.ham_spinful_exchange = (exch_onsite
+                                         if np.any(exch_onsite) else None)
+            self._spinful_exchange_built = True
+        return self.ham_spinful_exchange
 
 class RPA:
     """
@@ -2276,7 +2344,11 @@ class RPA:
                 # every on-site cross-orbital slot. Opt-out via
                 # [mode.param] spinful_vertex_exchange = false reproduces
                 # the pre-#137 ring-only numbers (ham_inter + fierz).
-                exch = getattr(self.ham_info, "ham_spinful_exchange", None)
+                # materializes the crossing on demand (#174): only this
+                # branch consumes it, so spin-free / spin-diag solves
+                # never allocate the (ns*norb)^4 tensor
+                _build_exch = getattr(self.ham_info, "spinful_exchange", None)
+                exch = _build_exch() if callable(_build_exch) else None
                 if exch is not None and self.spinful_vertex_exchange:
                     exch = xp.asarray(exch) if gpu_active else exch
                     ham_long = _to_bubble_pair_convention(

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -2344,12 +2344,42 @@ class RPA:
                 # every on-site cross-orbital slot. Opt-out via
                 # [mode.param] spinful_vertex_exchange = false reproduces
                 # the pre-#137 ring-only numbers (ham_inter + fierz).
-                # materializes the crossing on demand (#174): only this
-                # branch consumes it, so spin-free / spin-diag solves
-                # never allocate the (ns*norb)^4 tensor
-                _build_exch = getattr(self.ham_info, "spinful_exchange", None)
-                exch = _build_exch() if callable(_build_exch) else None
-                if exch is not None and self.spinful_vertex_exchange:
+                # Materialized on demand, and ONLY where this solve
+                # actually consumes it (#174, round-2 review). The tensor
+                # is (ns*norb)^4 complex128 -- about 1.6 GB at norb = 50 --
+                # and `spinful_exchange()` caches it on the Interaction,
+                # so asking for it in a branch that discards it would
+                # retain that allocation for the rest of the run. Two
+                # spinful cases discard it:
+                #
+                #   * spinful_vertex_exchange = false -- the ring-only
+                #     compatibility opt-out takes `_fierz_long()` by
+                #     definition;
+                #   * calc_scheme = 'reduced' -- the crossing's
+                #     density-pair projection vanishes STRUCTURALLY (its
+                #     (a,b,a,b) slots sit off the 'kaabb' diagonal
+                #     `project_density_pairs` keeps; pinned for every type
+                #     by test_density_projection_vanishes_all_types), and
+                #     so does the Fierz tensor's, for the same reason. So
+                #     both candidate `ham_long` values project to the same
+                #     array: measured bitwise identical -- the pre-#174
+                #     npz route reached reduced via `_fierz_long()` while
+                #     the spin-orbital route reached it via the crossing,
+                #     and the #161 adjudication probes found chi0q/chiq
+                #     bitwise equal across nine interaction sets (recorded
+                #     in tests/test_rpa_spinful_npz_reduced.py).
+                #
+                # Gating on 'reduced' cannot starve the transverse
+                # channel: calc_type='ring+ladder' requires
+                # calc_scheme='general' (rejected at init otherwise), and
+                # `_extract_transverse_from_dressed` slices THIS solve.
+                exch = None
+                if (self.spinful_vertex_exchange
+                        and self.calc_scheme != "reduced"):
+                    _build_exch = getattr(self.ham_info,
+                                          "spinful_exchange", None)
+                    exch = _build_exch() if callable(_build_exch) else None
+                if exch is not None:
                     exch = xp.asarray(exch) if gpu_active else exch
                     ham_long = _to_bubble_pair_convention(
                         ham_inter_q + exch[None, ...])

--- a/tests/test_rpa_flex_equivalence_table.py
+++ b/tests/test_rpa_flex_equivalence_table.py
@@ -2952,15 +2952,22 @@ class TestReducedSpinfulGuard(unittest.TestCase):
     ``calc_scheme='reduced'`` + ``spin_mode == 'spinful'`` with
     ``enable_spin_orbital=False`` throughout -- never touching the
     CONSTRUCTOR-time guard cell 36 exercises. No registry cell is
-    added for this route: recording one would also require
-    characterizing RPA's own reduced+spinful-via-``trans_mod``
-    behaviour, which is outside what this table measures. That
-    characterization is tracked in issue #161; this docstring records
-    the corresponding KNOWN LIMITATION of the table's coverage, namely
-    that no cell describes the ``trans_mod`` route and none is
-    planned. The guard pinned here closes the gap regardless of how
-    ``spin_mode`` came to be ``'spinful'``, as this test
-    demonstrates.
+    added for this route: the route lies outside this table's fixture
+    model (TOML plus text inputs), so this docstring records the
+    corresponding KNOWN LIMITATION of the table's coverage, namely that
+    no cell describes the ``trans_mod`` route and none is planned. The
+    guard pinned here closes the gap regardless of how ``spin_mode``
+    came to be ``'spinful'``, as this test demonstrates.
+
+    RPA's own behaviour on that route IS now characterized, outside
+    this table: ``tests/test_rpa_spinful_npz_reduced.py`` records issue
+    #161's adjudication -- reduced via ``trans_mod`` / ``green_init``
+    computes bitwise the same ``chi0q`` / ``chiq`` as the adjudicated
+    ``enable_spin_orbital = true`` run, so it inherits that mode's
+    adjudication and needs no RPA-side guard, while #167's
+    reduced-exactness diagnostic announces the approximation. (The
+    ``general`` scheme on the same route was a real defect, issue #174,
+    fixed and pinned in ``tests/test_rpa_spinful_npz_general.py``.)
     """
 
     def test_direct_semantic_state_pin_rejects_spinful(self):

--- a/tests/test_rpa_spinful_npz_general.py
+++ b/tests/test_rpa_spinful_npz_general.py
@@ -33,9 +33,15 @@ The crossing is materialized LAZILY by ``Interaction.spinful_exchange()``
 1.6 GB at norb = 50 -- and ``ham_spinful_exchange`` keeps a transposed
 view of it, so building it in the constructor would pin that allocation
 for every solver instance, including the spin-free and spin-diag solves
-that never read it. The contract these tests pin is therefore: absent
-after CONSTRUCTION in every mode; present after a SPINFUL solve; still
-absent after a non-spinful solve.
+that never read it. And it is asked for only where the solve actually
+CONSUMES it: not under the ``spinful_vertex_exchange = false`` opt-out,
+and not under ``calc_scheme = 'reduced'``, whose density projection
+annihilates the crossing structurally.
+
+The contract these tests pin is therefore: absent after CONSTRUCTION in
+every mode; present after a spinful solve that consumes it; absent after
+a non-spinful solve, after the ring-only opt-out, and after a reduced
+solve; and reused, not rebuilt, on a second solve of the same instance.
 
 Tests must run from the repository root.
 """
@@ -188,7 +194,8 @@ def write_fixture(d):
 
 
 def run_route(d, *, so, interactions, transfer, trans_mod=None,
-              green_init=None, calc_scheme="general", extra_param=None):
+              green_init=None, calc_scheme="general", extra_param=None,
+              resolve=False):
     """Run one RPA solve through the public input path.
 
     ``so`` selects the spin-orbital route (SO Geometry/Transfer plus the
@@ -215,9 +222,19 @@ def run_route(d, *, so, interactions, transfer, trans_mod=None,
     os.makedirs(out, exist_ok=True)
     rio = read_input_k.QLMSkInput(input_block)
     solver = solver_rpa.RPA(rio.get_param("ham"), {}, info_mode)
-    green = rio.get_param("green")
-    green.update(solver.read_init(input_block))
+
+    def _fresh_green():
+        g = rio.get_param("green")
+        g.update(solver.read_init(input_block))
+        return g
+
+    green = _fresh_green()
     solver.solve(green, out)
+    if resolve:
+        # same INSTANCE, second solve -- used by the caching pin
+        green2 = _fresh_green()
+        solver.solve(green2, out)
+        return solver, green, green2
     return solver, green
 
 
@@ -484,6 +501,84 @@ class TestExchangeIsNotMaterializedEagerly(unittest.TestCase):
         self.assertIsNotNone(X)
         self.assertEqual(np.asarray(X).shape, (nd, nd, nd, nd))
         self.assertGreater(np.asarray(X).nbytes, 5_000_000)
+
+
+class TestExchangeBuiltOnlyWhereConsumed(unittest.TestCase):
+    """Issue #174 round-2 review: a spinful solve must not materialize the
+    crossing in the branches that DISCARD it.
+
+    ``spinful_exchange()`` caches on the ``Interaction``, so asking for it
+    where the result is thrown away retains the (ns*norb)^4 allocation for
+    the rest of the run -- and for a non-``enable_spin_orbital`` npz route
+    that is a fresh regression against the behaviour before #174, where
+    the gate allocated nothing at all. Two spinful cases discard it:
+    ``spinful_vertex_exchange = false`` (the ring-only opt-out takes
+    ``_fierz_long()`` by definition) and ``calc_scheme = 'reduced'``
+    (``project_density_pairs`` annihilates the crossing structurally --
+    ``test_density_projection_vanishes_all_types`` -- and the Fierz
+    tensor likewise, so both candidates project to the same array;
+    measured bitwise identical, see ``tests/test_rpa_spinful_npz_reduced.py``).
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.d = tmp.name
+        write_fixture(self.d)
+        self.inter = {"CoulombIntra": "coulombintra.dat",
+                      "PairLift": "pairlift.dat"}
+
+    def _assert_unbuilt(self, solver):
+        self.assertEqual(solver.spin_mode, "spinful")
+        self.assertIsNone(solver.ham_info.ham_spinful_exchange)
+        self.assertFalse(solver.ham_info._spinful_exchange_built)
+        # laziness, not emptiness: this input does source a crossing
+        self.assertIsNotNone(solver.ham_info.spinful_exchange())
+
+    def test_ring_optout_solve_does_not_materialize(self):
+        """Spinful ``general`` ring solve with
+        ``spinful_vertex_exchange = false``: the opt-out takes
+        ``_fierz_long()``, so nothing must be allocated."""
+        solver, _ = run_route(
+            self.d, so=False, interactions=self.inter,
+            transfer=TRANSFER_MIX, trans_mod=TRANS_MOD,
+            calc_scheme="general",
+            extra_param={"spinful_vertex_exchange": False})
+        self._assert_unbuilt(solver)
+
+    def test_reduced_spinful_solve_does_not_materialize(self):
+        """Spinful ``reduced`` solve: the density projection is
+        independent of the crossing, so nothing must be allocated."""
+        solver, _ = run_route(self.d, so=False, interactions=self.inter,
+                              transfer=TRANSFER_MIX, trans_mod=TRANS_MOD,
+                              calc_scheme="reduced")
+        self._assert_unbuilt(solver)
+
+    def test_reduced_spin_orbital_solve_does_not_materialize(self):
+        """Same for the spin-orbital route, which HAS the flag set: the
+        gate is on what the solve consumes, not on the mode."""
+        solver, _ = run_route(self.d, so=True, interactions=self.inter,
+                              transfer=TRANSFER_MIX, trans_mod=TRANS_MOD,
+                              calc_scheme="reduced")
+        self._assert_unbuilt(solver)
+
+    def test_double_solve_reuses_the_cached_crossing(self):
+        """Two solves on the SAME instance (spinful ``general``, exchange
+        on): the cache must be reused, not rebuilt -- ``assertIs`` on the
+        tensor -- and the second chiq must equal the first bitwise, which
+        would fail if the crossing were accumulated twice."""
+        solver, g1, g2 = run_route(
+            self.d, so=False, interactions=self.inter,
+            transfer=TRANSFER_MIX, trans_mod=TRANS_MOD,
+            calc_scheme="general", resolve=True)
+        self.assertEqual(solver.spin_mode, "spinful")
+        X1 = solver.ham_info.ham_spinful_exchange
+        self.assertIsNotNone(X1)
+        self.assertTrue(solver.ham_info._spinful_exchange_built)
+        # the builder hands back the very same object, no rebuild
+        self.assertIs(solver.ham_info.spinful_exchange(), X1)
+        np.testing.assert_array_equal(np.asarray(g1["chiq"]),
+                                      np.asarray(g2["chiq"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_rpa_spinful_npz_general.py
+++ b/tests/test_rpa_spinful_npz_general.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+
+"""Regression tests for issue #174: the ``general`` scheme must build the
+spinful exchange crossing for EVERY run that can reach the spinful solve
+branch, not only for ``enable_spin_orbital = true`` runs.
+
+``RPA._calc_epsilon_k`` sets the spin-orbital branch UNCONDITIONALLY for
+the ``trans_mod`` / ``green_init`` npz routes, and ``spin_mode`` is then
+read off the supplied H0(k)'s block structure. So a spin-mixing H0 handed
+in through an npz reaches ``spin_mode == 'spinful'`` with
+``enable_spin_orbital = False``. Before the fix, the precursor of the #137
+antisymmetrized crossing (``onsite_r`` in ``Interaction._make_ham_inter``)
+was gated on the ``enable_spin_orbital`` flag, so on that route
+``ham_spinful_exchange`` was ``None`` and the spinful solve silently fell
+back to the pre-#137 ring-only vertex -- measured 1.705e-02 (12.2%
+relative) in ``chiq``, confined to the spin-flip pair slots, with no
+warning. ``calc_scheme = 'auto'`` promotes INTO that path since #167
+(``auto:mixed:trans_mod`` / ``auto:mixed:green_init``).
+
+Each test compares the npz route (route B: ``enable_spin_orbital=False``,
+physical Geometry/Transfer, spinful npz) against the ADJUDICATED
+spin-orbital run (route A: ``enable_spin_orbital=True``, interleaved SO
+Transfer) on IDENTICAL physics. The two routes assemble bit-identical
+H0(k), ``chi0q`` and ``ham_inter_q``; the only thing that ever differed
+was the vertex crossing, so the comparison is BITWISE.
+
+The reduced scheme is unaffected (the crossing has no density-diagonal
+content); that half is recorded in ``tests/test_rpa_spinful_npz_reduced.py``
+(issue #161).
+
+Tests must run from the repository root.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+import hwave.solver.rpa as solver_rpa
+
+
+NORB = 2          # physical orbitals
+NS = 2
+ND = NS * NORB
+LX = 8            # 1D chain cells
+T = 2.0
+FILLING = 0.5
+NMAT = 32
+
+
+# --------------------------------------------------------------------------
+# fixture: ONE physical spin-mixing H0, emitted in both index conventions
+# --------------------------------------------------------------------------
+
+def _h_blocks():
+    """H(R) in SPIN-BLOCK order (index = s*NORB + a) for R = 0, +1, -1.
+
+    The R = 0 block carries a genuinely spin-MIXING (spin off-diagonal,
+    non-symmetric, complex) sector -- that is what drives ``spin_mode``
+    to ``'spinful'``.
+    """
+    H = {}
+    h0 = np.zeros((ND, ND), dtype=complex)
+    h0[0:2, 0:2] = [[0.30, 0.10], [0.10, -0.20]]      # up-up
+    h0[2:4, 2:4] = [[-0.10, 0.05], [0.05, 0.25]]      # down-down
+    m = np.array([[0.15 + 0.05j, 0.02], [0.03, -0.07 + 0.04j]], dtype=complex)
+    h0[0:2, 2:4] = m
+    h0[2:4, 0:2] = m.conj().T
+    H[0] = h0
+
+    hp = np.zeros((ND, ND), dtype=complex)
+    hp[0:2, 0:2] = [[-0.50, 0.07], [0.04, -0.45]]
+    hp[2:4, 2:4] = [[-0.40, 0.02], [0.01, -0.35]]
+    hp[0:2, 2:4] = [[0.06j, 0.01], [0.02, 0.03]]
+    hp[2:4, 0:2] = [[0.0, 0.015], [0.025, 0.0]]
+    H[1] = hp
+    H[-1] = hp.conj().T
+    return H
+
+
+def _spinblock_to_interleaved(mat):
+    """spin-block (s*NORB + a) -> interleaved (2*a + s), on both axes."""
+    perm = [(j % NS) * NORB + (j // NS) for j in range(ND)]
+    return mat[np.ix_(perm, perm)]
+
+
+def _w90_header(fh, norb, nr, comment):
+    fh.write(comment + "\n")
+    fh.write("{}\n".format(norb))
+    fh.write("{}\n".format(nr))
+    fh.write(" ".join(["1"] * nr) + "\n")
+
+
+def write_fixture(d):
+    """Write geometry / transfer / interaction / npz files into ``d``."""
+    H = _h_blocks()
+
+    for name, n in (("geom_so.dat", ND), ("geom_phys.dat", NORB)):
+        with open(os.path.join(d, name), "w") as f:
+            f.write("  1.0 0.0 0.0\n  0.0 1.0 0.0\n  0.0 0.0 1.0\n")
+            f.write("{}\n".format(n))
+            for _ in range(n):
+                f.write("  0.0 0.0 0.0\n")
+
+    # SO Transfer: interleaved indices, the spin-mixing H0 itself
+    with open(os.path.join(d, "transfer_so_mix.dat"), "w") as f:
+        _w90_header(f, ND, 3, "SO spin-mixing transfer (interleaved)")
+        for R in (-1, 0, 1):
+            mil = _spinblock_to_interleaved(H[R])
+            for i in range(ND):
+                for j in range(ND):
+                    v = mil[i, j]
+                    if v != 0:
+                        f.write("{} 0 0 {} {} {:.12f} {:.12f}\n".format(
+                            R, i + 1, j + 1, v.real, v.imag))
+
+    # SO Transfer, spin-INDEPENDENT: used by the green_init route, where
+    # the spin mixing arrives through the Green function instead, so the
+    # SO and non-SO H0 assemblies must coincide before green_init is read
+    with open(os.path.join(d, "transfer_so_indep.dat"), "w") as f:
+        _w90_header(f, ND, 3, "SO spin-independent transfer (interleaved)")
+        for R in (-1, 1):
+            for a in range(NORB):
+                for s in range(NS):
+                    i = 2 * a + s + 1
+                    f.write("{} 0 0 {} {} -0.500000 0.0\n".format(R, i, i))
+
+    # physical (non-SO) Transfer: a spin-independent placeholder. On the
+    # trans_mod route H0 is REPLACED by the npz, so only its structure
+    # matters; on the green_init route it equals transfer_so_indep.
+    with open(os.path.join(d, "transfer_phys.dat"), "w") as f:
+        _w90_header(f, NORB, 3, "physical 2-orbital diagonal transfer")
+        for R in (-1, 1):
+            for a in range(NORB):
+                f.write("{} 0 0 {} {} -0.500000 0.0\n".format(R, a + 1, a + 1))
+
+    # interactions: PHYSICAL orbital indices in both modes
+    with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+        _w90_header(f, NORB, 1, "CoulombIntra")
+        for a in range(NORB):
+            f.write("0 0 0 {} {} 1.000000 0.0\n".format(a + 1, a + 1))
+
+    with open(os.path.join(d, "coulombinter_onsite.dat"), "w") as f:
+        _w90_header(f, NORB, 1, "CoulombInter, on-site cross-orbital")
+        f.write("0 0 0 1 2 0.350000 0.0\n")
+        f.write("0 0 0 2 1 0.350000 0.0\n")
+
+    with open(os.path.join(d, "pairlift.dat"), "w") as f:
+        _w90_header(f, NORB, 1, "PairLift on-site cross-orbital")
+        f.write("0 0 0 1 2 0.300000 0.0\n")
+        f.write("0 0 0 2 1 0.300000 0.0\n")
+
+    # trans_mod, in both conventions
+    tab_sb = np.zeros((LX, ND, ND), dtype=complex)
+    tab_il = np.zeros((LX, ND, ND), dtype=complex)
+    for R, m in H.items():
+        tab_sb[R % LX] += m
+        tab_il[R % LX] += _spinblock_to_interleaved(m)
+    np.savez(os.path.join(d, "trans_mod_spinblock.npz"), trans_mod=tab_sb)
+    np.savez(os.path.join(d, "trans_mod_interleaved.npz"), trans_mod=tab_il)
+
+    # green_init, in both conventions: spin-mixing on-site block
+    g = np.zeros((LX, ND, ND), dtype=complex)
+    g[0][0:2, 0:2] = [[0.55, 0.05], [0.05, 0.45]]
+    g[0][2:4, 2:4] = [[0.40, 0.03], [0.03, 0.50]]
+    gm = np.array([[0.12 + 0.04j, 0.02], [0.01, 0.09 - 0.03j]], dtype=complex)
+    g[0][0:2, 2:4] = gm
+    g[0][2:4, 0:2] = gm.conj().T
+    g[1][0:2, 0:2] = 0.05 * np.eye(2)
+    g[1][2:4, 2:4] = 0.05 * np.eye(2)
+    g[LX - 1] = g[1].conj().T
+    np.savez(os.path.join(d, "green_spinblock.npz"), green=g)
+    gi = np.zeros_like(g)
+    for r in range(LX):
+        gi[r] = _spinblock_to_interleaved(g[r])
+    np.savez(os.path.join(d, "green_interleaved.npz"), green=gi)
+
+
+def run_route(d, *, so, interactions, transfer, trans_mod=None,
+              green_init=None, calc_scheme="general", extra_param=None):
+    """Run one RPA solve through the public input path.
+
+    ``so`` selects the spin-orbital route (SO Geometry/Transfer plus the
+    interleaved npz) or the issue-#174 route (physical Geometry/Transfer
+    plus the spin-block npz).
+    """
+    inter = {"path_to_input": d,
+             "Geometry": "geom_so.dat" if so else "geom_phys.dat",
+             "Transfer": transfer[so]}
+    inter.update(interactions)
+    input_block = {"path_to_input": d, "interaction": inter}
+    if trans_mod is not None:
+        input_block["trans_mod"] = trans_mod[so]
+    if green_init is not None:
+        input_block["green_init"] = green_init[so]
+
+    param = {"T": T, "filling": FILLING, "CellShape": [LX, 1, 1],
+             "SubShape": [1, 1, 1], "Nmat": NMAT}
+    param.update(extra_param or {})
+    info_mode = {"mode": "RPA", "param": param,
+                 "enable_spin_orbital": so, "calc_scheme": calc_scheme}
+
+    out = os.path.join(d, "out")
+    os.makedirs(out, exist_ok=True)
+    rio = read_input_k.QLMSkInput(input_block)
+    solver = solver_rpa.RPA(rio.get_param("ham"), {}, info_mode)
+    green = rio.get_param("green")
+    green.update(solver.read_init(input_block))
+    solver.solve(green, out)
+    return solver, green
+
+
+TRANSFER_MIX = {True: "transfer_so_mix.dat", False: "transfer_phys.dat"}
+TRANSFER_INDEP = {True: "transfer_so_indep.dat", False: "transfer_phys.dat"}
+TRANS_MOD = {True: "trans_mod_interleaved.npz",
+             False: "trans_mod_spinblock.npz"}
+GREEN_INIT = {True: "green_interleaved.npz", False: "green_spinblock.npz"}
+
+
+class TestSpinfulNpzGeneralVertex(unittest.TestCase):
+    """Issue #174: under ``calc_scheme='general'`` the npz routes must
+    resum the SAME antisymmetrized vertex as the adjudicated
+    spin-orbital run.
+
+    RED evidence on the unfixed code (develop @ bbb8637f): ``chiq``
+    differed by max 1.705e-02 (12.2% relative) on the ``trans_mod``
+    route and 1.707e-02 (12.3%) on the ``green_init`` route, while
+    ``H0_k`` / ``chi0q`` / ``ham_inter_q`` were already bit-identical --
+    isolating the difference to the missing crossing.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.d = tmp.name
+        write_fixture(self.d)
+
+    def _assert_routes_agree(self, sA, gA, sB, gB):
+        # both routes must really be on the spinful branch, else the
+        # comparison would be vacuous
+        self.assertEqual(sA.spin_mode, "spinful")
+        self.assertEqual(sB.spin_mode, "spinful")
+        self.assertTrue(sA.ham_info.enable_spin_orbital)
+        self.assertFalse(sB.ham_info.enable_spin_orbital)
+        # the inputs to the solve are identical...
+        np.testing.assert_array_equal(np.asarray(sA.H0_k),
+                                      np.asarray(sB.H0_k))
+        np.testing.assert_array_equal(np.asarray(gA["chi0q"]),
+                                      np.asarray(gB["chi0q"]))
+        np.testing.assert_array_equal(
+            np.asarray(sA.ham_info.ham_inter_q),
+            np.asarray(sB.ham_info.ham_inter_q))
+        # ... so the OUTPUT must be too, BITWISE. Asserted before the
+        # structural checks below so that a regression reports the
+        # physical divergence (1.7e-02) rather than a None tensor.
+        np.testing.assert_array_equal(np.asarray(gA["chiq"]),
+                                      np.asarray(gB["chiq"]))
+        # and the crossing itself must exist, identically, on BOTH routes
+        self.assertIsNotNone(sA.ham_info.ham_spinful_exchange)
+        self.assertIsNotNone(sB.ham_info.ham_spinful_exchange)
+        np.testing.assert_array_equal(
+            np.asarray(sA.ham_info.ham_spinful_exchange),
+            np.asarray(sB.ham_info.ham_spinful_exchange))
+
+    def test_trans_mod_route_matches_spin_orbital_bitwise(self):
+        """CoulombIntra, spin-mixing H0 via ``trans_mod``: the
+        ``enable_spin_orbital=false`` run must reproduce the
+        ``enable_spin_orbital=true`` run bitwise under ``general``."""
+        inter = {"CoulombIntra": "coulombintra.dat"}
+        sA, gA = run_route(self.d, so=True, interactions=inter,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        sB, gB = run_route(self.d, so=False, interactions=inter,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        self._assert_routes_agree(sA, gA, sB, gB)
+
+    def test_trans_mod_route_pairlift_matches_spin_orbital_bitwise(self):
+        """PairLift + CoulombIntra: the sweep's largest divergence
+        (12.3% relative before the fix). PairLift's ring spin table has
+        spin-off-diagonal slots, so it exercises a different sourcing
+        branch of the crossing than CoulombIntra alone."""
+        inter = {"CoulombIntra": "coulombintra.dat",
+                 "PairLift": "pairlift.dat"}
+        sA, gA = run_route(self.d, so=True, interactions=inter,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        sB, gB = run_route(self.d, so=False, interactions=inter,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        self._assert_routes_agree(sA, gA, sB, gB)
+
+    def test_green_init_route_matches_spin_orbital_bitwise(self):
+        """The ``green_init`` half of the route: ``_calc_epsilon_k`` sets
+        the spin-orbital branch for it exactly as for ``trans_mod``, and
+        the Fock term of a spin-mixing Green function makes H0 spinful.
+        The transfer here is spin-INDEPENDENT and identical in the two
+        index conventions, so the assemblies coincide before the npz."""
+        inter = {"CoulombIntra": "coulombintra.dat",
+                 "PairLift": "pairlift.dat"}
+        sA, gA = run_route(self.d, so=True, interactions=inter,
+                           transfer=TRANSFER_INDEP, green_init=GREEN_INIT)
+        sB, gB = run_route(self.d, so=False, interactions=inter,
+                           transfer=TRANSFER_INDEP, green_init=GREEN_INIT)
+        self._assert_routes_agree(sA, gA, sB, gB)
+
+    def test_auto_scheme_on_npz_route_matches_spin_orbital(self):
+        """``calc_scheme='auto'`` promotes the ``trans_mod`` route to
+        ``general`` (``auto:mixed:trans_mod``, #167), i.e. the DEFAULT
+        configuration chose the defective computation. Pin that the
+        promoted run now agrees with the adjudicated one."""
+        inter = {"CoulombIntra": "coulombintra.dat",
+                 "CoulombInter": "coulombinter_onsite.dat"}
+        sA, gA = run_route(self.d, so=True, interactions=inter,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        sB, gB = run_route(self.d, so=False, interactions=inter,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD,
+                           calc_scheme="auto")
+        self.assertEqual(sB.calc_scheme, "general")
+        self.assertEqual(sB._scheme_resolution, "auto:mixed:trans_mod")
+        self._assert_routes_agree(sA, gA, sB, gB)
+
+
+class TestNonSpinfulRunsUnchanged(unittest.TestCase):
+    """No-change pin for issue #174's one-line fix.
+
+    The crossing is now built for every run, but only the
+    ``spin_mode == 'spinful'`` branch of ``RPA._solve_impl`` reads
+    ``ham_spinful_exchange``; the ``spin-free`` and ``spin-diag``
+    branches take ``_fierz_long()`` unconditionally. So building it
+    cannot move a non-spinful result.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.d = tmp.name
+        write_fixture(self.d)
+
+    def test_spin_free_general_run_is_bitwise_independent_of_exchange(self):
+        """A plain spin-free (no npz, spin-independent transfer)
+        ``general`` run: ``chiq`` is BITWISE identical with the crossing
+        enabled and disabled, and ``spinful_vertex_exchange=false`` is
+        exactly the pre-fix code path (the crossing is not consumed), so
+        this equality demonstrates the fix changed nothing here."""
+        inter = {"CoulombIntra": "coulombintra.dat"}
+        s_on, g_on = run_route(self.d, so=False, interactions=inter,
+                               transfer=TRANSFER_INDEP)
+        s_off, g_off = run_route(
+            self.d, so=False, interactions=inter, transfer=TRANSFER_INDEP,
+            extra_param={"spinful_vertex_exchange": False})
+        self.assertEqual(s_on.spin_mode, "spin-free")
+        np.testing.assert_array_equal(np.asarray(g_on["chiq"]),
+                                      np.asarray(g_off["chiq"]))
+        # the tensor IS built now (the falsified premise of the old pin)
+        self.assertIsNotNone(s_on.ham_info.ham_spinful_exchange)
+
+    def test_spin_diag_general_run_is_bitwise_independent_of_exchange(self):
+        """Same for a spin-DIAGONAL H0 supplied through ``trans_mod``
+        (spin-dependent but not spin-mixing): ``spin_mode`` is
+        ``'spin-diag'``, which also never reads the crossing."""
+        diag = np.zeros((LX, ND, ND), dtype=complex)
+        diag[0] = np.diag([0.30, -0.20, -0.10, 0.25])
+        diag[1] = np.diag([-0.50, -0.45, -0.40, -0.35])
+        diag[LX - 1] = diag[1].conj().T
+        np.savez(os.path.join(self.d, "trans_mod_diag.npz"), trans_mod=diag)
+        tm = {False: "trans_mod_diag.npz"}
+        inter = {"CoulombIntra": "coulombintra.dat"}
+        s_on, g_on = run_route(self.d, so=False, interactions=inter,
+                               transfer=TRANSFER_INDEP, trans_mod=tm)
+        s_off, g_off = run_route(
+            self.d, so=False, interactions=inter, transfer=TRANSFER_INDEP,
+            trans_mod=tm, extra_param={"spinful_vertex_exchange": False})
+        self.assertEqual(s_on.spin_mode, "spin-diag")
+        np.testing.assert_array_equal(np.asarray(g_on["chiq"]),
+                                      np.asarray(g_off["chiq"]))
+        self.assertIsNotNone(s_on.ham_info.ham_spinful_exchange)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_spinful_npz_general.py
+++ b/tests/test_rpa_spinful_npz_general.py
@@ -28,6 +28,15 @@ The reduced scheme is unaffected (the crossing has no density-diagonal
 content); that half is recorded in ``tests/test_rpa_spinful_npz_reduced.py``
 (issue #161).
 
+The crossing is materialized LAZILY by ``Interaction.spinful_exchange()``
+(round-2 review): the dense tensor is (ns*norb)^4 complex128 -- about
+1.6 GB at norb = 50 -- and ``ham_spinful_exchange`` keeps a transposed
+view of it, so building it in the constructor would pin that allocation
+for every solver instance, including the spin-free and spin-diag solves
+that never read it. The contract these tests pin is therefore: absent
+after CONSTRUCTION in every mode; present after a SPINFUL solve; still
+absent after a non-spinful solve.
+
 Tests must run from the repository root.
 """
 
@@ -257,7 +266,9 @@ class TestSpinfulNpzGeneralVertex(unittest.TestCase):
         # physical divergence (1.7e-02) rather than a None tensor.
         np.testing.assert_array_equal(np.asarray(gA["chiq"]),
                                       np.asarray(gB["chiq"]))
-        # and the crossing itself must exist, identically, on BOTH routes
+        # the spinful solve MATERIALIZED the crossing on both routes --
+        # reading the cache attribute (not calling the builder) is what
+        # makes this a pin on consumption, and it must be identical
         self.assertIsNotNone(sA.ham_info.ham_spinful_exchange)
         self.assertIsNotNone(sB.ham_info.ham_spinful_exchange)
         np.testing.assert_array_equal(
@@ -317,6 +328,24 @@ class TestSpinfulNpzGeneralVertex(unittest.TestCase):
         self.assertEqual(sB.calc_scheme, "general")
         self.assertEqual(sB._scheme_resolution, "auto:mixed:trans_mod")
         self._assert_routes_agree(sA, gA, sB, gB)
+    def test_auto_scheme_on_green_init_route_matches_spin_orbital(self):
+        """The ``green_init`` analogue of the previous test: ``auto``
+        resolves to ``general`` via ``auto:mixed:green_init``.
+
+        PairLift is what makes this fixture spinful at all -- its ring
+        spin table has the spin-off-diagonal slots the green_init Fock
+        term needs to produce a spin-MIXING H0 -- and it is also a
+        conditional type, so it drives the promotion too."""
+        inter = {"CoulombIntra": "coulombintra.dat",
+                 "PairLift": "pairlift.dat"}
+        sA, gA = run_route(self.d, so=True, interactions=inter,
+                           transfer=TRANSFER_INDEP, green_init=GREEN_INIT)
+        sB, gB = run_route(self.d, so=False, interactions=inter,
+                           transfer=TRANSFER_INDEP, green_init=GREEN_INIT,
+                           calc_scheme="auto")
+        self.assertEqual(sB.calc_scheme, "general")
+        self.assertEqual(sB._scheme_resolution, "auto:mixed:green_init")
+        self._assert_routes_agree(sA, gA, sB, gB)
 
 
 class TestNonSpinfulRunsUnchanged(unittest.TestCase):
@@ -350,8 +379,11 @@ class TestNonSpinfulRunsUnchanged(unittest.TestCase):
         self.assertEqual(s_on.spin_mode, "spin-free")
         np.testing.assert_array_equal(np.asarray(g_on["chiq"]),
                                       np.asarray(g_off["chiq"]))
-        # the tensor IS built now (the falsified premise of the old pin)
-        self.assertIsNotNone(s_on.ham_info.ham_spinful_exchange)
+        # the solve never materialized the crossing
+        self.assertIsNone(s_on.ham_info.ham_spinful_exchange)
+        self.assertFalse(s_on.ham_info._spinful_exchange_built)
+        # ... though this input does source one, on demand
+        self.assertIsNotNone(s_on.ham_info.spinful_exchange())
 
     def test_spin_diag_general_run_is_bitwise_independent_of_exchange(self):
         """Same for a spin-DIAGONAL H0 supplied through ``trans_mod``
@@ -372,7 +404,86 @@ class TestNonSpinfulRunsUnchanged(unittest.TestCase):
         self.assertEqual(s_on.spin_mode, "spin-diag")
         np.testing.assert_array_equal(np.asarray(g_on["chiq"]),
                                       np.asarray(g_off["chiq"]))
-        self.assertIsNotNone(s_on.ham_info.ham_spinful_exchange)
+        self.assertIsNone(s_on.ham_info.ham_spinful_exchange)
+        self.assertFalse(s_on.ham_info._spinful_exchange_built)
+        self.assertIsNotNone(s_on.ham_info.spinful_exchange())
+
+
+class TestExchangeIsNotMaterializedEagerly(unittest.TestCase):
+    """Memory regression pin (issue #174 round-2 review).
+
+    The crossing accumulator is ``(ns*norb)^4`` complex128, and
+    ``ham_spinful_exchange`` holds a transposed VIEW of it, so the base
+    allocation stays alive as long as the attribute does. Building it in
+    the constructor would add about 1.6 GB at ``norb = 50`` -- roughly
+    doubling the interaction-tensor footprint of a one-cell calculation
+    and able to turn a previously working non-spinful input into an OOM.
+
+    ``norb = 12`` here: ``(2*12)^4 * 16 B`` is about 5.3 MB, large enough
+    that eager construction is a real cost and cheap enough for the fast
+    gate. The pin asserts the named cache, which is non-fragile: it is
+    the only reference the solver keeps to that allocation.
+    """
+
+    NORB_BIG = 12
+    LX = 4
+
+    def _build(self, d):
+        nd = 2 * self.NORB_BIG
+        with open(os.path.join(d, "geom.dat"), "w") as f:
+            f.write("1.0 0.0 0.0\n0.0 1.0 0.0\n0.0 0.0 1.0\n%d\n"
+                    % self.NORB_BIG)
+            for _ in range(self.NORB_BIG):
+                f.write("0.0 0.0 0.0\n")
+        with open(os.path.join(d, "transfer.dat"), "w") as f:
+            f.write("hdr\n%d\n2\n1 1\n" % self.NORB_BIG)
+            for a in range(1, self.NORB_BIG + 1):
+                f.write(" 1 0 0 %d %d -0.500000 0.0\n" % (a, a))
+                f.write("-1 0 0 %d %d -0.500000 0.0\n" % (a, a))
+        with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+            f.write("hdr\n%d\n1\n1\n" % self.NORB_BIG)
+            for a in range(1, self.NORB_BIG + 1):
+                f.write(" 0 0 0 %d %d 1.000000 0.0\n" % (a, a))
+        inter = {"path_to_input": d, "Geometry": "geom.dat",
+                 "Transfer": "transfer.dat",
+                 "CoulombIntra": "coulombintra.dat"}
+        info_mode = {"mode": "RPA",
+                     "param": {"T": T, "filling": FILLING,
+                               "CellShape": [self.LX, 1, 1],
+                               "SubShape": [1, 1, 1], "Nmat": 8},
+                     "enable_spin_orbital": False,
+                     "calc_scheme": "general"}
+        rio = read_input_k.QLMSkInput(
+            {"path_to_input": d, "interaction": inter})
+        solver = solver_rpa.RPA(rio.get_param("ham"), {}, info_mode)
+        return solver, rio, nd
+
+    def test_cache_is_empty_after_construction_and_after_spin_free_solve(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = tmp.name
+        solver, rio, nd = self._build(d)
+
+        # after CONSTRUCTION: nothing dense is held
+        self.assertIsNone(solver.ham_info.ham_spinful_exchange)
+        self.assertFalse(solver.ham_info._spinful_exchange_built)
+
+        out = os.path.join(d, "out")
+        os.makedirs(out, exist_ok=True)
+        green = rio.get_param("green")
+        solver.solve(green, out)
+
+        # after a SPIN-FREE solve: still nothing
+        self.assertEqual(solver.spin_mode, "spin-free")
+        self.assertIsNone(solver.ham_info.ham_spinful_exchange)
+        self.assertFalse(solver.ham_info._spinful_exchange_built)
+
+        # and the tensor this input would have allocated is the big one,
+        # so the pin above is measuring something real
+        X = solver.ham_info.spinful_exchange()
+        self.assertIsNotNone(X)
+        self.assertEqual(np.asarray(X).shape, (nd, nd, nd, nd))
+        self.assertGreater(np.asarray(X).nbytes, 5_000_000)
 
 
 if __name__ == "__main__":

--- a/tests/test_rpa_spinful_npz_reduced.py
+++ b/tests/test_rpa_spinful_npz_reduced.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+
+"""Issue #161's ADJUDICATION RECORD: ``calc_scheme = 'reduced'`` with a
+spinful one-body Hamiltonian supplied through ``trans_mod`` / ``green_init``.
+
+THE QUESTION (#161). ``rpa.py`` decides ``spin_mode`` from the block
+structure of H0(k), independently of ``enable_spin_orbital``: the npz
+routes set the spin-orbital branch in ``_calc_epsilon_k``
+unconditionally, so a user-supplied spin-mixing ``trans_mod.npz`` /
+``green_init.npz`` reaches ``spin_mode == 'spinful'`` with
+``enable_spin_orbital = False``, and can be combined with the reduced
+scheme -- a state reachable from a public input path. FLEX now rejects
+that combination (``FLEX._check_reduced_rejects_spinful``); whether
+RPA's own ``chi0q`` / ``chiq`` there are meaningful had not been
+adjudicated, and the RPA/FLEX equivalence table has no cell for the
+route (its fixture model is TOML plus text inputs).
+
+THE ANSWER RECORDED HERE. The npz route is not a separate computation:
+on identical physics it produces BITWISE the same ``chi0q`` and
+``chiq`` as the ``enable_spin_orbital = true`` run, which IS
+adjudicated -- ``chi0`` against the exact Lindhard function (#133) and
+the vertex against exact diagonalization (#137, in the pair convention
+fixed by #139). The arrays are identical, so the adjudication transfers
+verbatim: nothing about the reduced scheme's meaning changes with how
+the spinful H0 arrived. No guard is warranted; the approximation the
+reduced scheme makes on a flavour-mixing H0 is the ORDINARY reduced
+approximation, and #167's exactness diagnostic already announces it on
+this very route (pinned below, with cause token ``trans_mod``).
+
+Route A : ``enable_spin_orbital=True``, SO Geometry/Transfer, interleaved
+          npz -- the adjudicated spin-orbital computation.
+Route B : ``enable_spin_orbital=False``, physical Geometry/Transfer,
+          spin-block npz -- the issue-#161 state.
+
+The ``general`` half of the same comparison is issue #174 and lives in
+``tests/test_rpa_spinful_npz_general.py``; there the two routes did NOT
+agree until the exchange crossing was built unconditionally. Reduced was
+never affected: the crossing has no density-diagonal content, so it
+cannot survive ``project_density_pairs``.
+
+Tests must run from the repository root.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+import hwave.solver.rpa as solver_rpa
+
+
+NORB = 2          # physical orbitals
+NS = 2
+ND = NS * NORB
+LX = 8            # 1D chain cells
+T = 2.0
+FILLING = 0.5
+NMAT = 32
+
+
+# --------------------------------------------------------------------------
+# fixture: ONE physical spin-mixing H0, emitted in both index conventions
+# --------------------------------------------------------------------------
+
+def _h_blocks():
+    """H(R) in SPIN-BLOCK order (index = s*NORB + a) for R = 0, +1, -1,
+    with a genuinely spin-MIXING R = 0 sector."""
+    H = {}
+    h0 = np.zeros((ND, ND), dtype=complex)
+    h0[0:2, 0:2] = [[0.30, 0.10], [0.10, -0.20]]
+    h0[2:4, 2:4] = [[-0.10, 0.05], [0.05, 0.25]]
+    m = np.array([[0.15 + 0.05j, 0.02], [0.03, -0.07 + 0.04j]], dtype=complex)
+    h0[0:2, 2:4] = m
+    h0[2:4, 0:2] = m.conj().T
+    H[0] = h0
+
+    hp = np.zeros((ND, ND), dtype=complex)
+    hp[0:2, 0:2] = [[-0.50, 0.07], [0.04, -0.45]]
+    hp[2:4, 2:4] = [[-0.40, 0.02], [0.01, -0.35]]
+    hp[0:2, 2:4] = [[0.06j, 0.01], [0.02, 0.03]]
+    hp[2:4, 0:2] = [[0.0, 0.015], [0.025, 0.0]]
+    H[1] = hp
+    H[-1] = hp.conj().T
+    return H
+
+
+def _spinblock_to_interleaved(mat):
+    """spin-block (s*NORB + a) -> interleaved (2*a + s), on both axes."""
+    perm = [(j % NS) * NORB + (j // NS) for j in range(ND)]
+    return mat[np.ix_(perm, perm)]
+
+
+def _w90_header(fh, norb, nr, comment):
+    fh.write(comment + "\n")
+    fh.write("{}\n".format(norb))
+    fh.write("{}\n".format(nr))
+    fh.write(" ".join(["1"] * nr) + "\n")
+
+
+def write_fixture(d):
+    H = _h_blocks()
+
+    for name, n in (("geom_so.dat", ND), ("geom_phys.dat", NORB)):
+        with open(os.path.join(d, name), "w") as f:
+            f.write("  1.0 0.0 0.0\n  0.0 1.0 0.0\n  0.0 0.0 1.0\n")
+            f.write("{}\n".format(n))
+            for _ in range(n):
+                f.write("  0.0 0.0 0.0\n")
+
+    with open(os.path.join(d, "transfer_so_mix.dat"), "w") as f:
+        _w90_header(f, ND, 3, "SO spin-mixing transfer (interleaved)")
+        for R in (-1, 0, 1):
+            mil = _spinblock_to_interleaved(H[R])
+            for i in range(ND):
+                for j in range(ND):
+                    v = mil[i, j]
+                    if v != 0:
+                        f.write("{} 0 0 {} {} {:.12f} {:.12f}\n".format(
+                            R, i + 1, j + 1, v.real, v.imag))
+
+    with open(os.path.join(d, "transfer_so_indep.dat"), "w") as f:
+        _w90_header(f, ND, 3, "SO spin-independent transfer (interleaved)")
+        for R in (-1, 1):
+            for a in range(NORB):
+                for s in range(NS):
+                    i = 2 * a + s + 1
+                    f.write("{} 0 0 {} {} -0.500000 0.0\n".format(R, i, i))
+
+    with open(os.path.join(d, "transfer_phys.dat"), "w") as f:
+        _w90_header(f, NORB, 3, "physical 2-orbital diagonal transfer")
+        for R in (-1, 1):
+            for a in range(NORB):
+                f.write("{} 0 0 {} {} -0.500000 0.0\n".format(R, a + 1, a + 1))
+
+    with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+        _w90_header(f, NORB, 1, "CoulombIntra")
+        for a in range(NORB):
+            f.write("0 0 0 {} {} 1.000000 0.0\n".format(a + 1, a + 1))
+
+    with open(os.path.join(d, "coulombinter.dat"), "w") as f:
+        _w90_header(f, NORB, 3, "CoulombInter (off-site, physical indices)")
+        for R in (-1, 1):
+            for a in range(NORB):
+                for b in range(NORB):
+                    f.write("{} 0 0 {} {} 0.400000 0.0\n".format(
+                        R, a + 1, b + 1))
+
+    with open(os.path.join(d, "pairlift.dat"), "w") as f:
+        _w90_header(f, NORB, 1, "PairLift on-site cross-orbital")
+        f.write("0 0 0 1 2 0.300000 0.0\n")
+        f.write("0 0 0 2 1 0.300000 0.0\n")
+
+    tab_sb = np.zeros((LX, ND, ND), dtype=complex)
+    tab_il = np.zeros((LX, ND, ND), dtype=complex)
+    for R, m in H.items():
+        tab_sb[R % LX] += m
+        tab_il[R % LX] += _spinblock_to_interleaved(m)
+    np.savez(os.path.join(d, "trans_mod_spinblock.npz"), trans_mod=tab_sb)
+    np.savez(os.path.join(d, "trans_mod_interleaved.npz"), trans_mod=tab_il)
+
+    g = np.zeros((LX, ND, ND), dtype=complex)
+    g[0][0:2, 0:2] = [[0.55, 0.05], [0.05, 0.45]]
+    g[0][2:4, 2:4] = [[0.40, 0.03], [0.03, 0.50]]
+    gm = np.array([[0.12 + 0.04j, 0.02], [0.01, 0.09 - 0.03j]], dtype=complex)
+    g[0][0:2, 2:4] = gm
+    g[0][2:4, 0:2] = gm.conj().T
+    g[1][0:2, 0:2] = 0.05 * np.eye(2)
+    g[1][2:4, 2:4] = 0.05 * np.eye(2)
+    g[LX - 1] = g[1].conj().T
+    np.savez(os.path.join(d, "green_spinblock.npz"), green=g)
+    gi = np.zeros_like(g)
+    for r in range(LX):
+        gi[r] = _spinblock_to_interleaved(g[r])
+    np.savez(os.path.join(d, "green_interleaved.npz"), green=gi)
+
+
+TRANSFER_MIX = {True: "transfer_so_mix.dat", False: "transfer_phys.dat"}
+TRANSFER_INDEP = {True: "transfer_so_indep.dat", False: "transfer_phys.dat"}
+TRANS_MOD = {True: "trans_mod_interleaved.npz",
+             False: "trans_mod_spinblock.npz"}
+GREEN_INIT = {True: "green_interleaved.npz", False: "green_spinblock.npz"}
+
+
+def run_route(d, *, so, interactions, transfer, trans_mod=None,
+              green_init=None, calc_scheme="reduced"):
+    """Run one RPA solve through the public input path."""
+    inter = {"path_to_input": d,
+             "Geometry": "geom_so.dat" if so else "geom_phys.dat",
+             "Transfer": transfer[so]}
+    inter.update(interactions)
+    input_block = {"path_to_input": d, "interaction": inter}
+    if trans_mod is not None:
+        input_block["trans_mod"] = trans_mod[so]
+    if green_init is not None:
+        input_block["green_init"] = green_init[so]
+
+    info_mode = {"mode": "RPA",
+                 "param": {"T": T, "filling": FILLING,
+                           "CellShape": [LX, 1, 1], "SubShape": [1, 1, 1],
+                           "Nmat": NMAT},
+                 "enable_spin_orbital": so, "calc_scheme": calc_scheme}
+    out = os.path.join(d, "out")
+    os.makedirs(out, exist_ok=True)
+    rio = read_input_k.QLMSkInput(input_block)
+    solver = solver_rpa.RPA(rio.get_param("ham"), {}, info_mode)
+    green = rio.get_param("green")
+    green.update(solver.read_init(input_block))
+    solver.solve(green, out)
+    return solver, green
+
+
+class TestReducedSpinfulNpzMatchesSpinOrbital(unittest.TestCase):
+    """Issue #161's adjudication record, part 1: the arrays are the same.
+
+    Explicit ``calc_scheme='reduced'`` with a spinful H0 arriving through
+    ``trans_mod`` / ``green_init`` and ``enable_spin_orbital = false``
+    computes BITWISE the same ``chi0q`` and ``chiq`` as the
+    ``enable_spin_orbital = true`` run on identical physics. Because the
+    arrays are identical, the npz route INHERITS the spin-orbital mode's
+    adjudication -- ``chi0`` = exact Lindhard (#133) and the #137/#139
+    vertex work -- and needs no adjudication of its own, and no guard.
+    (The investigation measured this equality across nine interaction
+    sets; the three below plus the ``green_init`` case are the record
+    kept in the suite.)
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.d = tmp.name
+        write_fixture(self.d)
+
+    def _assert_bitwise(self, sA, gA, sB, gB):
+        # both routes must really be spinful, else the record is vacuous
+        self.assertEqual(sA.spin_mode, "spinful")
+        self.assertEqual(sB.spin_mode, "spinful")
+        self.assertTrue(sA.ham_info.enable_spin_orbital)
+        self.assertFalse(sB.ham_info.enable_spin_orbital)
+        self.assertEqual(sA.calc_scheme, "reduced")
+        self.assertEqual(sB.calc_scheme, "reduced")
+        np.testing.assert_array_equal(np.asarray(sA.H0_k),
+                                      np.asarray(sB.H0_k))
+        np.testing.assert_array_equal(np.asarray(gA["chi0q"]),
+                                      np.asarray(gB["chi0q"]))
+        np.testing.assert_array_equal(np.asarray(gA["chiq"]),
+                                      np.asarray(gB["chiq"]))
+
+    def _trans_mod_case(self, interactions):
+        sA, gA = run_route(self.d, so=True, interactions=interactions,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        sB, gB = run_route(self.d, so=False, interactions=interactions,
+                           transfer=TRANSFER_MIX, trans_mod=TRANS_MOD)
+        self._assert_bitwise(sA, gA, sB, gB)
+
+    def test_trans_mod_coulombintra(self):
+        """CoulombIntra: the unconditional type, exact under reduced."""
+        self._trans_mod_case({"CoulombIntra": "coulombintra.dat"})
+
+    def test_trans_mod_coulombintra_plus_coulombinter(self):
+        """CoulombIntra + off-site CoulombInter: CoulombInter is a
+        CONDITIONAL type, so this is the case where reduced genuinely
+        discards cross-family vertex sectors -- and still both routes
+        discard exactly the same ones."""
+        self._trans_mod_case({"CoulombIntra": "coulombintra.dat",
+                              "CoulombInter": "coulombinter.dat"})
+
+    def test_trans_mod_pairlift_plus_coulombintra(self):
+        """PairLift + CoulombIntra: PairLift's ring spin table has
+        spin-off-diagonal slots, so it is the interaction most likely to
+        expose a spin-index convention mismatch between the interleaved
+        and spin-block readings. It does not."""
+        self._trans_mod_case({"CoulombIntra": "coulombintra.dat",
+                              "PairLift": "pairlift.dat"})
+
+    def test_green_init_route(self):
+        """The ``green_init`` half of the route. Here the transfer is
+        spin-INDEPENDENT and identical in both index conventions, and
+        the spin mixing enters through the initial Green function's Fock
+        term -- a different assembly path to the same conclusion."""
+        interactions = {"CoulombIntra": "coulombintra.dat",
+                        "PairLift": "pairlift.dat"}
+        sA, gA = run_route(self.d, so=True, interactions=interactions,
+                           transfer=TRANSFER_INDEP, green_init=GREEN_INIT)
+        sB, gB = run_route(self.d, so=False, interactions=interactions,
+                           transfer=TRANSFER_INDEP, green_init=GREEN_INIT)
+        self._assert_bitwise(sA, gA, sB, gB)
+
+
+class TestReducedSpinfulNpzExactnessWarning(unittest.TestCase):
+    """Issue #161's adjudication record, part 2: the user is told.
+
+    Part of the answer to "is this state acceptable?" is that it is not
+    silent. #167's reduced-exactness diagnostic fires on the npz route,
+    naming ``trans_mod`` / ``green_init`` as the cause of the flavour
+    mixing, so a user who explicitly asks for ``reduced`` with a
+    conditional type and a spinful npz is told the scheme is an
+    approximation for that input and that ``general`` / ``auto`` is
+    exact. No additional guard is warranted on top of it.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.d = tmp.name
+        write_fixture(self.d)
+
+    def test_warning_fires_with_trans_mod_cause(self):
+        interactions = {"CoulombIntra": "coulombintra.dat",
+                        "CoulombInter": "coulombinter.dat"}
+        with self.assertLogs("hwave.solver.rpa", level="WARNING") as ctx:
+            solver, _ = run_route(self.d, so=False,
+                                  interactions=interactions,
+                                  transfer=TRANSFER_MIX,
+                                  trans_mod=TRANS_MOD)
+        self.assertEqual(solver.spin_mode, "spinful")
+        hits = [m for m in ctx.output
+                if "mixes orbital flavour (trans_mod)" in m]
+        self.assertTrue(hits, ctx.output)
+        self.assertIn("calc_scheme='reduced' with CoulombInter", hits[0])
+        self.assertIn("is an APPROXIMATION for this input", hits[0])
+
+    def test_warning_fires_with_green_init_cause(self):
+        interactions = {"CoulombIntra": "coulombintra.dat",
+                        "PairLift": "pairlift.dat"}
+        with self.assertLogs("hwave.solver.rpa", level="WARNING") as ctx:
+            solver, _ = run_route(self.d, so=False,
+                                  interactions=interactions,
+                                  transfer=TRANSFER_INDEP,
+                                  green_init=GREEN_INIT)
+        self.assertEqual(solver.spin_mode, "spinful")
+        hits = [m for m in ctx.output
+                if "mixes orbital flavour (green_init)" in m]
+        self.assertTrue(hits, ctx.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpa_spinful_vertex_exchange.py
+++ b/tests/test_rpa_spinful_vertex_exchange.py
@@ -325,7 +325,12 @@ class TestExchangeTensorStructure(unittest.TestCase):
     it at all"; issue #174 falsified that premise (the npz routes reach
     the spinful solve with the flag off), so it is now a pin on the
     SOLVE instead -- see
-    ``test_non_spinful_solve_does_not_consume_exchange``."""
+    ``test_non_spinful_solve_does_not_consume_exchange``.
+
+    The tensor is materialized lazily, so the pins below call
+    ``ham_info.spinful_exchange()`` explicitly rather than reading the
+    ``ham_spinful_exchange`` cache, which construction alone leaves at
+    ``None`` for every mode."""
 
     LX = 4
 
@@ -374,7 +379,7 @@ class TestExchangeTensorStructure(unittest.TestCase):
         folded interaction itself must remain)."""
         solver = self._solver(True, (2, 1, 1), "CoulombInter",
                               [(1, 0, 0, 0.3), (-1, 0, 0, 0.3)])
-        self.assertIsNone(solver.ham_info.ham_spinful_exchange)
+        self.assertIsNone(solver.ham_info.spinful_exchange())
         self.assertTrue(np.any(np.abs(solver.ham_info.ham_inter_q) > 1e-12))
 
     def test_cell_aliased_offsite_is_not_crossed(self):
@@ -384,7 +389,7 @@ class TestExchangeTensorStructure(unittest.TestCase):
         solver = self._solver(True, (1, 1, 1), "CoulombInter",
                               [(self.LX, 0, 0, 0.3),
                                (-self.LX, 0, 0, 0.3)])
-        self.assertIsNone(solver.ham_info.ham_spinful_exchange)
+        self.assertIsNone(solver.ham_info.spinful_exchange())
 
     def test_non_spinful_solve_does_not_consume_exchange(self):
         """RESTATED for issue #174 (was
@@ -406,17 +411,21 @@ class TestExchangeTensorStructure(unittest.TestCase):
 
         WHAT REPLACES IT. The invariant is about the SOLVE, not the
         build: only the ``spin_mode == 'spinful'`` branch of
-        ``RPA._solve_impl`` reads ``ham_spinful_exchange``; the
-        ``spin-free`` and ``spin-diag`` branches take ``_fierz_long()``
-        unconditionally. So a NON-SPINFUL run's ``chiq`` is bitwise
-        independent of whether the crossing exists -- pinned here by
-        toggling ``spinful_vertex_exchange``, which is exactly the
-        switch that selects between consuming the crossing and taking
-        the ``_fierz_long()`` fallback, i.e. the pre-fix code path.
-        (The strongest available assertion: the crossing tensor itself
-        is not observable from a non-spinful solve, so equality of the
-        OUTPUT under the only switch that could expose it is what the
-        code supports.)
+        ``RPA._solve_impl`` reads the crossing; the ``spin-free`` and
+        ``spin-diag`` branches take ``_fierz_long()`` unconditionally.
+        Since the crossing is materialized lazily by
+        ``Interaction.spinful_exchange()`` (the round-2 review's memory
+        fix -- the tensor is (ns*norb)^4 complex128, 1.6 GB at norb=50,
+        so it must not be pinned by solves that never read it), "does
+        not consume" is now DIRECTLY observable: a non-spinful solve
+        leaves the ``ham_spinful_exchange`` cache at ``None``.
+
+        Pinned here in three ways: the output ``chiq`` is bitwise
+        independent of ``spinful_vertex_exchange`` (the switch that
+        selects between consuming the crossing and taking the
+        ``_fierz_long()`` fallback); the cache is still ``None`` after
+        the solve; and an explicit ``spinful_exchange()`` call does
+        produce a tensor, so its absence is laziness, not emptiness.
         """
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
@@ -442,9 +451,12 @@ class TestExchangeTensorStructure(unittest.TestCase):
         self.assertNotEqual(s_on.spin_mode, "spinful")
         np.testing.assert_array_equal(np.asarray(g_on["chiq"]),
                                       np.asarray(g_off["chiq"]))
-        # ... and the crossing IS built now, unlike under the old premise
-        self.assertIsNotNone(
-            getattr(s_on.ham_info, "ham_spinful_exchange", None))
+        # the solve never touched the crossing: the cache is untouched
+        self.assertIsNone(s_on.ham_info.ham_spinful_exchange)
+        self.assertFalse(s_on.ham_info._spinful_exchange_built)
+        # ... and that is laziness, not emptiness -- this input DOES
+        # source a crossing, as an explicit materialization shows
+        self.assertIsNotNone(s_on.ham_info.spinful_exchange())
 
     def test_aggregate_coulomb_mixed_sources_onsite_only(self):
         """The aggregate Coulomb input (split into intra + inter parts)
@@ -457,8 +469,8 @@ class TestExchangeTensorStructure(unittest.TestCase):
         onsite = [(0, 0, 0, 0.3)]
         s_mixed = self._solver(True, (2, 1, 1), "Coulomb", mixed)
         s_onsite = self._solver(True, (2, 1, 1), "Coulomb", onsite)
-        Xm = s_mixed.ham_info.ham_spinful_exchange
-        Xo = s_onsite.ham_info.ham_spinful_exchange
+        Xm = s_mixed.ham_info.spinful_exchange()
+        Xo = s_onsite.ham_info.spinful_exchange()
         self.assertIsNotNone(Xm)
         np.testing.assert_array_equal(Xm, Xo)
         # the folded off-site direct part must survive in ham_inter_q
@@ -480,8 +492,8 @@ class TestExchangeTensorStructure(unittest.TestCase):
                                norb_phys=2)
         s_onsite = self._solver(True, (2, 1, 1), "PairHop", onsite,
                                 norb_phys=2)
-        Xm = s_mixed.ham_info.ham_spinful_exchange
-        Xo = s_onsite.ham_info.ham_spinful_exchange
+        Xm = s_mixed.ham_info.spinful_exchange()
+        Xo = s_onsite.ham_info.spinful_exchange()
         self.assertIsNotNone(Xm)
         np.testing.assert_array_equal(Xm, Xo)
         # the complex phase must survive into the crossing
@@ -497,7 +509,7 @@ class TestExchangeTensorStructure(unittest.TestCase):
                 solver = self._solver(
                     True, (1, 1, 1), tname,
                     [(0, a, b, v) for (a, b, v) in ents], norb_phys=2)
-                X = solver.ham_info.ham_spinful_exchange
+                X = solver.ham_info.spinful_exchange()
                 self.assertIsNotNone(X)
                 nd = X.shape[0]
                 proj = project_density_pairs(

--- a/tests/test_rpa_spinful_vertex_exchange.py
+++ b/tests/test_rpa_spinful_vertex_exchange.py
@@ -319,8 +319,13 @@ class TestSpinConservingLimits(unittest.TestCase):
 class TestExchangeTensorStructure(unittest.TestCase):
     """Structural pins on ham_spinful_exchange itself (round-1 review):
     the crossing must be built from PRE-fold on-site declarations only,
-    its density-pair projection must vanish for every type, and
-    non-spin-orbital runs must not construct it at all."""
+    and its density-pair projection must vanish for every type.
+
+    The third pin used to be "non-spin-orbital runs must not construct
+    it at all"; issue #174 falsified that premise (the npz routes reach
+    the spinful solve with the flag off), so it is now a pin on the
+    SOLVE instead -- see
+    ``test_non_spinful_solve_does_not_consume_exchange``."""
 
     LX = 4
 
@@ -381,11 +386,65 @@ class TestExchangeTensorStructure(unittest.TestCase):
                                (-self.LX, 0, 0, 0.3)])
         self.assertIsNone(solver.ham_info.ham_spinful_exchange)
 
-    def test_non_spin_orbital_builds_no_exchange(self):
-        solver = self._solver(False, (1, 1, 1), "CoulombIntra",
-                              [(0, 0, 0, 0.3)])
-        self.assertIsNone(
-            getattr(solver.ham_info, "ham_spinful_exchange", None))
+    def test_non_spinful_solve_does_not_consume_exchange(self):
+        """RESTATED for issue #174 (was
+        ``test_non_spin_orbital_builds_no_exchange``).
+
+        FALSIFIED PREMISE. The old pin asserted that a
+        non-``enable_spin_orbital`` run builds no crossing at all,
+        encoding ``_make_ham_inter``'s comment that "no other mode
+        consumes it". That is false: ``RPA._calc_epsilon_k`` takes the
+        spin-orbital branch UNCONDITIONALLY for the ``trans_mod`` /
+        ``green_init`` npz routes, so a spin-mixing H0 supplied through
+        an npz reaches ``spin_mode == 'spinful'`` -- and therefore the
+        one solve branch that DOES consume the crossing -- with
+        ``enable_spin_orbital = False``. Gating construction on the flag
+        silently downgraded that solve to the pre-#137 ring-only vertex
+        (measured 1.7e-02, 12.2% relative in ``chiq``; issue #174,
+        regression-tested in ``tests/test_rpa_spinful_npz_general.py``).
+        The crossing is now built for every run.
+
+        WHAT REPLACES IT. The invariant is about the SOLVE, not the
+        build: only the ``spin_mode == 'spinful'`` branch of
+        ``RPA._solve_impl`` reads ``ham_spinful_exchange``; the
+        ``spin-free`` and ``spin-diag`` branches take ``_fierz_long()``
+        unconditionally. So a NON-SPINFUL run's ``chiq`` is bitwise
+        independent of whether the crossing exists -- pinned here by
+        toggling ``spinful_vertex_exchange``, which is exactly the
+        switch that selects between consuming the crossing and taking
+        the ``_fierz_long()`` fallback, i.e. the pre-fix code path.
+        (The strongest available assertion: the crossing tensor itself
+        is not observable from a non-spinful solve, so equality of the
+        OUTPUT under the only switch that could expose it is what the
+        code supports.)
+        """
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = tmp.name
+        _write_geom(d, 1)
+        with open(os.path.join(d, "transfer.dat"), "w") as f:
+            f.write("hdr\n1\n2\n1 1\n")
+            f.write(" 1 0 0 1 1 %.12f %.12f\n" % (THOP.real, THOP.imag))
+            f.write("-1 0 0 1 1 %.12f %.12f\n"
+                    % (np.conj(THOP).real, np.conj(THOP).imag))
+        with open(os.path.join(d, "coulombintra.dat"), "w") as f:
+            f.write("hdr\n1\n1\n1\n")
+            f.write(" 0 0 0 1 1 0.300000 0.0\n")
+        inter = {"path_to_input": d, "Geometry": "geom.dat",
+                 "Transfer": "transfer.dat",
+                 "CoulombIntra": "coulombintra.dat"}
+
+        s_on, g_on = _run_rpa(d, inter, self.LX, 16, so=False,
+                              exchange=True)
+        s_off, g_off = _run_rpa(d, inter, self.LX, 16, so=False,
+                                exchange=False)
+        # the run really is non-spinful (else the pin would be vacuous)
+        self.assertNotEqual(s_on.spin_mode, "spinful")
+        np.testing.assert_array_equal(np.asarray(g_on["chiq"]),
+                                      np.asarray(g_off["chiq"]))
+        # ... and the crossing IS built now, unlike under the old premise
+        self.assertIsNotNone(
+            getattr(s_on.ham_info, "ham_spinful_exchange", None))
 
     def test_aggregate_coulomb_mixed_sources_onsite_only(self):
         """The aggregate Coulomb input (split into intra + inter parts)

--- a/tests/test_spinful_transverse_ed.py
+++ b/tests/test_spinful_transverse_ed.py
@@ -567,7 +567,8 @@ def _s0_chi_dressed(v, nmat):
     solver.solve(green_info, tempfile.mkdtemp(prefix="s0_gate_out_"))
     chi0q = np.asarray(green_info["chi0q"])
     ham_inter_q = solver.ham_info.ham_inter_q
-    exch = solver.ham_info.ham_spinful_exchange
+    # materialize explicitly (#174): the crossing is lazy now
+    exch = solver.ham_info.spinful_exchange()
     if exch is None:
         exch = np.zeros(ham_inter_q.shape[-4:], dtype=complex)
     ham_long = rpa_mod._to_bubble_pair_convention(ham_inter_q + exch[None, ...])


### PR DESCRIPTION
## Summary

Two coupled items found by the #161 adjudication probes.

### Fix (#174)

With `enable_spin_orbital = false`, a spinful one-body Hamiltonian supplied via `trans_mod`/`green_init` reaches the spinful solve branch, but the antisymmetrized on-site exchange crossing (#137, `ham_spinful_exchange`) was never built — its precursor was gated on the config flag at construction. The `general`-scheme solve then silently fell back to the ring-only vertex: **12.2% relative chiq error**, confined to the spin-flip pair slots, no warning — and `calc_scheme="auto"` promotes INTO that path (`auto:mixed:trans_mod`/`green_init`).

The crossing is now **materialized lazily, exactly where a solve consumes it**: built (and cached) only for spinful, resolved-`general`, exchange-enabled solves. Consequences, all pinned by tests:
- npz-route `general` results are **bitwise identical** to the equivalent `enable_spin_orbital=true` run (trans_mod and green_init; RED at 1.705e-02/1.707e-02 before the fix);
- spin-free / spin-diag / opt-out (`spinful_vertex_exchange=false`) / `reduced` results are bitwise unchanged (56-array comparison across 8 interaction sets × both routes, max diff 0.0);
- no memory regression in either direction: non-spinful and `reduced` solves never allocate the `(ns·norb)⁴` tensor (peak-RSS measurements at norb=20 confirm exactly the 41 MB tensor is saved; cache verified empty), while the old pre-#174 gate's asymmetry is gone.

### Record (#161)

New `tests/test_rpa_spinful_npz_reduced.py` pins the adjudication: explicit `calc_scheme="reduced"` with a spinful H0 via `trans_mod`/`green_init` computes **bitwise** the same `chi0q`/`chiq` as the adjudicated spin-orbital run (which inherits the #133 exact-Lindhard chi0 validation and the #137/#139 vertex work), and the exactness warning fires with the right cause tokens. `TestReducedSpinfulGuard`'s docstring now points at the record instead of its former no-characterization caveat. No RPA guard is added — the FLEX-side rejection rationale (unvalidated dressed iteration) does not transfer to the one-shot ring.

## Verification

Three review rounds (final: zero findings). Full gate 2415 passed / 57 skipped / 1045 subtests (both runners on the changed modules). Known related items deliberately untouched: the `_read_trans_mod` interleaved/spin-block permutation hazard for `norb_phys>1` cross-mode npz reuse (noted in #174's body for a separate decision).

Closes #174. The #161 closure record accompanies this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJtf1VTFAPCmhDrMcwUtJj