### PR TITLE
FLEX: Hartree-Fock renormalisation and the bond-resolved longitudinal channel in the SCF loop (#181 Phase B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,4 @@ tests/rpa/input/*_fixture.npz
 # (test_grid_convergence_16_to_32), which regenerates it here on demand via
 # tests/sc/onari_bond/generate_fixtures.py. Never track this directory.
 tests/sc/onari_bond/_regenerated/
+tests/sc/onari_bond/_regenerated_flexbond/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ hwave_dos input.toml
 # RPA run (chi0q_mode = "load"), or chiq_s/chiq_c from a FLEX run
 # (chi0q_mode = "flex"), as selected in the [eliashberg] section.
 hwave_sc input.toml
+
+# Convert a total-form FLEX self-energy archive into the split form that a
+# run with flex_hartree_fock = true accepts as sigma_init
+hwave_sigma_split total.npz seed.npz --zero-static
 ```
 
 For input file format and examples, see the [User Manual](https://www.pasums.issp.u-tokyo.ac.jp/h-wave/en/doc/manual).

--- a/docs/en/source/algorithm/rpa.rst
+++ b/docs/en/source/algorithm/rpa.rst
@@ -676,12 +676,104 @@ Limitations of this version: real off-site coefficients only; off-site
 ``Exchange`` and ``PairHop`` declarations are rejected (their promotion
 through the bond basis is planned); no sublattice folding, no
 ``chi0q_init``, no ``enable_spin_orbital``; ``Nmat`` must be even; the
-gate cannot be combined with ``transverse_bond_channels``, and ``mode =
-"FLEX"`` refuses it (no bond-basis self-consistency yet). Each RPA
+gate cannot be combined with ``transverse_bond_channels``; in ``mode =
+"FLEX"`` the same key selects the self-consistent Hartree-Fock FLEX
+treatment of :ref:`flex_bond_hf`. Each RPA
 denominator is checked for conditioning at every :math:`q` and the run
 is refused inside the instability region (the smallest scores are
 reported as ``longitudinal_bond_cond_min_s`` / ``_c``); the estimated
 peak host memory is checked against ``longitudinal_bond_memory_cap_gb``
 before any expensive step.
+
+.. _flex_bond_hf:
+
+Bond-resolved FLEX with Hartree-Fock renormalisation (experimental)
+--------------------------------------------------------------------
+
+With ``flex_hartree_fock = true`` (``mode = "FLEX"``, ``calc_scheme =
+"general"``, spin-free system) the FLEX self-energy is the sum of two
+components that are iterated together,
+
+.. math::
+
+   \Sigma(k, i\omega_n) = \Sigma_{\rm HF}[G](k) + \Sigma_{\rm fluct}[G](k, i\omega_n),
+
+where :math:`\Sigma_{\rm HF}[G]` is the frequency-independent Hartree-Fock
+self-energy of EVERY accepted interaction term (on-site and off-site;
+``PairLift`` contributes zero on a paramagnetic density) built by the same
+kernel the UHFk solver uses, from the equal-time density matrix
+:math:`\rho_{ab}(r) = T \sum_n G_{ab}(r, i\omega_n) e^{i\omega_n 0^+}`
+of the dressed Green function (evaluated exactly for the static part of
+:math:`\Sigma` and with an :math:`O(N_{\rm mat}^{-3})` tail for the rest),
+and :math:`\Sigma_{\rm fluct}` is the second-and-higher-order fluctuation
+self-energy. Without the option the first-order terms a single chemical
+potential cannot absorb (orbital-dependent on-site Hartree shifts, the
+:math:`k`-dependent Fock term of an off-site interaction) are silently
+dropped; with it the theory is exact at first order in every coupling,
+:math:`\Sigma_{\rm HF}` is linear in each coefficient, and a fluctuation-free
+run reproduces the paramagnetic UHFk fixed point. A user mean field
+(``trans_mod`` / ``green_init``) is not folded into the band: the band stays
+the bare transfer and the mean field becomes the initial static self-energy
+:math:`\Delta H = H_{\rm mod} - H_0`, so it is never counted twice. The
+self-consistency is accepted when three residuals -- of the total
+self-energy, of the Green function and of the split components -- all fall
+below ``EPS`` for three consecutive iterations (the iteration log prints
+them with a ``[pass k/3]`` counter); the chemical potential is re-solved from
+the dressed Green function every iteration.
+
+With ``longitudinal_bond_channels = true`` in addition, the fluctuation
+self-energy is built on the bond-enlarged pair basis of the previous
+section at every bosonic frequency: the bubble :math:`\bar\chi_{mm'}(q,
+i\nu)` is assembled block by block from the dressed Green function, the
+spin and charge channels are dressed batch-wise in frequency with the same
+vertices :math:`S`, :math:`C` (channel-0 block: the general path's vertices
+including the Hartree part :math:`V(q)`; bond-diagonal blocks: the exchange
+crossing :math:`w_t V^{(t)}_{l_1 l_2}(R_m)`), and the effective interaction
+is
+
+.. math::
+
+   W = \tfrac{3}{2} S (\chi_s - \bar\chi) S + \tfrac{1}{2} C (\chi_c - \bar\chi) C + W^{(2)},
+
+the ring series from third order on plus the exact second order
+:math:`W^{(2)}`: on the channel-0 block :math:`[\tfrac{3}{2} S \bar\chi S +
+\tfrac{1}{2} C \bar\chi C]_{00} - \tfrac{1}{4}(S_{\rm on} + C_{\rm on})
+\bar\chi_{00} (S_{\rm on} + C_{\rm on})` (the general path's double-counting
+subtraction restricted to the on-site vertices, so that with every off-site
+coefficient zero the run is identical to the standard Hartree-Fock FLEX),
+on the mixed channel-0/bond blocks :math:`\tfrac{1}{4}(S \bar\chi S + C
+\bar\chi C)` (the exchange skeleton of the off-site interaction, once) and
+zero on the bond-bond blocks (their ring second order is the direct skeleton
+again). The self-energy is
+
+.. math::
+
+   \Sigma_{ab}(k, i\omega_n) = \frac{T}{N} \sum_{q, \nu} \sum_{m m'} \sum_{cd}
+   e^{+i(k-q)\cdot(R_{m'} - R_m)}\, W_{(m, c, a), (m', d, b)}(q, i\nu)\,
+   G_{cd}(k - q, i\omega_n - i\nu),
+
+with the bond form factor on the internal leg at both ends of :math:`W`
+(the block :math:`(m, m')` of :math:`W` pairs with the phase of the bubble
+block :math:`(m', m)`), realised as real-space rolls of :math:`G`. At second
+order in the couplings this reproduces the direct and exchange skeletons of
+the off-site interaction exactly (pinned by an independent real-space
+enumeration), including the :math:`UV` cross term; the standard general path,
+whose vertex is the Hartree part :math:`V(q)` only, keeps half of the direct
+:math:`V^2` term and no :math:`UV` cross term at second order. The ordinary
+``chi0q``, ``chiq_s``, ``chiq_c`` outputs of such a run are the
+:math:`(m = 0, m' = 0)` blocks of the bond-resolved objects of the last map;
+the sixteen ``longitudinal_bond_*`` static keys of the previous section are
+written as well, and the full dynamic channels on request
+(``longitudinal_bond_output_full``). Restarts: ``sigma.npz`` stores the two
+components (``sigma_convention = "split"``) and only such an archive can seed
+a run with ``flex_hartree_fock = true``; a legacy archive is converted with
+``hwave_sigma_split`` (``--zero-static``, ``--static static.npz`` or, for a
+UHFk mean field, ``--uhfk-trans-mod trans_mod.npz --bare-transfer
+transfer.dat``). Domain of this version: spin-free general scheme, uniform
+Matsubara grid, CPU, no sublattice, no external field, real off-site
+coefficients, off-site ``Exchange`` / ``PairHop`` refused; the estimated peak
+memory of the whole solve is checked against
+``longitudinal_bond_memory_cap_gb`` and the frequency batch is chosen to fit
+it.
 
 .. [1] `K. Yoshimi, T. Kato, H. Maebashi, J. Phys. Soc. Jpn. 78, 104002 (2009). <https://journals.jps.jp/doi/10.1143/JPSJ.78.104002>`_

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -286,7 +286,10 @@ in the ``output`` directory:
 - ``chiq_s.npz``: Spin susceptibility :math:`\chi_s(\mathbf{q}, i\nu_m)`
 - ``chiq_c.npz``: Charge susceptibility :math:`\chi_c(\mathbf{q}, i\nu_m)`
 - ``chiq.npz``: Combined susceptibility file
-- ``sigma.npz``: Self-energy :math:`\Sigma(\mathbf{k}, i\omega_n)`
+- ``sigma.npz``: Self-energy :math:`\Sigma(\mathbf{k}, i\omega_n)` (with
+  ``flex_hartree_fock = true`` also its two components ``sigma_static`` and
+  ``sigma_fluct``, the marker ``sigma_convention = "split"`` and the
+  convergence provenance; see :ref:`flex_bond_hf_tutorial`)
 - ``green.npz``: Dressed Green's function :math:`G(\mathbf{k}, i\omega_n)`
 - ``energy.dat``: Text file with the particle number ``NCond``, spin
   ``Sz``, and the converged ``ChemicalPotential`` :math:`\mu`.
@@ -350,6 +353,72 @@ aspect-ratio change like ``[2,8,1]`` vs ``[4,4,1]`` is caught), so keep
       [file.input]
         path_to_input = "."
         sigma_init = "run_T0.50/output/sigma.npz"
+
+.. _flex_bond_hf_tutorial:
+
+Hartree-Fock renormalisation and the bond-resolved channel (experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``flex_hartree_fock = true`` adds the self-consistent Hartree-Fock
+self-energy of every interaction term to the FLEX loop, and
+``longitudinal_bond_channels = true`` (which requires it) builds the
+fluctuation part on the bond-resolved pair basis so that the exchange
+crossing of an off-site ``CoulombInter`` / ``Hund`` / ``Ising`` enters
+self-consistently (see :ref:`flex_bond_hf` for the equations and the domain).
+Both are ``calc_scheme = "general"``, spin-free, CPU, uniform-grid options:
+
+.. code-block:: toml
+
+   [mode]
+     mode = "FLEX"
+     calc_scheme = "general"
+   [mode.param]
+     T = 0.02
+     filling = 0.35
+     CellShape = [16, 16, 1]
+     Nmat = 2048
+     mixing_scheme = "anderson"
+     anderson_depth = 8
+     Mix = 0.2
+     EPS = 8
+     flex_hartree_fock = true
+     longitudinal_bond_channels = true
+     # longitudinal_bond_output_full = true   # dynamic chi_s_w / chi_c_w archive
+   [file.output]
+     path_to_output = "output"
+     sigma = "sigma"
+     green = "green"
+     chiq = "chiq"         # the static longitudinal_bond_* keys go here
+     energy = "energy.dat"
+
+The run is accepted only when the three residuals of the split state stay
+below ``EPS`` for three consecutive iterations; the log prints them with a
+``[pass k/3]`` counter, and every archive records ``scf_converged`` and the
+last residuals (see the output reference). The ``hf_density_error`` field
+reports how well the Hartree-Fock density closes on the target filling.
+
+*Starting from a UHFk mean field.* Pass the UHFk ``trans_mod`` archive as
+today (``[file.input] trans_mod = "trans_mod.npz"``): with
+``flex_hartree_fock = true`` the mean field is NOT folded into the band but
+becomes the initial static self-energy, so the first iteration starts from
+the UHFk solution and the Hartree-Fock term is never counted twice. No
+converter is needed for this workflow.
+
+*Restarting from a previous run.* A ``sigma.npz`` written with
+``flex_hartree_fock = true`` carries the split components and seeds a new
+run exactly as stored (``[file.input] sigma_init``); do not pass a mean
+field at the same time (it is refused, since the archive already contains
+one). A ``sigma.npz`` from a run without ``flex_hartree_fock`` (or a
+hand-made total self-energy) is refused as a seed and must be converted::
+
+   hwave_sigma_split total.npz seed.npz --zero-static
+   hwave_sigma_split total.npz seed.npz --static static.npz
+   hwave_sigma_split total.npz seed.npz --uhfk-trans-mod trans_mod.npz --bare-transfer transfer.dat
+
+The last form builds the static correction from a native UHFk ``trans_mod``
+archive and the run's bare Transfer input (the archive is Fourier-transformed
+with the solver's convention, the bare transfer is subtracted and the result
+is reduced to the spin-free block). ``--force`` overwrites an existing output.
 
 **Spin susceptibility** :math:`\chi_s(\mathbf{q}, i\nu_0)`:
 
@@ -795,7 +864,8 @@ are shared with the RPA solver. See :ref:`Ch:Config_rpa` for details.
    measured element-complete equal to the RPA ring. (The omitted
    crossing is available, statically, in the RPA solver's experimental
    bond-resolved longitudinal channel, ``longitudinal_bond_channels =
-   true``; see :ref:`rpa_longitudinal_bond`.) Off-site ``Exchange``
+   true``, see :ref:`rpa_longitudinal_bond`, and self-consistently in the
+   Hartree-Fock FLEX, see :ref:`flex_bond_hf_tutorial`.) Off-site ``Exchange``
    and ``PairHop`` raise a ``ValueError``. An off-site ``Exchange`` has no
    effect a :math:`q`-dependent spin/charge vertex could carry (verified
    by exact diagonalization): its physics is spin-flip (transverse), which

--- a/docs/en/source/flex/tutorial/tu-index.rst
+++ b/docs/en/source/flex/tutorial/tu-index.rst
@@ -365,7 +365,11 @@ self-energy of every interaction term to the FLEX loop, and
 fluctuation part on the bond-resolved pair basis so that the exchange
 crossing of an off-site ``CoulombInter`` / ``Hund`` / ``Ising`` enters
 self-consistently (see :ref:`flex_bond_hf` for the equations and the domain).
-Both are ``calc_scheme = "general"``, spin-free, CPU, uniform-grid options:
+Both are ``calc_scheme = "general"``, spin-free, CPU, uniform-grid options.
+A complete input for a single-band square lattice with an on-site ``U`` and a
+nearest-neighbour ``V`` (the interaction files follow the Wannier90-style
+format of the :ref:`interaction input <Ch:Config_rpa>`; ``coulombinter.dat``
+lists the four bonds ``(+-1, 0, 0)``, ``(0, +-1, 0)``):
 
 .. code-block:: toml
 
@@ -383,13 +387,28 @@ Both are ``calc_scheme = "general"``, spin-free, CPU, uniform-grid options:
      EPS = 8
      flex_hartree_fock = true
      longitudinal_bond_channels = true
-     # longitudinal_bond_output_full = true   # dynamic chi_s_w / chi_c_w archive
+     # longitudinal_bond_memory_cap_gb = 8.0  # refuse before running if the estimate exceeds it
+     # longitudinal_bond_freq_batch = 64      # override the automatic frequency batch
+     # longitudinal_bond_output_full = true   # dynamic chi_s_w / chi_c_w archive (doubles the memory)
+   [file.input]
+     path_to_input = "."
+   [file.input.interaction]
+     path_to_input = "."
+     Geometry = "geom.dat"
+     Transfer = "transfer.dat"
+     CoulombIntra = "coulombintra.dat"
+     CoulombInter = "coulombinter.dat"
    [file.output]
      path_to_output = "output"
      sigma = "sigma"
      green = "green"
      chiq = "chiq"         # the static longitudinal_bond_* keys go here
+     # longitudinal_bond = "longitudinal_bond.npz"   # the dynamic archive (output_full only)
      energy = "energy.dat"
+
+Set ``[file.output] chiq`` in such runs: without it the static bond keys of
+BOTH channels are written into ``chiq_s.npz``. Output archive names without
+a ``.npz`` suffix get one appended, as for every other ``.npz`` output.
 
 The run is accepted only when the three residuals of the split state stay
 below ``EPS`` for three consecutive iterations; the log prints them with a
@@ -402,14 +421,21 @@ today (``[file.input] trans_mod = "trans_mod.npz"``): with
 ``flex_hartree_fock = true`` the mean field is NOT folded into the band but
 becomes the initial static self-energy, so the first iteration starts from
 the UHFk solution and the Hartree-Fock term is never counted twice. No
-converter is needed for this workflow.
+converter is needed for this workflow. The UHFk solution must be
+paramagnetic (``2Sz = 0``, equal spin blocks, no spin mixing): a
+magnetically ordered ``trans_mod`` is refused, because the Hartree-Fock
+FLEX is spin-free.
 
 *Restarting from a previous run.* A ``sigma.npz`` written with
 ``flex_hartree_fock = true`` carries the split components and seeds a new
-run exactly as stored (``[file.input] sigma_init``); do not pass a mean
-field at the same time (it is refused, since the archive already contains
-one). A ``sigma.npz`` from a run without ``flex_hartree_fock`` (or a
-hand-made total self-energy) is refused as a seed and must be converted::
+run exactly as stored (``[file.input] sigma_init``). Remove (or comment
+out) ``trans_mod`` and ``green_init`` from ``[file.input]`` in that case:
+the archive already contains the static part, and a mean field given at
+the same time is refused. A ``sigma.npz`` from a run without
+``flex_hartree_fock`` (or a hand-made total self-energy) is refused as a
+seed and must be converted; use ``--zero-static`` when that run had no
+mean field (its static part was absorbed by the chemical potential), and
+``--uhfk-trans-mod`` when it was started from a UHFk band modification::
 
    hwave_sigma_split total.npz seed.npz --zero-static
    hwave_sigma_split total.npz seed.npz --static static.npz

--- a/docs/en/source/howtouse/ho-index.rst
+++ b/docs/en/source/howtouse/ho-index.rst
@@ -128,6 +128,7 @@ Basic usage
      See File format sections for the details of the output files.
 
      The package also provides the post-processing tools ``hwave_dos`` (density of states)
-     and ``hwave_sc`` (Eliashberg / superconducting analysis), which take the same input file,
-     and the converter ``hwave_sigma_split`` (a total-form FLEX self-energy archive into the
-     split form that a run with ``flex_hartree_fock = true`` accepts as ``sigma_init``).
+     and ``hwave_sc`` (Eliashberg / superconducting analysis), which take the same input file.
+     The standalone converter ``hwave_sigma_split total.npz out.npz ...`` (positional
+     arguments, no input file) turns a total-form FLEX self-energy archive into the split
+     form that a run with ``flex_hartree_fock = true`` accepts as ``sigma_init``.

--- a/docs/en/source/howtouse/ho-index.rst
+++ b/docs/en/source/howtouse/ho-index.rst
@@ -128,4 +128,6 @@ Basic usage
      See File format sections for the details of the output files.
 
      The package also provides the post-processing tools ``hwave_dos`` (density of states)
-     and ``hwave_sc`` (Eliashberg / superconducting analysis), which take the same input file.
+     and ``hwave_sc`` (Eliashberg / superconducting analysis), which take the same input file,
+     and the converter ``hwave_sigma_split`` (a total-form FLEX self-energy archive into the
+     split form that a run with ``flex_hartree_fock = true`` accepts as ``sigma_init``).

--- a/docs/en/source/rpa/filespecification/config/index_config.rst
+++ b/docs/en/source/rpa/filespecification/config/index_config.rst
@@ -592,6 +592,7 @@ to the definition files.
   Name of the dedicated archive of the dynamic bond-resolved
   susceptibilities, written only when ``longitudinal_bond_channels =
   true`` and ``longitudinal_bond_output_full = true`` in FLEX mode (see
-  :ref:`flex_bond_hf`). It must not resolve to the same file as any other
-  output of the run (the collision is refused before the calculation
-  starts).
+  :ref:`flex_bond_hf`). A name without the ``.npz`` suffix gets it
+  appended, as for the other ``.npz`` outputs. It must not resolve to the
+  same file as any other output of the run (the collision is refused
+  before the calculation starts).

--- a/docs/en/source/rpa/filespecification/config/index_config.rst
+++ b/docs/en/source/rpa/filespecification/config/index_config.rst
@@ -261,9 +261,14 @@ Parameters
   ``Nmat``, no sublattice, no ``chi0q_init`` and no
   ``enable_spin_orbital``; an off-site ``Exchange`` or ``PairHop``
   declaration is rejected with an error. It cannot be combined with
-  ``transverse_bond_channels = true``. In ``mode = "FLEX"`` a ``true``
-  value is rejected (the bond basis has no self-consistent FLEX
-  treatment yet).
+  ``transverse_bond_channels = true``. In ``mode = "FLEX"`` the same key
+  enables the self-consistent bond-resolved channel of the Hartree-Fock
+  FLEX (experimental; requires ``flex_hartree_fock = true``,
+  ``calc_scheme = "general"``, a spin-free system, the uniform Matsubara
+  grid, CPU execution, no sublattice and an even ``Nmat``; see
+  :ref:`flex_bond_hf`). The bond-specific companions below keep their
+  meaning; ``longitudinal_bond_output_full`` and
+  ``longitudinal_bond_freq_batch`` are FLEX-only.
 
 - ``longitudinal_bond_max_shells``
 
@@ -291,6 +296,55 @@ Parameters
   The refusal message reports the estimate and the shapes behind it; on
   a machine with enough physical memory, raise the cap to proceed.
   Ignored with a warning unless ``longitudinal_bond_channels = true``.
+
+- ``flex_hartree_fock``
+
+  **Type :**
+  Boolean (default value is ``false``; FLEX mode only)
+
+  **Description :**
+  **Experimental.** Adds the self-consistent Hartree-Fock self-energy
+  :math:`\Sigma_{\rm HF}[G]` of EVERY accepted interaction term (on-site
+  and off-site) to the FLEX self-energy, :math:`\Sigma = \Sigma_{\rm HF}
+  + \Sigma_{\rm fluct}`, recomputed from the dressed Green function every
+  iteration (see :ref:`flex_bond_hf`). Requires ``calc_scheme =
+  "general"`` on a spin-free system, the uniform Matsubara grid
+  (``matsubara_basis = "ir"`` is refused), CPU execution (``gpu = true``
+  is refused), no sublattice, no external field and an even ``Nmat``.
+  A user mean field (``trans_mod`` / ``green_init``) is taken as the
+  initial static self-energy instead of being folded into the band;
+  ``sigma.npz`` gains the members ``sigma_static``, ``sigma_fluct``,
+  ``sigma_convention = "split"`` and a provenance block, and only a
+  ``"split"`` archive is accepted as ``sigma_init`` (see ``sigma_init``
+  and ``hwave_sigma_split``). Mandatory (``true``) when
+  ``longitudinal_bond_channels = true`` in FLEX mode. With ``false``
+  every output is unchanged.
+
+- ``longitudinal_bond_output_full``
+
+  **Type :**
+  Boolean (default value is ``false``; FLEX mode only)
+
+  **Description :**
+  Writes the full dynamic bond-resolved spin and charge susceptibilities
+  ``chi_s_w`` / ``chi_c_w`` (``ndarray(l, q, I, J)`` over the bosonic
+  frequencies) of the last SCF map into the dedicated archive named by
+  ``[file.output] longitudinal_bond`` (default ``longitudinal_bond.npz``).
+  Doubles the persistent memory of the bond-resolved solve; the archive
+  size is logged before writing. Ignored with a warning unless
+  ``longitudinal_bond_channels = true``.
+
+- ``longitudinal_bond_freq_batch``
+
+  **Type :**
+  Integer (default: chosen automatically; FLEX mode only)
+
+  **Description :**
+  Number of bosonic frequencies dressed at once by the bond-resolved
+  FLEX (in ``[1, Nmat]``). By default the largest batch that keeps the
+  estimated peak memory under ``longitudinal_bond_memory_cap_gb`` is
+  used; an explicit value is checked against the same cap. Ignored with
+  a warning unless ``longitudinal_bond_channels = true``.
 
 - ``matsubara_frequency``
 
@@ -456,7 +510,13 @@ They specify the settings of the input and output files, respectively, on the ty
   path is resolved relative to ``path_to_input``. The recorded ``CellShape``
   and the array's ``Nmat`` must match the current run (a mismatch is a
   fail-fast error). See the FLEX tutorial section "Warm-starting the SCF
-  loop" for the sweep workflow.
+  loop" for the sweep workflow. With ``flex_hartree_fock = true`` only a
+  ``sigma.npz`` written by such a run (``sigma_convention = "split"``,
+  carrying ``sigma_static`` and ``sigma_fluct``) is accepted, the two
+  components seed the loop exactly as stored, and a mean field
+  (``trans_mod`` / ``green_init``) given at the same time is refused; a
+  legacy or ``"total"`` archive is converted with ``hwave_sigma_split``
+  (see :ref:`flex_bond_hf`).
 
 
 ``file.input.interaction`` section
@@ -522,3 +582,16 @@ to the definition files.
   This parameter specifies the name of the file to store the susceptibility matrix
   :math:`\chi(\vec{q})`.
   If it is not set, no output will be generated.
+
+- ``longitudinal_bond``
+
+  **Type :**
+  String (default value is ``longitudinal_bond.npz``; FLEX mode only)
+
+  **Description :**
+  Name of the dedicated archive of the dynamic bond-resolved
+  susceptibilities, written only when ``longitudinal_bond_channels =
+  true`` and ``longitudinal_bond_output_full = true`` in FLEX mode (see
+  :ref:`flex_bond_hf`). It must not resolve to the same file as any other
+  output of the run (the collision is refused before the calculation
+  starts).

--- a/docs/en/source/rpa/filespecification/outputfiles/chiq_rpa.rst
+++ b/docs/en/source/rpa/filespecification/outputfiles/chiq_rpa.rst
@@ -168,6 +168,33 @@ on-site :math:`R = 0`), :math:`n_d = n_{\rm orb}^2` and :math:`N_D = B\, n_d`:
   :math:`q`; the run is refused when it reaches the instability floor) and
   ``longitudinal_bond_schema`` (integer, ``1``).
 
+In ``mode = "FLEX"`` with ``longitudinal_bond_channels = true`` (the
+Hartree-Fock FLEX of :ref:`flex_bond_hf`) the same sixteen keys describe the
+LAST self-consistent map (``longitudinal_bond_source = "last_map"``) and are
+written into the combined ``chiq`` file when ``[file.output] chiq`` is set,
+otherwise into the ``chiq_s`` file (which always exists; the charge-channel
+static keys are then found in ``chiq_s.npz`` -- an INFO line says so). The
+ordinary ``chi0q``, ``chiq_s`` and ``chiq_c`` arrays of such a run are the
+:math:`(m = 0, m' = 0)` blocks of the bond-resolved objects at every bosonic
+frequency. Every archive of a run with ``flex_hartree_fock = true`` (``chi0q``,
+``chiq_s``, ``chiq_c``, ``chiq``, ``sigma`` and ``green``) also carries the
+provenance block ``scf_converged``, ``scf_iterations``, ``map_iteration``,
+``state_iteration``, ``scf_sigma_residual``, ``scf_green_residual``,
+``scf_component_residual``, ``payload_kind`` (``"last_map"`` for the
+susceptibilities, ``"final_state"`` for ``sigma`` / ``green``),
+``hf_density_error`` (the density-closure error of the state the payload
+describes, with ``hf_density_source``) and ``density_target_enforced``.
+With ``longitudinal_bond_output_full = true`` the dedicated archive
+(``[file.output] longitudinal_bond``, default ``longitudinal_bond.npz``)
+holds ``bond_archive_schema`` (``1``), the full dynamic ``chi_s_w`` and
+``chi_c_w`` (``ndarray(l, q, I, J)``, ``freq_axis = "bosonic l -> 2l -
+nmat"``), ``beta``, ``T``, ``nmat``, ``cell_shape``, the momentum-convention
+markers, ``index_order``, ``delta_r``, ``reverse``, ``types``, the sixteen
+static keys and the provenance block; nothing else duplicates these arrays.
+With ``IterationMax = 0`` no map is executed and every last-map archive is
+omitted (an INFO line lists them); only ``sigma``, ``green`` and ``energy``
+of the seed state are written.
+
 
 Example for reading data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ja/source/algorithm/rpa.rst
+++ b/docs/ja/source/algorithm/rpa.rst
@@ -641,11 +641,85 @@ e^{ik\cdot(R_m - R_{m'})} G_{l_1 l_3}(k+q)\, G_{l_4 l_2}(k)`\ 、
 取り込みは今後の予定）。副格子折り畳み・\ ``chi0q_init``\ ・
 ``enable_spin_orbital``\ は非対応。\ ``Nmat``\ は偶数である必要が
 あります。\ ``transverse_bond_channels``\ とは併用できず、
-``mode = "FLEX"``\ では拒否されます（ボンド基底の自己無撞着計算は
-未実装）。各 RPA 分母は全ての\ :math:`q`\ で条件数が検査され、
+``mode = "FLEX"``\ では同じキーが :ref:`flex_bond_hf`\ の自己無撞着な
+Hartree-Fock FLEX 版を選択します。各 RPA 分母は全ての\ :math:`q`\ で条件数が検査され、
 不安定領域では実行が拒否されます（最小スコアは
 ``longitudinal_bond_cond_min_s`` / ``_c``\ として出力）。推定ピーク
 ホストメモリは高コストな計算の前に\ ``longitudinal_bond_memory_cap_gb``
 と照合されます。
+
+.. _flex_bond_hf:
+
+Hartree-Fock 繰り込み付きボンド分解 FLEX（実験的機能）
+----------------------------------------------------------
+
+``flex_hartree_fock = true``\ （``mode = "FLEX"``\ 、\ ``calc_scheme = "general"``\ 、
+スピンフリー系）では、FLEX の自己エネルギーは同時に反復される2つの成分の和
+
+.. math::
+
+   \Sigma(k, i\omega_n) = \Sigma_{\rm HF}[G](k) + \Sigma_{\rm fluct}[G](k, i\omega_n)
+
+になります。ここで\ :math:`\Sigma_{\rm HF}[G]`\ は、受理された **全て** の相互作用項
+（オンサイト・オフサイト。\ ``PairLift``\ は常磁性密度に対してゼロ）の振動数に依らない
+Hartree-Fock 自己エネルギーで、UHFk ソルバーと同じカーネルにより、ドレスドグリーン関数の
+等時刻密度行列\ :math:`\rho_{ab}(r) = T \sum_n G_{ab}(r, i\omega_n) e^{i\omega_n 0^+}`
+（:math:`\Sigma`\ の静的部分については厳密、それ以外は\ :math:`O(N_{\rm mat}^{-3})`\ の
+裾で評価）から作られます。\ :math:`\Sigma_{\rm fluct}`\ は2次以上のゆらぎ自己エネルギー
+です。このオプションなしでは、1つの化学ポテンシャルで吸収できない1次の項（軌道依存の
+オンサイト Hartree シフト、オフサイト相互作用の\ :math:`k`\ 依存 Fock 項）は暗黙に
+落とされます。オプションありでは理論は全ての結合について1次で厳密になり、
+:math:`\Sigma_{\rm HF}`\ は各係数について線形で、ゆらぎを切った計算は常磁性 UHFk の
+固定点を再現します。ユーザー指定の平均場（``trans_mod`` / ``green_init``\ ）はバンドに
+折り込まれません。バンドは裸の移動積分のままで、平均場は静的自己エネルギーの初期値
+:math:`\Delta H = H_{\rm mod} - H_0`\ となるため、二重に数えられることはありません。
+自己無撞着性は、全自己エネルギー・グリーン関数・分割成分の3つの残差が3反復連続で
+``EPS``\ を下回ったときに受理されます（反復ログには\ ``[pass k/3]``\ カウンタとともに
+出力されます）。化学ポテンシャルは毎反復ドレスドグリーン関数から解き直されます。
+
+さらに\ ``longitudinal_bond_channels = true``\ とすると、ゆらぎ自己エネルギーは前節の
+ボンド拡張した対基底の上で全てのボソン振動数について構築されます。バブル
+:math:`\bar\chi_{mm'}(q, i\nu)`\ はドレスドグリーン関数からブロックごとに組み立てられ、
+スピン・電荷チャネルは同じ頂点\ :math:`S`\ ・\ :math:`C`\ （チャネル0ブロック：Hartree 部分
+:math:`V(q)`\ を含む一般経路の頂点、ボンド対角ブロック：交換交差
+:math:`w_t V^{(t)}_{l_1 l_2}(R_m)`\ ）で振動数のバッチごとにドレスされ、有効相互作用は
+
+.. math::
+
+   W = \tfrac{3}{2} S (\chi_s - \bar\chi) S + \tfrac{1}{2} C (\chi_c - \bar\chi) C + W^{(2)}
+
+すなわち3次以上の ring 級数と厳密な2次項\ :math:`W^{(2)}`\ の和です。\ :math:`W^{(2)}`\ は、
+チャネル0ブロックでは\ :math:`[\tfrac{3}{2} S \bar\chi S + \tfrac{1}{2} C \bar\chi C]_{00}
+- \tfrac{1}{4}(S_{\rm on} + C_{\rm on}) \bar\chi_{00} (S_{\rm on} + C_{\rm on})`
+（一般経路の二重計算補正をオンサイト頂点に限定したもの。オフサイト係数が全てゼロなら
+計算は標準の Hartree-Fock FLEX と同一）、チャネル0とボンドの混合ブロックでは
+:math:`\tfrac{1}{4}(S \bar\chi S + C \bar\chi C)`\ （オフサイト相互作用の交換スケルトンを
+1回）、ボンド–ボンドブロックではゼロ（その ring の2次は直接スケルトンの重複）です。
+自己エネルギーは
+
+.. math::
+
+   \Sigma_{ab}(k, i\omega_n) = \frac{T}{N} \sum_{q, \nu} \sum_{m m'} \sum_{cd}
+   e^{+i(k-q)\cdot(R_{m'} - R_m)}\, W_{(m, c, a), (m', d, b)}(q, i\nu)\,
+   G_{cd}(k - q, i\omega_n - i\nu)
+
+で、ボンドの形状因子は\ :math:`W`\ の両端で内線側に付き（:math:`W`\ のブロック
+:math:`(m, m')`\ はバブルのブロック\ :math:`(m', m)`\ の位相と対になります）、実空間では
+:math:`G`\ の roll として実装されています。結合の2次では、オフサイト相互作用の直接・交換
+スケルトンを\ :math:`UV`\ 交差項も含めて厳密に再現します（独立な実空間列挙で固定）。
+一方、Hartree 部分\ :math:`V(q)`\ のみを頂点に持つ標準の一般経路は、2次で直接\ :math:`V^2`
+項の半分のみを持ち、\ :math:`UV`\ 交差項を持ちません。このような計算の通常の
+``chi0q``\ ・\ ``chiq_s``\ ・\ ``chiq_c``\ 出力は、最後の写像のボンド分解した量の
+:math:`(m = 0, m' = 0)`\ ブロックです。前節の16個の\ ``longitudinal_bond_*``\ 静的キーも
+書き出され、要求に応じて動的チャネル全体も出力されます
+（``longitudinal_bond_output_full``\ ）。再開: ``sigma.npz``\ は2つの成分を保存し
+（``sigma_convention = "split"``\ ）、\ ``flex_hartree_fock = true``\ の計算の初期値には
+このアーカイブのみが使えます。旧形式のアーカイブは\ ``hwave_sigma_split``\ で変換します
+（``--zero-static``\ 、\ ``--static static.npz``\ 、または UHFk 平均場からは
+``--uhfk-trans-mod trans_mod.npz --bare-transfer transfer.dat``\ ）。このバージョンの
+適用範囲: スピンフリーの一般スキーム、一様松原格子、CPU、副格子なし、外場なし、実数の
+オフサイト係数、オフサイト\ ``Exchange`` / ``PairHop``\ は拒否。解法全体の推定ピーク
+メモリは\ ``longitudinal_bond_memory_cap_gb``\ と照合され、振動数バッチはそれに収まる
+ように選ばれます。
 
 .. [1] `K. Yoshimi, T. Kato, H. Maebashi, J. Phys. Soc. Jpn. 78, 104002 (2009). <https://journals.jps.jp/doi/10.1143/JPSJ.78.104002>`_

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -340,7 +340,10 @@ Hartree-Fock 繰り込みとボンド分解チャネル（実験的機能）
 はゆらぎ部分をボンド分解した対基底の上で構築して、オフサイト
 ``CoulombInter`` / ``Hund`` / ``Ising``\ の交換交差を自己無撞着に取り込みます
 （式と適用範囲は\ :ref:`flex_bond_hf`\ を参照）。いずれも\ ``calc_scheme = "general"``\ ・
-スピンフリー・CPU・一様格子のオプションです:
+スピンフリー・CPU・一様格子のオプションです。オンサイト\ ``U``\ と最近接\ ``V``\ を
+持つ単一バンド正方格子の完全な入力例を示します（相互作用ファイルは
+:ref:`相互作用入力 <Ch:Config_rpa>`\ の Wannier90 形式で、\ ``coulombinter.dat``\ には
+4本のボンド\ ``(+-1, 0, 0)``\ ・\ ``(0, +-1, 0)``\ を列挙します）:
 
 .. code-block:: toml
 
@@ -358,13 +361,28 @@ Hartree-Fock 繰り込みとボンド分解チャネル（実験的機能）
      EPS = 8
      flex_hartree_fock = true
      longitudinal_bond_channels = true
-     # longitudinal_bond_output_full = true   # 動的 chi_s_w / chi_c_w のアーカイブ
+     # longitudinal_bond_memory_cap_gb = 8.0  # 推定値がこれを超えると実行前に拒否
+     # longitudinal_bond_freq_batch = 64      # 振動数バッチの自動選択を上書き
+     # longitudinal_bond_output_full = true   # 動的 chi_s_w / chi_c_w のアーカイブ（メモリ2倍）
+   [file.input]
+     path_to_input = "."
+   [file.input.interaction]
+     path_to_input = "."
+     Geometry = "geom.dat"
+     Transfer = "transfer.dat"
+     CoulombIntra = "coulombintra.dat"
+     CoulombInter = "coulombinter.dat"
    [file.output]
      path_to_output = "output"
      sigma = "sigma"
      green = "green"
      chiq = "chiq"         # 静的な longitudinal_bond_* キーはここに書かれます
+     # longitudinal_bond = "longitudinal_bond.npz"   # 動的アーカイブ（output_full のときのみ）
      energy = "energy.dat"
+
+このような計算では\ ``[file.output] chiq``\ を指定してください。指定がないと、両チャネルの
+静的ボンドキーが\ ``chiq_s.npz``\ に書き出されます。\ ``.npz``\ 拡張子のない出力名には、
+他の\ ``.npz``\ 出力と同様に拡張子が付加されます。
 
 計算は、分割状態の3つの残差が3反復連続で\ ``EPS``\ を下回ったときにのみ収束と
 みなされます。ログには\ ``[pass k/3]``\ カウンタとともに残差が出力され、全ての
@@ -375,13 +393,18 @@ Hartree-Fock 繰り込みとボンド分解チャネル（実験的機能）
 （``[file.input] trans_mod = "trans_mod.npz"``\ ）。\ ``flex_hartree_fock = true``\ では
 平均場はバンドに折り込まれ **ず** 、静的自己エネルギーの初期値になるため、最初の反復は
 UHFk 解から始まり、Hartree-Fock 項が二重に数えられることはありません。この使い方に
-変換ツールは不要です。
+変換ツールは不要です。UHFk 解は常磁性（``2Sz = 0``\ 、等しいスピンブロック、スピン混合なし）
+である必要があります。磁気秩序のある\ ``trans_mod``\ は拒否されます（Hartree-Fock FLEX は
+スピンフリーのため）。
 
 *以前の計算から再開する。* ``flex_hartree_fock = true``\ で出力された\ ``sigma.npz``\ は
 分割成分を含み、そのまま新しい計算の初期値になります（``[file.input] sigma_init``\ ）。
-同時に平均場は渡さないでください（アーカイブが既に平均場を含むため拒否されます）。
+その場合は\ ``[file.input]``\ の\ ``trans_mod``\ と\ ``green_init``\ を削除（またはコメント
+アウト）してください。アーカイブは既に静的部分を含むため、同時に平均場を渡すと拒否されます。
 ``flex_hartree_fock``\ なしの計算の\ ``sigma.npz``\ （や手作りの全自己エネルギー）は
-初期値として拒否されるため、変換が必要です::
+初期値として拒否されるため、変換が必要です。その計算が平均場なしだった（静的部分が
+化学ポテンシャルに吸収されていた）場合は\ ``--zero-static``\ を、UHFk のバンド修正から
+始めていた場合は\ ``--uhfk-trans-mod``\ を使います::
 
    hwave_sigma_split total.npz seed.npz --zero-static
    hwave_sigma_split total.npz seed.npz --static static.npz

--- a/docs/ja/source/flex/tutorial/tu-index.rst
+++ b/docs/ja/source/flex/tutorial/tu-index.rst
@@ -269,7 +269,9 @@ Kanamori頂点を **保持** します。これはMochizuki--Yanase--Ogata (MYO)
 - ``chiq_s.npz``: スピン感受率\ :math:`\chi_s(\mathbf{q}, i\nu_m)`
 - ``chiq_c.npz``: 電荷感受率\ :math:`\chi_c(\mathbf{q}, i\nu_m)`
 - ``chiq.npz``: 結合感受率ファイル
-- ``sigma.npz``: 自己エネルギー\ :math:`\Sigma(\mathbf{k}, i\omega_n)`
+- ``sigma.npz``: 自己エネルギー\ :math:`\Sigma(\mathbf{k}, i\omega_n)`\ （``flex_hartree_fock = true``
+  では2つの成分\ ``sigma_static``\ ・\ ``sigma_fluct``\ 、マーカー\ ``sigma_convention = "split"``\ 、
+  収束の来歴も含みます。:ref:`flex_bond_hf_tutorial`\ を参照）
 - ``green.npz``: ドレスドグリーン関数\ :math:`G(\mathbf{k}, i\omega_n)`
 - ``energy.dat``: 粒子数\ ``NCond``\ 、スピン\ ``Sz``\ 、収束した化学ポテンシャル
   ``ChemicalPotential`` :math:`\mu`\ を記載したテキストファイル。
@@ -327,6 +329,67 @@ continuation スイープでは\ ``Nmat``\ と\ ``CellShape``\ を固定して�
       [file.input]
         path_to_input = "."
         sigma_init = "run_T0.50/output/sigma.npz"
+
+.. _flex_bond_hf_tutorial:
+
+Hartree-Fock 繰り込みとボンド分解チャネル（実験的機能）
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``flex_hartree_fock = true``\ は全ての相互作用項の自己無撞着な Hartree-Fock
+自己エネルギーを FLEX ループに加え、\ ``longitudinal_bond_channels = true``\ （前者が必須）
+はゆらぎ部分をボンド分解した対基底の上で構築して、オフサイト
+``CoulombInter`` / ``Hund`` / ``Ising``\ の交換交差を自己無撞着に取り込みます
+（式と適用範囲は\ :ref:`flex_bond_hf`\ を参照）。いずれも\ ``calc_scheme = "general"``\ ・
+スピンフリー・CPU・一様格子のオプションです:
+
+.. code-block:: toml
+
+   [mode]
+     mode = "FLEX"
+     calc_scheme = "general"
+   [mode.param]
+     T = 0.02
+     filling = 0.35
+     CellShape = [16, 16, 1]
+     Nmat = 2048
+     mixing_scheme = "anderson"
+     anderson_depth = 8
+     Mix = 0.2
+     EPS = 8
+     flex_hartree_fock = true
+     longitudinal_bond_channels = true
+     # longitudinal_bond_output_full = true   # 動的 chi_s_w / chi_c_w のアーカイブ
+   [file.output]
+     path_to_output = "output"
+     sigma = "sigma"
+     green = "green"
+     chiq = "chiq"         # 静的な longitudinal_bond_* キーはここに書かれます
+     energy = "energy.dat"
+
+計算は、分割状態の3つの残差が3反復連続で\ ``EPS``\ を下回ったときにのみ収束と
+みなされます。ログには\ ``[pass k/3]``\ カウンタとともに残差が出力され、全ての
+アーカイブに\ ``scf_converged``\ と最後の残差が記録されます（出力ファイルの説明を参照）。
+``hf_density_error``\ は Hartree-Fock 密度が目標の充填にどれだけ閉じているかを示します。
+
+*UHFk の平均場から始める。* 従来どおり UHFk の\ ``trans_mod``\ アーカイブを渡します
+（``[file.input] trans_mod = "trans_mod.npz"``\ ）。\ ``flex_hartree_fock = true``\ では
+平均場はバンドに折り込まれ **ず** 、静的自己エネルギーの初期値になるため、最初の反復は
+UHFk 解から始まり、Hartree-Fock 項が二重に数えられることはありません。この使い方に
+変換ツールは不要です。
+
+*以前の計算から再開する。* ``flex_hartree_fock = true``\ で出力された\ ``sigma.npz``\ は
+分割成分を含み、そのまま新しい計算の初期値になります（``[file.input] sigma_init``\ ）。
+同時に平均場は渡さないでください（アーカイブが既に平均場を含むため拒否されます）。
+``flex_hartree_fock``\ なしの計算の\ ``sigma.npz``\ （や手作りの全自己エネルギー）は
+初期値として拒否されるため、変換が必要です::
+
+   hwave_sigma_split total.npz seed.npz --zero-static
+   hwave_sigma_split total.npz seed.npz --static static.npz
+   hwave_sigma_split total.npz seed.npz --uhfk-trans-mod trans_mod.npz --bare-transfer transfer.dat
+
+最後の形式は、UHFk の\ ``trans_mod``\ アーカイブと計算の裸の Transfer 入力から静的補正を
+作ります（アーカイブをソルバーの規約で Fourier 変換し、裸の移動積分を引き、スピンフリーの
+ブロックに縮約します）。\ ``--force``\ で既存の出力を上書きします。
 
 **スピン感受率** :math:`\chi_s(\mathbf{q}, i\nu_0)`:
 
@@ -739,7 +802,8 @@ FLEXソルバーは\ ``[mode.param]``\ セクションで以下のパラメー�
    これらのクラスはいずれも RPA ring と要素完全一致が実測されています
    （省かれた交換交差は、RPA ソルバーの実験的なボンド分解縦方向チャネル
    ``longitudinal_bond_channels = true``\ で静的に取り込めます。
-   :ref:`rpa_longitudinal_bond`\ を参照）。
+   :ref:`rpa_longitudinal_bond`\ を参照。Hartree-Fock FLEX では自己無撞着に
+   取り込まれます。:ref:`flex_bond_hf_tutorial`\ を参照）。
    オフサイトの\ ``Exchange``\ と\ ``PairHop``\ は\ ``ValueError``\ と
    なります。オフサイトの\ ``Exchange``\ には、:math:`q` に依存する
    スピン・電荷頂点で表せる効果がありません（厳密対角化で確認済み）。

--- a/docs/ja/source/howtouse/ho-index.rst
+++ b/docs/ja/source/howtouse/ho-index.rst
@@ -138,6 +138,7 @@
 
      また、本パッケージには後処理ツール\ ``hwave_dos``\ （状態密度）および
      ``hwave_sc``\ （Eliashberg方程式・超伝導解析）が含まれており、同じ入力ファイルを利用します。
-     また、変換ツール\ ``hwave_sigma_split``\ （FLEX の全自己エネルギーアーカイブを、
-     ``flex_hartree_fock = true``\ の計算が\ ``sigma_init``\ として受理する分割形式に変換）も含まれます。
+     また、単独で動く変換ツール\ ``hwave_sigma_split total.npz out.npz ...``\ （位置引数で
+     指定し、入力ファイルは使いません）は、FLEX の全自己エネルギーアーカイブを
+     ``flex_hartree_fock = true``\ の計算が\ ``sigma_init``\ として受理する分割形式に変換します。
 

--- a/docs/ja/source/howtouse/ho-index.rst
+++ b/docs/ja/source/howtouse/ho-index.rst
@@ -138,4 +138,6 @@
 
      また、本パッケージには後処理ツール\ ``hwave_dos``\ （状態密度）および
      ``hwave_sc``\ （Eliashberg方程式・超伝導解析）が含まれており、同じ入力ファイルを利用します。
+     また、変換ツール\ ``hwave_sigma_split``\ （FLEX の全自己エネルギーアーカイブを、
+     ``flex_hartree_fock = true``\ の計算が\ ``sigma_init``\ として受理する分割形式に変換）も含まれます。
 

--- a/docs/ja/source/rpa/filespecification/config/index_config.rst
+++ b/docs/ja/source/rpa/filespecification/config/index_config.rst
@@ -213,8 +213,13 @@ TOML形式
   ``chi0q_init``\ なし、\ ``enable_spin_orbital``\ なしが必要で、
   オフサイトの\ ``Exchange``\ または\ ``PairHop``\ の宣言はエラーとして
   拒否されます。\ ``transverse_bond_channels = true``\ とは併用でき
-  ません。\ ``mode = "FLEX"``\ では\ ``true``\ は拒否されます
-  （ボンド基底の自己無撞着 FLEX はまだありません）。
+  ません。\ ``mode = "FLEX"``\ では同じキーが Hartree-Fock FLEX の
+  自己無撞着なボンド分解チャネルを有効にします（実験的機能。
+  ``flex_hartree_fock = true``\ ・\ ``calc_scheme = "general"``\ ・
+  スピンフリー系・一様松原格子・CPU 実行・副格子なし・偶数の\ ``Nmat``
+  が必要。:ref:`flex_bond_hf`\ を参照）。以下のボンド関連の補助キーは
+  同じ意味を持ち、\ ``longitudinal_bond_output_full``\ と
+  ``longitudinal_bond_freq_batch``\ は FLEX 専用です。
 
 - ``longitudinal_bond_max_shells``
 
@@ -239,6 +244,52 @@ TOML形式
   その根拠となる配列形状が示されるので、物理メモリに余裕がある計算機では
   上限を引き上げて実行してください。\ ``longitudinal_bond_channels = true``
   でない場合は警告付きで無視されます。
+
+- ``flex_hartree_fock``
+
+  **形式 :** bool型 (デフォルトは\ ``false``\ 。FLEXモードのみ)
+
+  **説明 :**
+  **実験的機能。** 受理された **全て** の相互作用項（オンサイト・
+  オフサイト）の自己無撞着な Hartree-Fock 自己エネルギー
+  :math:`\Sigma_{\rm HF}[G]`\ を FLEX の自己エネルギーに加えます
+  （:math:`\Sigma = \Sigma_{\rm HF} + \Sigma_{\rm fluct}`\ 。毎反復
+  ドレスドグリーン関数から再計算。:ref:`flex_bond_hf`\ を参照）。
+  スピンフリー系での\ ``calc_scheme = "general"``\ 、一様松原格子
+  （``matsubara_basis = "ir"``\ は拒否）、CPU 実行（``gpu = true``\ は
+  拒否）、副格子なし、外場なし、偶数の\ ``Nmat``\ が必要です。
+  ユーザー指定の平均場（``trans_mod`` / ``green_init``\ ）はバンドに
+  折り込まれず、静的自己エネルギーの初期値として扱われます。
+  ``sigma.npz``\ には\ ``sigma_static``\ ・\ ``sigma_fluct``\ ・
+  ``sigma_convention = "split"``\ と来歴ブロックが追加され、
+  ``sigma_init``\ には\ ``"split"``\ 形式のアーカイブのみが受理されます
+  （``sigma_init``\ と\ ``hwave_sigma_split``\ を参照）。FLEX モードで
+  ``longitudinal_bond_channels = true``\ とする場合は\ ``true``\ が必須
+  です。\ ``false``\ では全ての出力が従来と同一です。
+
+- ``longitudinal_bond_output_full``
+
+  **形式 :** bool型 (デフォルトは\ ``false``\ 。FLEXモードのみ)
+
+  **説明 :**
+  最後の SCF 写像のボンド分解した動的スピン・電荷感受率
+  ``chi_s_w`` / ``chi_c_w``\ （ボソン振動数上の\ ``ndarray(l, q, I, J)``\ ）
+  を、\ ``[file.output] longitudinal_bond``\ で指定した専用アーカイブ
+  （デフォルト\ ``longitudinal_bond.npz``\ ）に書き出します。ボンド分解
+  した解法の常駐メモリが2倍になります。アーカイブのサイズは書き出し前に
+  ログに出力されます。\ ``longitudinal_bond_channels = true``\ でない
+  場合は警告付きで無視されます。
+
+- ``longitudinal_bond_freq_batch``
+
+  **形式 :** int型 (デフォルトは自動選択。FLEXモードのみ)
+
+  **説明 :**
+  ボンド分解 FLEX が一度にドレスするボソン振動数の数（``[1, Nmat]``\ ）
+  です。デフォルトでは推定ピークメモリが
+  ``longitudinal_bond_memory_cap_gb``\ 以下に収まる最大のバッチが
+  選ばれ、明示した値も同じ上限と照合されます。
+  ``longitudinal_bond_channels = true``\ でない場合は警告付きで無視されます。
 
 - ``matsubara_frequency``
 
@@ -350,7 +401,7 @@ TOML形式
 
   **形式 :** str型（FLEXモードのみ）
 
-  **説明 :** FLEX の SCF ループの初期自己エネルギーとして読み込む\ ``sigma.npz``\ （以前の FLEX 計算の出力）のファイル名を指定します。パスは\ ``path_to_input``\ からの相対で解決されます。``CellShape``\ と\ ``Nmat``\ は現在の計算と一致している必要があります（不一致は即エラー）。詳細は FLEX チュートリアルの「SCFループのウォームスタート」を参照してください。
+  **説明 :** FLEX の SCF ループの初期自己エネルギーとして読み込む\ ``sigma.npz``\ （以前の FLEX 計算の出力）のファイル名を指定します。パスは\ ``path_to_input``\ からの相対で解決されます。``CellShape``\ と\ ``Nmat``\ は現在の計算と一致している必要があります（不一致は即エラー）。詳細は FLEX チュートリアルの「SCFループのウォームスタート」を参照してください。\ ``flex_hartree_fock = true``\ の計算では、同じ設定の計算が出力した\ ``sigma.npz``\ （``sigma_convention = "split"``\ 、\ ``sigma_static``\ と\ ``sigma_fluct``\ を含む）のみが受理され、2つの成分は保存されたままの形でループの初期値になります。同時に平均場（``trans_mod`` / ``green_init``\ ）を指定すると拒否されます。旧形式または\ ``"total"``\ 形式のアーカイブは\ ``hwave_sigma_split``\ で変換してください（:ref:`flex_bond_hf`\ を参照）。
 
 
 ``file.input.interaction``\ セクション
@@ -398,3 +449,9 @@ TOML形式
   **形式 :** str型
 
   **説明 :** 感受率行列\ :math:`\chi(\vec{q})`\ を出力するファイル名を指定します。このキーワードがない場合には情報は出力されません。
+
+- ``longitudinal_bond``
+
+  **形式 :** str型 (デフォルトは\ ``longitudinal_bond.npz``\ 。FLEXモードのみ)
+
+  **説明 :** ボンド分解した動的感受率の専用アーカイブのファイル名です。FLEX モードで\ ``longitudinal_bond_channels = true``\ かつ\ ``longitudinal_bond_output_full = true``\ の場合にのみ書き出されます（:ref:`flex_bond_hf`\ を参照）。他の出力ファイルと同じファイルに解決される指定は、計算開始前に拒否されます。

--- a/docs/ja/source/rpa/filespecification/config/index_config.rst
+++ b/docs/ja/source/rpa/filespecification/config/index_config.rst
@@ -454,4 +454,4 @@ TOML形式
 
   **形式 :** str型 (デフォルトは\ ``longitudinal_bond.npz``\ 。FLEXモードのみ)
 
-  **説明 :** ボンド分解した動的感受率の専用アーカイブのファイル名です。FLEX モードで\ ``longitudinal_bond_channels = true``\ かつ\ ``longitudinal_bond_output_full = true``\ の場合にのみ書き出されます（:ref:`flex_bond_hf`\ を参照）。他の出力ファイルと同じファイルに解決される指定は、計算開始前に拒否されます。
+  **説明 :** ボンド分解した動的感受率の専用アーカイブのファイル名です。FLEX モードで\ ``longitudinal_bond_channels = true``\ かつ\ ``longitudinal_bond_output_full = true``\ の場合にのみ書き出されます（:ref:`flex_bond_hf`\ を参照）。\ ``.npz``\ 拡張子のない名前には他の\ ``.npz``\ 出力と同様に拡張子が付加されます。他の出力ファイルと同じファイルに解決される指定は、計算開始前に拒否されます。

--- a/docs/ja/source/rpa/filespecification/outputfiles/chiq_rpa.rst
+++ b/docs/ja/source/rpa/filespecification/outputfiles/chiq_rpa.rst
@@ -162,6 +162,32 @@ chiq のデータ形式
   スピン／電荷の RPA 分母の\ :math:`q`\ にわたる最小の条件数スコア。不安定性の
   下限に達すると実行は拒否されます）、\ ``longitudinal_bond_schema``\ （整数、\ ``1``\ ）。
 
+``mode = "FLEX"``\ で\ ``longitudinal_bond_channels = true``\ の場合（:ref:`flex_bond_hf`\ の
+Hartree-Fock FLEX）、同じ16個のキーは **最後の** 自己無撞着写像を記述し
+（``longitudinal_bond_source = "last_map"``\ ）、\ ``[file.output] chiq``\ が
+指定されていれば結合\ ``chiq``\ ファイルに、なければ常に存在する\ ``chiq_s``\ ファイルに
+書き出されます（この場合、電荷チャネルの静的キーも\ ``chiq_s.npz``\ の中にあります。
+INFO ログにその旨が出力されます）。そのような計算の通常の\ ``chi0q``\ ・\ ``chiq_s``\ ・
+``chiq_c``\ 配列は、ボンド分解した量の全ボソン振動数における
+:math:`(m = 0, m' = 0)`\ ブロックです。\ ``flex_hartree_fock = true``\ の計算の全ての
+アーカイブ（``chi0q``\ ・\ ``chiq_s``\ ・\ ``chiq_c``\ ・\ ``chiq``\ ・\ ``sigma``\ ・
+``green``\ ）には来歴ブロック\ ``scf_converged``\ ・\ ``scf_iterations``\ ・
+``map_iteration``\ ・\ ``state_iteration``\ ・\ ``scf_sigma_residual``\ ・
+``scf_green_residual``\ ・\ ``scf_component_residual``\ ・\ ``payload_kind``
+（感受率は\ ``"last_map"``\ 、\ ``sigma`` / ``green``\ は\ ``"final_state"``\ ）・
+``hf_density_error``\ （そのペイロードが記述する状態の密度閉包誤差。
+``hf_density_source``\ 付き）・\ ``density_target_enforced``\ が含まれます。
+``longitudinal_bond_output_full = true``\ の場合、専用アーカイブ
+（``[file.output] longitudinal_bond``\ 、デフォルト\ ``longitudinal_bond.npz``\ ）に
+``bond_archive_schema``\ （``1``\ ）、動的な\ ``chi_s_w``\ と\ ``chi_c_w``
+（``ndarray(l, q, I, J)``\ 、\ ``freq_axis = "bosonic l -> 2l - nmat"``\ ）、
+``beta``\ ・\ ``T``\ ・\ ``nmat``\ ・\ ``cell_shape``\ ・運動量規約マーカー・
+``index_order``\ ・\ ``delta_r``\ ・\ ``reverse``\ ・\ ``types``\ 、16個の静的キー、
+来歴ブロックが格納されます。これらの配列を重複して持つファイルは他にありません。
+``IterationMax = 0``\ では写像は実行されず、最後の写像に属するアーカイブは全て省略され
+（INFO ログに一覧が出ます）、初期状態の\ ``sigma``\ ・\ ``green``\ ・\ ``energy``\ のみが
+書き出されます。
+
 
 データ読み込みの例
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ coverage = "^7.0.0"
 hwave = "hwave.qlms:main"
 hwave_dos = "hwave.dos:main"
 hwave_sc = "hwave.sc:main"
+hwave_sigma_split = "hwave.sigma_split:main"
 hwave_tsweep = "hwave.tsweep:main"
 
 [tool.mypy]

--- a/src/hwave/qlms.py
+++ b/src/hwave/qlms.py
@@ -148,6 +148,10 @@ def run(*, input_dict: Optional[dict] = None, input_file: Optional[str] = None):
         exit(0)
 
     # Execute calculation
+    if mode == "FLEX":
+        # output-path validation before any work (a collision between two
+        # artifacts is refused here, at solve entry and again before writing)
+        solver.validate_output_paths(info_outputfile, path_to_output)
     logger.info("Start UHF calculation")
     solver.solve(green_info, path_to_output)
     logger.info("Save calculation results.")

--- a/src/hwave/sigma_split.py
+++ b/src/hwave/sigma_split.py
@@ -1,0 +1,71 @@
+"""``hwave_sigma_split``: convert a total-form FLEX self-energy archive into
+the ``"split"`` form (``sigma = sigma_static + sigma_fluct``) that a run with
+``flex_hartree_fock = true`` accepts as ``sigma_init``.
+
+    hwave_sigma_split total.npz out.npz --static static.npz [--uhfk-spin-major]
+    hwave_sigma_split total.npz out.npz --zero-static
+    hwave_sigma_split total.npz out.npz --uhfk-trans-mod trans_mod.npz --bare-transfer transfer.dat
+
+The static correction is the interaction-only mean field in the FLEX
+reciprocal-space layout. With ``--uhfk-trans-mod`` it is built from a
+native UHFk ``trans_mod`` archive: the archive is Fourier-transformed to
+the FLEX C-order momentum layout with the solver's convention
+(``e^{+ikR}``), the bare transfer assembled from ``--bare-transfer``
+(the same Transfer input the FLEX run reads) is subtracted, the result is
+validated spin-diagonal with equal spin blocks and reduced to the
+spin-free block. External one-body fields are not supported by
+``flex_hartree_fock`` and are therefore not part of the recipe.
+"""
+import argparse
+import logging
+import sys
+
+_USAGE = ("hwave_sigma_split total.npz out.npz "
+          "(--static static.npz [--uhfk-spin-major] | --zero-static | "
+          "--uhfk-trans-mod trans_mod.npz --bare-transfer transfer.dat) [--force]")
+
+
+def _parser():
+    p = argparse.ArgumentParser(prog="hwave_sigma_split", usage=_USAGE,
+                                description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("total", help="total-form sigma archive (no sigma_convention or \"total\")")
+    p.add_argument("out", help="output split archive")
+    p.add_argument("--static", metavar="static.npz",
+                   help="archive with the static correction (member sigma_static; sigma as fallback)")
+    p.add_argument("--zero-static", action="store_true", help="write sigma_static = 0")
+    p.add_argument("--uhfk-trans-mod", metavar="trans_mod.npz",
+                   help="native UHFk trans_mod archive (requires --bare-transfer)")
+    p.add_argument("--bare-transfer", metavar="transfer",
+                   help="the bare Transfer input of the run (Wannier90-style text or .npz)")
+    p.add_argument("--uhfk-spin-major", action="store_true",
+                   help="the --static array is spin-major (nvol, 2 norb, 2 norb)")
+    p.add_argument("--force", action="store_true", help="overwrite an existing output")
+    return p
+
+
+def main(argv=None):
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    log = logging.getLogger("hwave_sigma_split")
+    parser = _parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return 0 if exc.code == 0 else 1
+    from hwave.solver.flex_hf import sigma_split_convert
+    try:
+        summary = sigma_split_convert(
+            args.total, args.out, static_path=args.static, zero_static=args.zero_static,
+            uhfk_trans_mod=args.uhfk_trans_mod, bare_transfer=args.bare_transfer,
+            uhfk_spin_major=args.uhfk_spin_major, force=args.force, logger=log)
+    except (ValueError, FileExistsError, OSError, KeyError) as exc:
+        log.error("%s", exc)
+        parser.print_usage(sys.stderr)
+        return 1
+    log.info("wrote %s (nmat=%d, nvol=%d, norb=%d; max|sigma_static| = %.3e, max|sigma_fluct| = %.3e)",
+             summary["out"], summary["nmat"], summary["nvol"], summary["norb"],
+             summary["static_max"], summary["fluct_max"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hwave/sigma_split.py
+++ b/src/hwave/sigma_split.py
@@ -35,7 +35,7 @@ def _parser():
     p.add_argument("--zero-static", action="store_true", help="write sigma_static = 0")
     p.add_argument("--uhfk-trans-mod", metavar="trans_mod.npz",
                    help="native UHFk trans_mod archive (requires --bare-transfer)")
-    p.add_argument("--bare-transfer", metavar="transfer",
+    p.add_argument("--bare-transfer", metavar="transfer.dat",
                    help="the bare Transfer input of the run (Wannier90-style text or .npz)")
     p.add_argument("--uhfk-spin-major", action="store_true",
                    help="the --static array is spin-major (nvol, 2 norb, 2 norb)")

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -3481,3 +3481,53 @@ def W_sc_bond(topo, S0, C0, *, imag_tol=1e-12, types=None):
     so that only one ``(nvol, ND, ND)`` vertex is alive)."""
     return (build_sc_bond_channel(topo, S0, "S", imag_tol=imag_tol, types=types),
             build_sc_bond_channel(topo, C0, "C", imag_tol=imag_tol, types=types))
+
+
+def dress_batch(chi_bar_b, W, channel, *, l0, nmat, spatial_shape, cond_tol=_BOND_COND_FLOOR):
+    """One frequency batch of the bond dressing (#181 Phase B, spec 3.2):
+    ``chi_bar_b`` `(nb, nvol, ND, ND)`, ``W`` `(nvol, ND, ND)` broadcast
+    over the batch; ``mat = 1 -/+ chi_bar_b @ W`` is conditioning-checked
+    with BOTH criteria of :func:`_check_bond_conditioning` on the
+    flattened ``(nb * nvol)`` batch and solved with ``numpy.linalg.solve``.
+    Returns ``(chi_b, cond_min)``; a refusal names the bosonic Matsubara
+    index ``2 (l0 + i // nvol) - nmat``, the q point and the channel."""
+    if channel not in _DRESS_CHANNELS:
+        raise ValueError("dress_batch: channel must be 'spin' or 'charge', got {!r}".format(channel))
+    sign = _DRESS_CHANNELS[channel]
+    cb = np.asarray(chi_bar_b)
+    W = np.asarray(W)
+    if cb.ndim != 4 or cb.shape[2] != cb.shape[3] or W.shape != cb.shape[1:]:
+        raise ValueError("dress_batch: chi_bar_b must be (nb, nvol, ND, ND) and W (nvol, ND, ND); got {} and {}"
+                         .format(cb.shape, W.shape))
+    nb, nvol, ND = cb.shape[0], cb.shape[1], cb.shape[2]
+    Nx, Ny, Nz = (int(x) for x in spatial_shape)
+    if Nx * Ny * Nz != nvol:
+        raise ValueError("dress_batch: prod(spatial_shape) != nvol")
+    mat = cb @ W[None]
+    if sign < 0:
+        np.negative(mat, out=mat)
+    idx = np.arange(ND)
+    mat[:, :, idx, idx] += 1.0
+    flat = mat.reshape(nb * nvol, ND, ND)
+    try:
+        cond_min = _check_bond_conditioning(channel, flat.reshape(nb * nvol, 1, 1, ND, ND), cond_tol)
+    except ValueError as exc:
+        # decode the flattened index named as "q-point index (i, 0, 0)"
+        import re
+        m = re.search(r"q-point index \((\d+), 0, 0\)", str(exc))
+        if m is None:
+            raise
+        i = int(m.group(1))
+        l = l0 + i // nvol
+        q = i % nvol
+        qx, rem = divmod(q, Ny * Nz)
+        qy, qz = divmod(rem, Nz)
+        raise ValueError(
+            "dress_batch: the {} RPA denominator is singular or nearly singular at "
+            "bosonic Matsubara index {} (grid index l={}) and q-point index ({}, {}, {}); "
+            "the bond path has entered the instability region. Reduce the interaction "
+            "strength, raise the temperature, refine or reduce the q grid, or lower "
+            "cond_tol deliberately.".format(channel, 2 * l - nmat, l, qx, qy, qz)) from exc
+    chi = np.linalg.solve(flat, cb.reshape(nb * nvol, ND, ND)).reshape(nb, nvol, ND, ND)
+    del mat, flat
+    return chi, (None if cond_min is None else float(cond_min))

--- a/src/hwave/solver/bond_channels.py
+++ b/src/hwave/solver/bond_channels.py
@@ -3361,6 +3361,13 @@ def W_pm_bond(topo, ham_pm_onsite, *, spatial_shape):
 # equality with bare_bond_vertices for CoulombInter; Gate G2: exact
 # diagonalization for Hund/Ising, tests/test_bond_longitudinal_ed.py).
 
+def is_real_coefficient(v, imag_tol=1e-12):
+    """True when the interaction coefficient ``v`` is real to ``imag_tol``
+    (the admissibility rule shared by the RPA and FLEX bond gates and by
+    :func:`build_sc_bond_channel`)."""
+    return abs(complex(v).imag) <= imag_tol
+
+
 def build_sc_bond_channel(topo, W0, channel, *, imag_tol=1e-12, types=None):
     """One channel (``"S"`` or ``"C"``) of the bond-resolved longitudinal
     vertex, shape ``(nvol, ND, ND)`` complex128, ``ND = B * norb**2``.
@@ -3459,7 +3466,7 @@ def build_sc_bond_channel(topo, W0, channel, *, imag_tol=1e-12, types=None):
         arr = topo.coeffs[t]
         for (m, a, b) in orbits:
             v = complex(arr[m, a, b])
-            if abs(v.imag) > imag_tol:
+            if not is_real_coefficient(v, imag_tol=imag_tol):
                 raise ValueError(
                     "build_sc_bond_channel: the off-site {} coefficient at "
                     "channel {} (delta_r={}), orbitals ({}, {}) is complex "

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -418,6 +418,15 @@ class FLEX(RPA):
                         "when resuming from a Phase B sigma archive, or fold the mean field "
                         "into the archive's sigma_static with hwave_sigma_split".format(env.file_name))
                 static, fluct = flex_hf.validate_split_seed(env, expected_shape)
+                diag = flex_hf.split_tail_diagnostic(fluct, nmat)
+                if diag is not None and diag[0] > 0.1 and diag[1] > 1e-8:
+                    logger.warning(
+                        "sigma_init '{}': sigma_fluct carries a frequency-independent "
+                        "remainder on the outer Matsubara window (pair-even/pair-odd ratio "
+                        "{:.3e}, max |even| {:.3e}); a constant part in sigma_fluct degrades "
+                        "the density truncation from O(Nmat^-3) towards O(Nmat^-1). Move the "
+                        "static part into sigma_static (e.g. with hwave_sigma_split "
+                        "--static).".format(env.file_name, diag[0], diag[1]))
             else:
                 raise ValueError(
                     "sigma_init '{}' carries sigma_convention={!r}; a run with "
@@ -731,9 +740,10 @@ class FLEX(RPA):
     def _read_sigma(self, file_name):
         """Load a saved self-energy array from a FLEX ``sigma.npz``.
 
-        Returns ``(sigma, ir_meta)``: ``ir_meta`` is ``None`` for uniform
-        (densified) files, or the node metadata of an IR-native file
-        (Stage 3; ``read_init`` decides whether this run can consume it).
+        Returns a :class:`hwave.solver.flex_hf.SigmaSeedEnvelope` (the
+        arrays, the ``sigma_convention`` marker, and ``ir_meta``: ``None``
+        for uniform (densified) files, or the node metadata of an IR-native
+        file -- Stage 3; ``read_init`` decides whether this run can consume it).
 
         Validates the recorded ``cell_shape`` against this run's lattice:
         ``Nvol = Lx*Ly*Lz`` is a single dimension of the sigma array, so an
@@ -796,6 +806,13 @@ class FLEX(RPA):
             self._path_to_output = path_to_output
             if getattr(self, "_info_outputfile", None) is not None:
                 self.validate_output_paths(path_to_output=path_to_output)
+            try:
+                return self._solve_restoring_host_attrs(green_info, path_to_output)
+            except BaseException:
+                # spec 3.5: after a failed solve nothing is produced -- every
+                # solve-produced member and solver-owned cache is dropped
+                self._phase_b_reset(green_info)
+                raise
         return self._solve_restoring_host_attrs(green_info, path_to_output)
 
     def _solve_impl(self, green_info, path_to_output):
@@ -1276,20 +1293,24 @@ class FLEX(RPA):
                              "(spin-diagonal H0)")
         self._phase_b_seed = self._assemble_static_seed(green_info, expected)
         self._hf_tables = flex_hf.build_flex_hf_tables(self.ham_info.param_ham, norb, shape)
+        split = self._validate_phase_b_interactions()
         if self.longitudinal_bond_channels:
-            self._bond_topo, self._bond_split = self._validate_bond_gate_prereqs()
+            self._bond_topo, self._bond_split = self._validate_bond_gate_prereqs(split)
             self._bond_view = bond_channels.BondSetView(self._bond_topo)
             env = green_info.get("sigma_init_envelope")
             split_seed = env is not None and getattr(env, "marker", None) == "split"
             self._bond_est = self._bond_memory_preflight(self._bond_topo, split_seed)
             self._bond_nb = int(self._bond_est["nb"])
 
-    def _validate_bond_gate_prereqs(self):
-        """Interaction admissibility and topology of the FLEX bond gate
-        (spec 4.1 steps 6-7; the RPA gate's rules). Returns ``(topo, split)``."""
+    def _validate_phase_b_interactions(self):
+        """Interaction admissibility shared by flex_hartree_fock and the
+        bond gate (spec 2.2 / 4.1 step 6): off-site Exchange and PairHop are
+        refused, and every off-site coefficient of every type (PairLift
+        included) must be real. Returns the pre-fold locality split."""
         from hwave.solver import bond_channels
         from hwave.solver.offsite import split_locality
-        g = "[mode.param] longitudinal_bond_channels=true (FLEX)"
+        g = ("[mode.param] longitudinal_bond_channels=true (FLEX)"
+             if self.longitudinal_bond_channels else "[mode.param] flex_hartree_fock=true")
         if getattr(self.ham_info, "enable_spin_orbital", False):
             raise ValueError(g + " does not support enable_spin_orbital.")
         split = split_locality(self.ham_info, self.lattice)
@@ -1309,19 +1330,26 @@ class FLEX(RPA):
                     "orbvec={} -- the declared displacement and the zero-based orbital "
                     "pair): {}. Remove those entries from the interaction input."
                     .format(itype, tuple(irvec), tuple(orbvec), reason))
-        if "PairLift" in split.offsite_types:
+        if "PairLift" in split.offsite_types and self.longitudinal_bond_channels:
             logger.info(g + ": off-site PairLift declarations carry no longitudinal "
-                        "(spin/charge) content and are ignored by the bond channels.")
+                        "(spin/charge) content and are ignored by the bond channels "
+                        "(they reach the Hartree-Fock kernel, where they vanish on the "
+                        "paramagnetic density).")
         for itype, tbl in split.offsite_prefold_tbl.items():
-            if itype not in bond_channels._LONGITUDINAL_ACTIVE_TYPES:
-                continue
             for (irvec, orbvec), v in tbl.items():
                 if not bond_channels.is_real_coefficient(v):
                     raise ValueError(
                         g + ": off-site {} coefficients must be real in this version "
                         "(irvec={}, orbvec={} carries {}); the imaginary direction is not "
-                        "represented by the bond-diagonal Fock rule."
+                        "represented by the Hartree-Fock term or the bond-diagonal Fock rule."
                         .format(itype, tuple(irvec), tuple(orbvec), complex(v)))
+        return split
+
+    def _validate_bond_gate_prereqs(self, split):
+        """Topology of the FLEX bond gate (spec 4.1 step 7) on the validated
+        split. Returns ``(topo, split)``."""
+        from hwave.solver import bond_channels
+        g = "[mode.param] longitudinal_bond_channels=true (FLEX)"
         interactions = CaseInsensitiveDict(split.whole_tbl)
         topo = bond_channels.resolve_bond_topology(
             interactions, np.eye(3), self.norb,
@@ -1346,7 +1374,8 @@ class FLEX(RPA):
         included), the batch selection and the operation warnings."""
         from hwave.solver import flex_bond
         B = int(np.asarray(topo.delta_r).shape[0])
-        n_types = len(getattr(self._hf_tables, "inter_table", {}) or {})
+        n_types = sum(1 for t in (getattr(self._hf_tables, "inter_table", {}) or {}).values()
+                      if t is not None)
         est = flex_bond.estimate_bond_memory(
             nmat=self.nmat, nvol=self.lattice.nvol, norb=self.norb, B=B,
             depth=self.anderson_depth, output_full=self.longitudinal_bond_output_full,
@@ -1438,6 +1467,8 @@ class FLEX(RPA):
         shape = tuple(int(x) for x in self.lattice.shape)
         static0, fluct0 = self._phase_b_seed
         state = SplitState(static=np.array(static0, copy=True), fluct=np.array(fluct0, copy=True))
+        del static0, fluct0
+        del self._phase_b_seed            # the working state owns the seed from here on (spec 3.6)
         if np.any(state.static != 0) or np.any(state.fluct != 0):
             logger.info("FLEX: warm-starting the Phase B loop from the seed")
         mixer = (StackedAndersonMixer(self.mix, self.anderson_depth)
@@ -1561,6 +1592,15 @@ class FLEX(RPA):
                     self.mu = mu
                 green_kw = self._calc_dressed_green(beta, mu, sigma)
                 dens = _hf.equal_time_density(_bk.to_host(green_kw), heff, mu, beta, shape)
+                if self.calc_mu:
+                    dev = abs(dens.n_per_spin - Ncond_target)
+                    if dev > 1e-10 * max(1.0, abs(Ncond_target)):
+                        raise ValueError(
+                            "flex_hartree_fock: the final-state chemical potential search closed "
+                            "on N/2 = {:.12g} but the equal-time density gives {:.12g} (residual "
+                            "{:.3e} > tolerance {:.3e})".format(
+                                Ncond_target, dens.n_per_spin, dev,
+                                1e-10 * max(1.0, abs(Ncond_target))))
                 self.hf_density_error_state = abs(
                     2.0 * dens.n_per_spin - getattr(self, "Ncond", float("nan"))) / nvol
                 physics = {"NCond": float(2.0 * dens.n_per_spin), "Sz": 0.0, "mu": float(mu)}
@@ -2818,10 +2858,16 @@ class FLEX(RPA):
             # but warn so a configured PairLift term is not silently ignored --
             # matching the Eliashberg-path wording.
             if "PairLift" in self.ham_info.param_ham:
-                logger.warning(
-                    "PairLift is configured but does not contribute to the S/C "
-                    "pairing vertex (S=C=0); it is ignored in the general FLEX "
-                    "calculation.")
+                if getattr(self, "flex_hartree_fock", False):
+                    logger.warning(
+                        "PairLift is configured but does not contribute to the S/C "
+                        "pairing vertex (S=C=0); it enters only the Hartree-Fock term, "
+                        "where it vanishes on the paramagnetic density.")
+                else:
+                    logger.warning(
+                        "PairLift is configured but does not contribute to the S/C "
+                        "pairing vertex (S=C=0); it is ignored in the general FLEX "
+                        "calculation.")
 
             # OFF-SITE entries (#181, Tier 1). The interaction is split by
             # PRE-fold locality and the two parts reach the S/C matrices
@@ -2947,15 +2993,18 @@ class FLEX(RPA):
                             if t in _OFFSITE_DENSITY_TYPES]
 
             if offsite_used:
-                logger.warning(
-                    "FLEX calc_scheme='general': proceeding with the "
-                    "Hartree (density-slot) vertex V(q) only for the "
-                    "off-site entries of {}; the exchange crossing of an "
-                    "off-site term is not representable by a q-only "
-                    "vertex and is omitted (the same approximation the "
-                    "RPA ring makes; a bond-resolved treatment is tracked "
-                    "in GitHub issue #181).".format(
-                        ", ".join(sorted(offsite_used))))
+                _msg = ("FLEX calc_scheme='general': proceeding with the "
+                        "Hartree (density-slot) vertex V(q) only for the "
+                        "off-site entries of {}; the exchange crossing of an "
+                        "off-site term is not representable by a q-only "
+                        "vertex and is omitted (the same approximation the "
+                        "RPA ring makes; a bond-resolved treatment is tracked "
+                        "in GitHub issue #181).")
+                if getattr(self, "flex_hartree_fock", False):
+                    _msg += (" With flex_hartree_fock=true the FIRST-order exchange of "
+                             "these terms is carried by the Hartree-Fock self-energy; "
+                             "longitudinal_bond_channels=true resums the crossing.")
+                logger.warning(_msg.format(", ".join(sorted(offsite_used))))
 
             no = self.norb
             nx, ny, nz = self.lattice.shape

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -236,31 +236,136 @@ class FLEX(RPA):
     def __init__(self, param_ham, info_log, info_mode):
         logger.debug(">>> FLEX.__init__")
 
-        # The RPA-only experimental bond-resolved longitudinal gate (#181
-        # Tier 3 Phase A): FLEX has no bond-basis self-consistency yet
-        # (Phase B), so a TRUE key is a configuration error, not a
-        # silently ignored option. Read the RAW (case-insensitive) value
-        # BEFORE the RPA base parses it -- under calc_type='ring+ladder'
-        # the base parser turns a true flag into False with a warning,
-        # which would hide this refusal.
-        _lbc = CaseInsensitiveDict(info_mode.get("param", {})).get(
-            "longitudinal_bond_channels", False)
-        if not isinstance(_lbc, (bool, np.bool_)):
-            raise ValueError(
-                "[mode.param] longitudinal_bond_channels must be a boolean, "
-                "got {!r}".format(_lbc))
-        if bool(_lbc):
-            raise ValueError(
-                "[mode.param] longitudinal_bond_channels=true is RPA-only "
-                "in Phase A (mode='RPA', calc_type='ring'): the FLEX "
-                "self-consistency on the bond basis is Phase B of GitHub "
-                "issue #181. Remove the key for a FLEX run.")
+        # Phase B (#181): the raw Phase B keys are parsed BEFORE the RPA
+        # base runs (refusal precedence steps 1-3 of the spec), because the
+        # base parser would turn a true gate flag into False under
+        # calc_type='ring+ladder' and exits on an odd Nmat.
+        self._phase_b_raw = self._parse_phase_b_keys(info_mode)
 
         # Initialize RPA infrastructure (lattice, interaction, params)
         super().__init__(param_ham, info_log, info_mode)
 
         # FLEX-specific parameters
         self._init_flex_param()
+        self._install_phase_b_keys()
+
+    # ------------------------------------------------------------------
+    # Phase B (#181): configuration surface -- spec 2026-09-06 section 4.1
+    # ------------------------------------------------------------------
+    _accepts_flex_keys = True
+    _PHASE_B_SWITCHES = ("flex_hartree_fock", "longitudinal_bond_channels")
+    _PHASE_B_BOND_KEYS = ("longitudinal_bond_output_full",
+                          "longitudinal_bond_freq_batch",
+                          "longitudinal_bond_max_shells",
+                          "longitudinal_bond_memory_cap_gb")
+
+    @staticmethod
+    def _parse_phase_b_keys(info_mode):
+        """Refusal precedence steps 1-3 on the RAW ``[mode.param]`` (before
+        any numerical state exists). Returns the parsed values as a dict;
+        stale bond-only keys (gate off) are NOT parsed and are listed in
+        one warning."""
+        import numbers
+        param = CaseInsensitiveDict(info_mode.get("param", {}) or {})
+        out = {}
+        # step 1: types of the switches
+        for key in FLEX._PHASE_B_SWITCHES:
+            v = param.get(key, False)
+            if not isinstance(v, (bool, np.bool_)):
+                raise ValueError("[mode.param] {} must be a boolean, got {!r}".format(key, v))
+            out[key] = bool(v)
+        hf_on, gate_on = out["flex_hartree_fock"], out["longitudinal_bond_channels"]
+        active = hf_on or gate_on
+        out["active"] = active
+        stale = [k for k in FLEX._PHASE_B_BOND_KEYS if k in param]
+        if not active:
+            if stale:
+                logger.warning(
+                    "[mode.param] %s set but longitudinal_bond_channels is not "
+                    "true; these bond-only options are ignored (not parsed).",
+                    ", ".join(stale))
+            out.update(longitudinal_bond_output_full=False, longitudinal_bond_freq_batch=None,
+                       longitudinal_bond_max_shells=None, longitudinal_bond_memory_cap_gb=8.0)
+            return out
+        # step 2: domain keys that need no assembly
+        nmat = param.get("Nmat", None)
+        if nmat is None or isinstance(nmat, bool) or not isinstance(nmat, numbers.Integral) or int(nmat) % 2 != 0:
+            raise ValueError(
+                "[mode.param] Nmat must be an even integer when flex_hartree_fock or "
+                "longitudinal_bond_channels is true (the static Matsubara slice is read at "
+                "Nmat//2), got {!r}".format(nmat))
+        scheme = str(info_mode.get("calc_scheme", "auto")).lower()
+        if scheme not in ("general", "auto"):
+            raise ValueError(
+                "flex_hartree_fock / longitudinal_bond_channels require calc_scheme='general' "
+                "(or 'auto' resolving to it), got {!r}".format(scheme))
+        basis = str(param.get("matsubara_basis", "uniform")).lower()
+        if basis != "uniform":
+            raise ValueError(
+                "[mode.param] matsubara_basis='{}' is not supported with flex_hartree_fock / "
+                "longitudinal_bond_channels (uniform Matsubara grid only; the IR fit of bond "
+                "susceptibilities is ill-conditioned)".format(basis))
+        if _bk.as_bool(param.get("gpu", False)):
+            raise ValueError(
+                "[mode.param] gpu=true is not supported with flex_hartree_fock / "
+                "longitudinal_bond_channels in this version (CPU only)")
+        sub = param.get("SubShape", None)
+        if sub is not None and tuple(int(x) for x in sub) != (1, 1, 1):
+            raise ValueError(
+                "[mode.param] a sublattice (SubShape={}) is not supported with flex_hartree_fock / "
+                "longitudinal_bond_channels; run with SubShape=[1,1,1]".format(list(sub)))
+        # step 3: gate-HF coupling
+        if gate_on and not hf_on:
+            raise ValueError(
+                "[mode.param] longitudinal_bond_channels=true in FLEX requires "
+                "flex_hartree_fock=true (the bond-resolved channel renormalises the band with "
+                "the self-consistent Hartree-Fock term; set both keys)")
+        if not gate_on and stale:
+            logger.warning(
+                "[mode.param] %s set but longitudinal_bond_channels is not true; these "
+                "bond-only options are ignored (not parsed).", ", ".join(stale))
+            out.update(longitudinal_bond_output_full=False, longitudinal_bond_freq_batch=None,
+                       longitudinal_bond_max_shells=None, longitudinal_bond_memory_cap_gb=8.0)
+            return out
+        v = param.get("longitudinal_bond_output_full", False)
+        if not isinstance(v, (bool, np.bool_)):
+            raise ValueError("[mode.param] longitudinal_bond_output_full must be a boolean, got {!r}".format(v))
+        out["longitudinal_bond_output_full"] = bool(v)
+        fb = param.get("longitudinal_bond_freq_batch", None)
+        if fb is not None:
+            if isinstance(fb, bool) or not isinstance(fb, numbers.Integral) or not (1 <= int(fb) <= int(nmat)):
+                raise ValueError(
+                    "[mode.param] longitudinal_bond_freq_batch must be an integer in [1, Nmat={}], "
+                    "got {!r}".format(int(nmat), fb))
+            fb = int(fb)
+        out["longitudinal_bond_freq_batch"] = fb
+        ms = param.get("longitudinal_bond_max_shells", None)
+        if ms is not None:
+            if isinstance(ms, bool) or not isinstance(ms, numbers.Integral) or int(ms) < 1:
+                raise ValueError("[mode.param] longitudinal_bond_max_shells must be an integer >= 1, got {!r}".format(ms))
+            ms = int(ms)
+        out["longitudinal_bond_max_shells"] = ms
+        cap = param.get("longitudinal_bond_memory_cap_gb", 8.0)
+        if isinstance(cap, bool) or not isinstance(cap, numbers.Real) or not np.isfinite(cap) or cap <= 0:
+            raise ValueError("[mode.param] longitudinal_bond_memory_cap_gb must be a finite number > 0 (binary GiB), got {!r}".format(cap))
+        out["longitudinal_bond_memory_cap_gb"] = float(cap)
+        return out
+
+    def _install_phase_b_keys(self):
+        raw = self._phase_b_raw
+        self.flex_hartree_fock = raw["flex_hartree_fock"]
+        # the FLEX meaning of the gate key (the RPA base parser's value is
+        # replaced: it is calc_type-scoped and RPA-owned)
+        self.longitudinal_bond_channels = raw["longitudinal_bond_channels"]
+        self.longitudinal_bond_output_full = raw["longitudinal_bond_output_full"]
+        self.longitudinal_bond_freq_batch = raw["longitudinal_bond_freq_batch"]
+        self.longitudinal_bond_max_shells = raw["longitudinal_bond_max_shells"]
+        self.longitudinal_bond_memory_cap_gb = raw["longitudinal_bond_memory_cap_gb"]
+        self._phase_b_active = raw["active"]
+        if self._phase_b_active:
+            logger.info("    flex_hartree_fock = {}".format(self.flex_hartree_fock))
+            logger.info("    longitudinal_bond_channels (FLEX) = {}".format(
+                self.longitudinal_bond_channels))
 
     def _init_flex_param(self):
         """Initialize FLEX-specific parameters."""

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -289,12 +289,18 @@ class FLEX(RPA):
                        longitudinal_bond_max_shells=None, longitudinal_bond_memory_cap_gb=8.0)
             return out
         # step 2: domain keys that need no assembly
-        nmat = param.get("Nmat", None)
-        if nmat is None or isinstance(nmat, bool) or not isinstance(nmat, numbers.Integral) or int(nmat) % 2 != 0:
+        nmat = param.get("Nmat", 1024)          # the solver's default grid
+        if (isinstance(nmat, bool) or not isinstance(nmat, numbers.Integral) or int(nmat) <= 0
+                or int(nmat) % 2 != 0):
             raise ValueError(
-                "[mode.param] Nmat must be an even integer when flex_hartree_fock or "
+                "[mode.param] Nmat must be a positive even integer when flex_hartree_fock or "
                 "longitudinal_bond_channels is true (the static Matsubara slice is read at "
                 "Nmat//2), got {!r}".format(nmat))
+        itmax = param.get("IterationMax", 100)
+        if isinstance(itmax, bool) or not isinstance(itmax, numbers.Integral) or int(itmax) < 0:
+            raise ValueError(
+                "[mode.param] IterationMax must be an integer >= 0 when flex_hartree_fock or "
+                "longitudinal_bond_channels is true, got {!r}".format(itmax))
         scheme = str(info_mode.get("calc_scheme", "auto")).lower()
         if scheme not in ("general", "auto"):
             raise ValueError(
@@ -363,6 +369,12 @@ class FLEX(RPA):
         self.longitudinal_bond_max_shells = raw["longitudinal_bond_max_shells"]
         self.longitudinal_bond_memory_cap_gb = raw["longitudinal_bond_memory_cap_gb"]
         self._phase_b_active = raw["active"]
+        if self._phase_b_active and str(self.calc_scheme).lower() != "general":
+            raise ValueError(
+                "[mode.param] flex_hartree_fock / longitudinal_bond_channels require "
+                "calc_scheme='general'; calc_scheme='auto' resolved to {!r} for this "
+                "interaction set -- set calc_scheme = \"general\" explicitly".format(
+                    self.calc_scheme))
         if self._phase_b_active:
             logger.info("    flex_hartree_fock = {}".format(self.flex_hartree_fock))
             logger.info("    longitudinal_bond_channels (FLEX) = {}".format(
@@ -723,6 +735,13 @@ class FLEX(RPA):
             file_name = os.path.join(path_to_input,
                                      info_inputfile["sigma_init"])
             env = self._read_sigma(file_name)
+            if env.marker not in (None, "split", "total"):
+                raise ValueError(
+                    "sigma_init file '{}' carries an unknown sigma_convention {!r} "
+                    "(accepted: \"split\", \"total\", or no marker)".format(file_name, env.marker))
+            if env.marker == "split" and not getattr(self, "_phase_b_active", False):
+                logger.info("sigma_init '{}' is a split archive; without flex_hartree_fock "
+                            "its total sigma is used as the one seed".format(file_name))
             sigma, ir_meta = env.sigma, env.ir_meta
             if ir_meta is not None and not self.use_ir:
                 raise ValueError(
@@ -1494,6 +1513,10 @@ class FLEX(RPA):
             heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], state.static[0, 0])
             for iteration in range(self.max_iter):
                 logger.info("FLEX iteration {}/{}".format(iteration + 1, self.max_iter))
+                # the previous map's collapses and static slices are released
+                # before the next map allocates theirs (spec 3.6: one set)
+                chi0q_out = chi_s = chi_c = None
+                self._bond_last = None
                 with self._traced("green_mu"):
                     sigma = xp.asarray(state.total())
                     if self.calc_mu:
@@ -1535,6 +1558,9 @@ class FLEX(RPA):
                             name, iteration + 1))
                 with self._traced("convergence"):
                     g_new = self._calc_dressed_green(beta, mu, xp.asarray(new_state.total()))
+                    if not np.all(np.isfinite(g_new)):
+                        raise _hf.NonFiniteError("non-finite Green function of the new "
+                                                 "self-energy at iteration {}".format(iteration + 1))
                     res_sigma, res_g, res_comp = residuals(state, new_state, _bk.to_host(green_kw),
                                                            _bk.to_host(g_new))
                     del g_new

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -825,7 +825,16 @@ class FLEX(RPA):
         # _calc_epsilon_k determines self.spin_mode from H0(k); the general
         # full-vertex path (v1) is paramagnetic only, so guard here once
         # spin_mode is known.
-        self._calc_epsilon_k(green_info)
+        if self._phase_b_active:
+            # Phase B (#181): the band stays BARE -- a user mean field is an
+            # initial self-energy (spec 2.3, D7), so trans_mod/green_init are
+            # withheld from the H0 path (the inputs themselves are preserved).
+            self._phase_b_reset(green_info)
+            _gi_h0 = {k: v for k, v in green_info.items()
+                      if k not in ("trans_mod", "green_init")}
+            self._calc_epsilon_k(_gi_h0)
+        else:
+            self._calc_epsilon_k(green_info)
 
         if self._flex_general and self.spin_mode != "spin-free":
             raise ValueError(
@@ -938,6 +947,10 @@ class FLEX(RPA):
         nfreq_axis = self._ir_axF.n_freq if self.use_ir else nmat
         expected_uniform = (nblock, nmat, nvol, nd_block, nd_block)
         expected = (nblock, nfreq_axis, nvol, nd_block, nd_block)
+        if self._phase_b_active:
+            return self._solve_phase_b(green_info, beta, mu, Ncond_target, xp,
+                                       green0_tail, green_tail_w,
+                                       self.ham_info.ham_inter_q)
         sigma_init = green_info.get("sigma_init")
         seed_ir_meta = green_info.get("sigma_init_ir")
         if sigma_init is not None:
@@ -1159,6 +1172,210 @@ class FLEX(RPA):
     # ------------------------------------------------------------------
     # IR-basis Matsubara axis (Stage 2, docs/design/ir-matsubara.md 3.3/3.4)
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Phase B (#181): the self-consistent loop with the Hartree-Fock term
+    # (spec 2026-09-06 sections 1, 2, 5.6). Entered only when
+    # flex_hartree_fock or longitudinal_bond_channels is true; the legacy
+    # loop in _solve_impl is untouched.
+    # ------------------------------------------------------------------
+    _iteration_hook = None      # test-only callback (spec G0)
+
+    def _phase_b_reset(self, green_info):
+        """Solve-entry reset by ownership (spec 3.5): every solve-produced
+        member and solver result attribute is dropped; the inputs
+        (sigma_init, trans_mod, green_init, chi0q_init, reader entries)
+        are preserved."""
+        produced = ("sigma", "sigma_static", "sigma_fluct", "green", "physics",
+                    "chi0q", "chiq_s", "chiq_c")
+        prov = ("map_iteration", "state_iteration", "payload_kind", "hf_density_error",
+                "hf_density_source", "density_target_enforced")
+        for k in list(green_info):
+            ks = str(k)
+            if (k in produced or ks.startswith("longitudinal_bond_")
+                    or ks.startswith("scf_") or ks in prov):
+                green_info.pop(k, None)
+        for attr in ("sigma", "green_kw", "chi_s", "chi_c", "physics", "sigma_static",
+                     "sigma_fluct", "_bond_detached", "_bond_static_keys", "_bond_topo",
+                     "_bond_split", "_bond_view", "_bond_S", "_bond_C", "_hf_tables"):
+            if hasattr(self, attr):
+                delattr(self, attr)
+        self.scf_converged = False
+        self.scf_iterations = 0
+        self.scf_sigma_residual = float("nan")
+        self.scf_green_residual = float("nan")
+        self.scf_component_residual = float("nan")
+        self.map_iteration = 0
+        self.state_iteration = 0
+        self.hf_density_error_map = float("nan")
+        self.hf_density_error_state = float("nan")
+
+    def _provenance_block(self, payload_kind):
+        """The provenance block of every archive of an active Phase B run
+        (spec 4.3)."""
+        return {
+            "scf_converged": bool(self.scf_converged),
+            "scf_iterations": int(self.scf_iterations),
+            "map_iteration": int(self.map_iteration),
+            "state_iteration": int(self.state_iteration),
+            "scf_sigma_residual": float(self.scf_sigma_residual),
+            "scf_green_residual": float(self.scf_green_residual),
+            "scf_component_residual": float(self.scf_component_residual),
+            "payload_kind": payload_kind,
+            "hf_density_error": float(self.hf_density_error_map if payload_kind == "last_map"
+                                      else self.hf_density_error_state),
+            "hf_density_source": payload_kind,
+            "density_target_enforced": bool(self.calc_mu),
+        }
+
+    def _phase_b_density_and_hf(self, green_kw, static, mu, beta, Ncond_target):
+        """rho, the density-closure check and Sigma_HF for one map."""
+        from hwave.solver import flex_hf, hartree_fock as _hf
+        shape = tuple(int(x) for x in self.lattice.shape)
+        heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], np.asarray(static)[0, 0])
+        dens = _hf.equal_time_density(_bk.to_host(green_kw), heff, mu, beta, shape)
+        if self.calc_mu:
+            dev = abs(dens.n_per_spin - Ncond_target)
+            if dev > 1e-10 * max(1.0, abs(Ncond_target)):
+                raise ValueError(
+                    "flex_hartree_fock: the chemical potential search closed on "
+                    "N/2 = {:.12g} but the equal-time density gives {:.12g} "
+                    "(residual {:.3e} > tolerance {:.3e})".format(
+                        Ncond_target, dens.n_per_spin, dev,
+                        1e-10 * max(1.0, abs(Ncond_target))))
+        sigma_hf = flex_hf.hf_map(dens.rho_r, self._hf_tables, shape, self.norb)
+        return dens, sigma_hf[None, None], heff
+
+    def _solve_phase_b(self, green_info, beta, mu, Ncond_target, xp,
+                       green0_tail, green_tail_w, ham_orig):
+        from hwave.solver import flex_hf, hartree_fock as _hf
+        from hwave.solver.flex_mixing import (SplitState, StackedAndersonMixer,
+                                              linear_mix_pair, residuals, PassCounter)
+        nvol, nmat, norb = self.lattice.nvol, self.nmat, self.norb
+        shape = tuple(int(x) for x in self.lattice.shape)
+        expected = (1, nmat, nvol, norb, norb)
+        self._hf_tables = flex_hf.build_flex_hf_tables(
+            self.ham_info.param_ham, norb, shape)
+        static0, fluct0 = self._assemble_static_seed(green_info, expected)
+        state = SplitState(static=static0, fluct=fluct0)
+        if np.any(state.static != 0) or np.any(state.fluct != 0):
+            logger.info("FLEX: warm-starting the Phase B loop from the seed")
+        mixer = (StackedAndersonMixer(self.mix, self.anderson_depth)
+                 if self.mixing_scheme == "anderson" else None)
+        if self.mixing_scheme == "linear" and self.longitudinal_bond_channels:
+            logger.warning("longitudinal_bond_channels with mixing_scheme='linear': "
+                           "linear mixing is known to mis-converge near the charge "
+                           "instability; consider mixing_scheme='anderson'.")
+        counter = PassCounter(self.eps, needed=3)
+        converged = False
+        n_iter_done = 0
+        chi0q_out = chi_s = chi_c = None
+        heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], state.static[0, 0])
+        for iteration in range(self.max_iter):
+            logger.info("FLEX iteration {}/{}".format(iteration + 1, self.max_iter))
+            sigma = xp.asarray(state.total())
+            if self.calc_mu:
+                mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
+                self.mu = mu
+            green_kw = self._calc_dressed_green(beta, mu, sigma)
+            dens, sigma_hf, _ = self._phase_b_density_and_hf(green_kw, state.static, mu, beta,
+                                                             Ncond_target)
+            self.hf_density_error_map = abs(2.0 * dens.n_per_spin - self.Ncond) / nvol
+            green_scf = green_kw - green_tail_w if green_tail_w is not None else green_kw
+            if self.longitudinal_bond_channels:
+                chi0q_out, chi_s, chi_c, sigma_fluct = self._phase_b_bond_map(
+                    green_kw, green_scf, green0_tail, beta, iteration + 1)
+            else:
+                chi0q_raw = self._calc_chi0q(green_scf, green0_tail, beta)
+                assert chi0q_raw.shape[0] == 1
+                chi0q_raw = chi0q_raw[0]
+                chi0q_out, v_eff, chi_s, chi_c = \
+                    self._flex_compute_veff_general(chi0q_raw, ham_orig)
+                sigma_fluct = self._calc_self_energy_general(green_kw, v_eff, beta)
+            new_state = SplitState(static=_bk.to_host(sigma_hf),
+                                   fluct=_bk.to_host(sigma_fluct))
+            for name, arr in (("Sigma_HF", new_state.static), ("Sigma_fluct", new_state.fluct)):
+                if not np.all(np.isfinite(arr)):
+                    raise _hf.NonFiniteError("non-finite {} at iteration {}".format(name, iteration + 1))
+            g_new = self._calc_dressed_green(beta, mu, xp.asarray(new_state.total()))
+            res_sigma, res_g, res_comp = residuals(state, new_state, _bk.to_host(green_kw),
+                                                   _bk.to_host(g_new))
+            del g_new
+            self.map_iteration = iteration + 1
+            n_iter_done = iteration + 1
+            self.scf_sigma_residual, self.scf_green_residual, self.scf_component_residual = \
+                res_sigma, res_g, res_comp
+            done, count = counter.update(res_sigma, res_g, res_comp)
+            logger.info("  residuals: sigma {:.3e}  green {:.3e}  component {:.3e}  [pass {}/3]"
+                        .format(res_sigma, res_g, res_comp, count))
+            if self._iteration_hook is not None:
+                self._iteration_hook(dict(
+                    iteration=iteration + 1, mu=float(mu),
+                    static_new=np.array(new_state.static, copy=True),
+                    fluct_new=np.array(new_state.fluct, copy=True),
+                    chi0q=np.array(_bk.to_host(chi0q_out), copy=True),
+                    chiq_s=np.array(_bk.to_host(chi_s), copy=True),
+                    chiq_c=np.array(_bk.to_host(chi_c), copy=True)))
+            if mixer is not None:
+                state = mixer.step(state, new_state)
+            else:
+                state = linear_mix_pair(state, new_state, self.mix)
+            self.state_iteration = iteration + 1
+            ok, err = _hf.is_hermitian_batch(state.static[:, 0], 1e-10)
+            if not ok:
+                raise ValueError("the mixed static self-energy is not Hermitian "
+                                 "(relative deviation {:.3e})".format(err))
+            heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], state.static[0, 0])
+            if done:
+                logger.info("FLEX converged after {} iterations".format(iteration + 1))
+                converged = True
+                break
+        if not converged:
+            logger.warning("FLEX did not converge after {} iterations (residuals sigma={:.3e}, "
+                           "green={:.3e}, component={:.3e}, eps={:.3e})".format(
+                               self.max_iter, self.scf_sigma_residual, self.scf_green_residual,
+                               self.scf_component_residual, self.eps))
+        self.scf_converged = converged
+        self.scf_iterations = n_iter_done
+        # final state: mu, G, density, physics from the (post-mix) state
+        sigma = xp.asarray(state.total())
+        if self.calc_mu:
+            mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
+            self.mu = mu
+        green_kw = self._calc_dressed_green(beta, mu, sigma)
+        dens = _hf.equal_time_density(_bk.to_host(green_kw), heff, mu, beta, shape)
+        self.hf_density_error_state = abs(2.0 * dens.n_per_spin - self.Ncond) / nvol
+        physics = {"NCond": float(2.0 * dens.n_per_spin), "Sz": 0.0, "mu": float(mu)}
+        self.physics = physics
+        logger.info("FLEX: NCond = {}, Sz = {}, ChemicalPotential = {}".format(
+            physics["NCond"], physics["Sz"], physics["mu"]))
+        self.sigma = _bk.to_host(sigma)
+        self.sigma_static = np.array(state.static, copy=True)
+        self.sigma_fluct = np.array(state.fluct, copy=True)
+        self.green_kw = _bk.to_host(green_kw)
+        green_info["sigma"] = self.sigma
+        green_info["sigma_static"] = self.sigma_static
+        green_info["sigma_fluct"] = self.sigma_fluct
+        green_info["green"] = self.green_kw
+        green_info["physics"] = physics
+        if self.max_iter > 0:
+            self.chi_s = _bk.to_host(chi_s)
+            self.chi_c = _bk.to_host(chi_c)
+            green_info["chi0q"] = _bk.to_host(chi0q_out)
+            green_info["chiq_s"] = self.chi_s
+            green_info["chiq_c"] = self.chi_c
+            if self.longitudinal_bond_channels:
+                self._phase_b_publish_bond(green_info)
+        else:
+            logger.info("FLEX IterationMax=0: no map executed; only the final-state "
+                        "outputs (sigma, green, physics) of the seed state are stored.")
+        logger.info("End FLEX calculations")
+
+    def _phase_b_bond_map(self, green_kw, green_scf, green0_tail, beta, iteration):
+        raise NotImplementedError("the bond-resolved map is implemented in a later task")
+
+    def _phase_b_publish_bond(self, green_info):
+        raise NotImplementedError("the bond-resolved outputs are implemented in a later task")
 
     def _ir_setup(self, beta):
         """Build the fermionic/bosonic IR axes once per solve."""
@@ -1853,7 +2070,7 @@ class FLEX(RPA):
         return n, dn
 
     @do_profile
-    def _find_mu_dressed(self, sigma, beta, Ncond):
+    def _find_mu_dressed(self, sigma, beta, Ncond, ew_ref=None):
         """Re-solve mu so the dressed Green's function carries ``Ncond``.
 
         Holds ``sigma`` fixed and solves ``N(mu) = Ncond``.  The ``M``
@@ -1894,6 +2111,10 @@ class FLEX(RPA):
         # and returns plain floats, so the Newton/bisection logic below is
         # backend-independent.
         lam, ew = self._matsubara_number_operator(sigma, beta)
+        if ew_ref is not None:
+            # Phase B (#181): the analytic reference is Heff = H0 + sigma_static
+            # (exact Fermi count when the fluctuation part vanishes)
+            ew = np.asarray(ew_ref)
         w = ew
 
         def _delta_n(mu, with_deriv=False):
@@ -3070,8 +3291,11 @@ class FLEX(RPA):
                          else {"coeff_tail": getattr(self, "coeff_tail", 0.0),
                                # endpoint convention marker (issue #134)
                                "tail_endpoint": TAIL_ENDPOINT_CONVENTION})
+            chi0_extra = (self._provenance_block("last_map")
+                          if getattr(self, "_phase_b_active", False) else {})
             np.savez(file_name,
                      chi0q=green_info["chi0q"],
+                     **chi0_extra,
                      # full grid size: lets consumers locate the zero bosonic
                      # frequency (index nmat//2) unambiguously (run
                      # provenance only on IR-native files)
@@ -3129,6 +3353,8 @@ class FLEX(RPA):
             # be false machine-readable metadata. The reader accepts
             # marker-less "kuroki" files; only "myo" requires the marker.
             common_meta["chi_orbital_layout"] = "acbd"
+        if getattr(self, "_phase_b_active", False):
+            common_meta.update(self._provenance_block("last_map"))
 
         if "chiq_s" in green_info:
             file_name = os.path.join(path_to_output,
@@ -3157,8 +3383,15 @@ class FLEX(RPA):
             file_name = os.path.join(path_to_output, info_outputfile["sigma"])
             # #167: no scheme stamp here -- sigma/green are outside the
             # spec's listed npz-stamp scope (deliberate, not an omission).
+            sigma_extra = {}
+            if getattr(self, "_phase_b_active", False):
+                sigma_extra = dict(sigma_convention="split",
+                                   sigma_static=green_info.get("sigma_static"),
+                                   sigma_fluct=green_info.get("sigma_fluct"),
+                                   **self._provenance_block("final_state"))
             np.savez(file_name,
                      sigma=green_info.get("sigma"),
+                     **sigma_extra,
                      wavevector_unit=self.kvec,
                      wavevector_index=self.wavenum_table,
                      cell_shape=np.array(self.lattice.shape),
@@ -3176,6 +3409,8 @@ class FLEX(RPA):
                 # native-only provenance key (the densified green.npz key
                 # set stays unchanged -- design R-S3-2)
                 green_extra["cell_shape"] = np.array(self.lattice.shape)
+            if getattr(self, "_phase_b_active", False):
+                green_extra.update(self._provenance_block("final_state"))
             np.savez(file_name,
                      green=green_info.get("green"),
                      wavevector_unit=self.kvec,

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -804,9 +804,9 @@ class FLEX(RPA):
         self._myo_sc_cache = None
         if getattr(self, "_phase_b_active", False):
             self._path_to_output = path_to_output
-            if getattr(self, "_info_outputfile", None) is not None:
-                self.validate_output_paths(path_to_output=path_to_output)
             try:
+                if getattr(self, "_info_outputfile", None) is not None:
+                    self.validate_output_paths(path_to_output=path_to_output)
                 return self._solve_restoring_host_attrs(green_info, path_to_output)
             except BaseException:
                 # spec 3.5: after a failed solve nothing is produced -- every
@@ -1292,8 +1292,8 @@ class FLEX(RPA):
             raise ValueError("flex_hartree_fock=true does not support an external field "
                              "(spin-diagonal H0)")
         self._phase_b_seed = self._assemble_static_seed(green_info, expected)
-        self._hf_tables = flex_hf.build_flex_hf_tables(self.ham_info.param_ham, norb, shape)
         split = self._validate_phase_b_interactions()
+        self._hf_tables = flex_hf.build_flex_hf_tables(self.ham_info.param_ham, norb, shape)
         if self.longitudinal_bond_channels:
             self._bond_topo, self._bond_split = self._validate_bond_gate_prereqs(split)
             self._bond_view = bond_channels.BondSetView(self._bond_topo)
@@ -1590,7 +1590,11 @@ class FLEX(RPA):
                 if self.calc_mu:
                     mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
                     self.mu = mu
+                if not np.isfinite(mu):
+                    raise _hf.NonFiniteError("non-finite final-state chemical potential")
                 green_kw = self._calc_dressed_green(beta, mu, sigma)
+                if not np.all(np.isfinite(green_kw)):
+                    raise _hf.NonFiniteError("non-finite final-state Green function")
                 dens = _hf.equal_time_density(_bk.to_host(green_kw), heff, mu, beta, shape)
                 if self.calc_mu:
                     dev = abs(dens.n_per_spin - Ncond_target)
@@ -2993,17 +2997,21 @@ class FLEX(RPA):
                             if t in _OFFSITE_DENSITY_TYPES]
 
             if offsite_used:
-                _msg = ("FLEX calc_scheme='general': proceeding with the "
-                        "Hartree (density-slot) vertex V(q) only for the "
-                        "off-site entries of {}; the exchange crossing of an "
-                        "off-site term is not representable by a q-only "
-                        "vertex and is omitted (the same approximation the "
-                        "RPA ring makes; a bond-resolved treatment is tracked "
-                        "in GitHub issue #181).")
                 if getattr(self, "flex_hartree_fock", False):
-                    _msg += (" With flex_hartree_fock=true the FIRST-order exchange of "
-                             "these terms is carried by the Hartree-Fock self-energy; "
-                             "longitudinal_bond_channels=true resums the crossing.")
+                    _msg = ("FLEX calc_scheme='general' with flex_hartree_fock=true: the "
+                            "off-site entries of {} enter the fluctuation vertex through "
+                            "their Hartree (density-slot) part V(q); their first-order "
+                            "exchange is carried by the Hartree-Fock self-energy, and "
+                            "their exchange crossing beyond first order is resummed only "
+                            "with longitudinal_bond_channels=true.")
+                else:
+                    _msg = ("FLEX calc_scheme='general': proceeding with the "
+                            "Hartree (density-slot) vertex V(q) only for the "
+                            "off-site entries of {}; the exchange crossing of an "
+                            "off-site term is not representable by a q-only "
+                            "vertex and is omitted (the same approximation the "
+                            "RPA ring makes; a bond-resolved treatment is tracked "
+                            "in GitHub issue #181).")
                 logger.warning(_msg.format(", ".join(sorted(offsite_used))))
 
             no = self.norb

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -367,6 +367,73 @@ class FLEX(RPA):
             logger.info("    longitudinal_bond_channels (FLEX) = {}".format(
                 self.longitudinal_bond_channels))
 
+    def _assemble_static_seed(self, green_info, expected_shape):
+        """Refusal precedence steps 4-5 and the seed matrix (spec 2.3, D7,
+        D10, D15) under flex_hartree_fock=true. Returns
+        ``(sigma_static (nb, 1, nvol, norb, norb), sigma_fluct
+        (expected_shape))`` as fresh arrays; ``green_info`` is not
+        modified (inputs are preserved)."""
+        from hwave.solver import flex_hf, hartree_fock as _hf
+        nb, nmat, nvol, norb, _ = (int(x) for x in expected_shape)
+        env = green_info.get("sigma_init_envelope")
+        has_tm = "trans_mod" in green_info
+        has_gi = "green_init" in green_info
+        # step 4: copied mean-field assembly and spin classification
+        delta_h = None
+        if has_tm or has_gi:
+            if has_tm and has_gi:
+                logger.info("flex_hartree_fock: both trans_mod and green_init "
+                            "are given; trans_mod takes precedence (as in the "
+                            "legacy H0 path) and green_init is ignored")
+            if has_tm:
+                h_mod = np.array(green_info["trans_mod"], dtype=np.complex128, copy=True)
+            else:
+                h_mod = self._calc_trans_mod_copy(green_info["green_init"])
+            h_mod = h_mod.reshape(nvol, 2, norb, 2, norb)
+            off = max(float(np.max(np.abs(h_mod[:, 0, :, 1, :]))),
+                      float(np.max(np.abs(h_mod[:, 1, :, 0, :]))))
+            diff = float(np.max(np.abs(h_mod[:, 0, :, 0, :] - h_mod[:, 1, :, 1, :])))
+            scale = max(1.0, float(np.max(np.abs(h_mod))))
+            if off > 1e-12 * scale or diff > 1e-12 * scale:
+                raise ValueError(
+                    "flex_hartree_fock=true requires a spin-free mean field: the supplied "
+                    "trans_mod/green_init is spin-mixing ({:.3e}) or spin-diagonal with unequal "
+                    "blocks ({:.3e}); Phase B is spin-free only".format(off, diff))
+            if self.ham_info.ham_extern_q is not None:
+                raise ValueError("flex_hartree_fock=true does not support an external field "
+                                 "(spin-diagonal H0)")
+            h0_bare = np.array(self.ham_info.ham_trans_q, dtype=np.complex128,
+                               copy=True).reshape(nvol, norb, norb)
+            delta_h = h_mod[:, 0, :, 0, :] - h0_bare
+        # step 5: seed file semantics
+        static = np.zeros((nb, 1, nvol, norb, norb), dtype=np.complex128)
+        fluct = np.zeros(tuple(expected_shape), dtype=np.complex128)
+        if env is not None:
+            if env.marker == "split":
+                if delta_h is not None:
+                    raise ValueError(
+                        "sigma_init '{}' is a split self-energy archive and a mean field "
+                        "(trans_mod/green_init) is also given; remove trans_mod/green_init "
+                        "when resuming from a Phase B sigma archive, or fold the mean field "
+                        "into the archive's sigma_static with hwave_sigma_split".format(env.file_name))
+                static, fluct = flex_hf.validate_split_seed(env, expected_shape)
+            else:
+                raise ValueError(
+                    "sigma_init '{}' carries sigma_convention={!r}; a run with "
+                    "flex_hartree_fock=true accepts only a \"split\" archive. Convert it "
+                    "with: hwave_sigma_split {} out.npz --static static.npz (or --zero-static, "
+                    "or --uhfk-trans-mod ...)".format(env.file_name, env.marker, env.file_name))
+        elif delta_h is not None:
+            static[:, 0] = delta_h[None]
+        # checkpoint 4b: the assembled static seed
+        if not np.all(np.isfinite(static)):
+            raise _hf.NonFiniteError("the assembled static self-energy seed is not finite")
+        ok, err = _hf.is_hermitian_batch(static[:, 0], 1e-10)
+        if not ok:
+            raise ValueError("the assembled static self-energy seed is not Hermitian "
+                             "(relative deviation {:.3e})".format(err))
+        return static, fluct
+
     def _init_flex_param(self):
         """Initialize FLEX-specific parameters."""
         logger.debug(">>> FLEX._init_flex_param")
@@ -645,7 +712,8 @@ class FLEX(RPA):
             path_to_input = info_inputfile.get("path_to_input", "")
             file_name = os.path.join(path_to_input,
                                      info_inputfile["sigma_init"])
-            sigma, ir_meta = self._read_sigma(file_name)
+            env = self._read_sigma(file_name)
+            sigma, ir_meta = env.sigma, env.ir_meta
             if ir_meta is not None and not self.use_ir:
                 raise ValueError(
                     "sigma_init file '{}' holds sparse-IR node data "
@@ -654,6 +722,7 @@ class FLEX(RPA):
                     "run, or re-run the seeding FLEX with [mode.param] "
                     "write_densified = true.".format(file_name))
             info["sigma_init"] = sigma
+            info["sigma_init_envelope"] = env
             if ir_meta is not None:
                 info["sigma_init_ir"] = ir_meta
         return info
@@ -700,7 +769,8 @@ class FLEX(RPA):
         # do NOT search by size, nmat == nvol collisions are realistic
         validate_momentum_convention(data, file_name, sig, 2,
                                      self.lattice.shape)
-        return sig, meta
+        from hwave.solver.flex_hf import make_seed_envelope
+        return make_seed_envelope(data, file_name, sig, meta)
 
     @do_profile
     def solve(self, green_info, path_to_output):

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -15,6 +15,7 @@ The solver inherits from the RPA class to reuse infrastructure for:
 from __future__ import annotations
 from typing import Optional
 
+import contextlib
 import os
 import numpy as np
 from requests.structures import CaseInsensitiveDict
@@ -791,6 +792,10 @@ class FLEX(RPA):
         # _inflate_chi0q_and_ham_general is emitted once per solve, not
         # once per object.
         self._myo_sc_cache = None
+        if getattr(self, "_phase_b_active", False):
+            self._path_to_output = path_to_output
+            if getattr(self, "_info_outputfile", None) is not None:
+                self.validate_output_paths(path_to_output=path_to_output)
         return self._solve_restoring_host_attrs(green_info, path_to_output)
 
     def _solve_impl(self, green_info, path_to_output):
@@ -830,6 +835,7 @@ class FLEX(RPA):
             # initial self-energy (spec 2.3, D7), so trans_mod/green_init are
             # withheld from the H0 path (the inputs themselves are preserved).
             self._phase_b_reset(green_info)
+            self._phase_b_preflight(green_info)
             _gi_h0 = {k: v for k, v in green_info.items()
                       if k not in ("trans_mod", "green_init")}
             self._calc_epsilon_k(_gi_h0)
@@ -1180,6 +1186,13 @@ class FLEX(RPA):
     # loop in _solve_impl is untouched.
     # ------------------------------------------------------------------
     _iteration_hook = None      # test-only callback (spec G0)
+    _phase_tracer = None        # test-only per-phase context factory (spec 3.6)
+    _info_outputfile = None     # [file.output] mapping stored by validate_output_paths
+    _path_to_output = None
+
+    def _traced(self, name):
+        tracer = getattr(self, "_phase_tracer", None)
+        return contextlib.nullcontext() if tracer is None else tracer(name)
 
     def _phase_b_reset(self, green_info):
         """Solve-entry reset by ownership (spec 3.5): every solve-produced
@@ -1197,7 +1210,8 @@ class FLEX(RPA):
                 green_info.pop(k, None)
         for attr in ("sigma", "green_kw", "chi_s", "chi_c", "physics", "sigma_static",
                      "sigma_fluct", "_bond_detached", "_bond_static_keys", "_bond_topo",
-                     "_bond_split", "_bond_view", "_bond_S", "_bond_C", "_hf_tables"):
+                     "_bond_split", "_bond_view", "_bond_S", "_bond_C", "_bond_types",
+                     "_bond_last", "_bond_est", "_bond_nb", "_phase_b_seed", "_hf_tables"):
             if hasattr(self, attr):
                 delattr(self, attr)
         self.scf_converged = False
@@ -1246,23 +1260,186 @@ class FLEX(RPA):
         sigma_hf = flex_hf.hf_map(dens.rho_r, self._hf_tables, shape, self.norb)
         return dens, sigma_hf[None, None], heff
 
-    def _solve_phase_b(self, green_info, beta, mu, Ncond_target, xp,
-                       green0_tail, green_tail_w, ham_orig):
-        from hwave.solver import flex_hf, hartree_fock as _hf
-        from hwave.solver.flex_mixing import (SplitState, StackedAndersonMixer,
-                                              linear_mix_pair, residuals, PassCounter)
+    def _phase_b_preflight(self, green_info):
+        """Refusal precedence steps 4-7 (spec 4.1): the copied mean-field
+        assembly and the seed (4-5), the HF tables and the interaction
+        admissibility (6), the topology and the memory preflight (7) --
+        all BEFORE H0 is diagonalised, before the backend is resolved and
+        before any expensive work."""
+        from hwave.solver import flex_hf, bond_channels
         nvol, nmat, norb = self.lattice.nvol, self.nmat, self.norb
         shape = tuple(int(x) for x in self.lattice.shape)
         expected = (1, nmat, nvol, norb, norb)
-        self._hf_tables = flex_hf.build_flex_hf_tables(
-            self.ham_info.param_ham, norb, shape)
-        static0, fluct0 = self._assemble_static_seed(green_info, expected)
-        state = SplitState(static=static0, fluct=fluct0)
+        if self.ham_info.ham_extern_q is not None:
+            raise ValueError("flex_hartree_fock=true does not support an external field "
+                             "(spin-diagonal H0)")
+        self._phase_b_seed = self._assemble_static_seed(green_info, expected)
+        self._hf_tables = flex_hf.build_flex_hf_tables(self.ham_info.param_ham, norb, shape)
+        if self.longitudinal_bond_channels:
+            self._bond_topo, self._bond_split = self._validate_bond_gate_prereqs()
+            self._bond_view = bond_channels.BondSetView(self._bond_topo)
+            env = green_info.get("sigma_init_envelope")
+            split_seed = env is not None and getattr(env, "marker", None) == "split"
+            self._bond_est = self._bond_memory_preflight(self._bond_topo, split_seed)
+            self._bond_nb = int(self._bond_est["nb"])
+
+    def _validate_bond_gate_prereqs(self):
+        """Interaction admissibility and topology of the FLEX bond gate
+        (spec 4.1 steps 6-7; the RPA gate's rules). Returns ``(topo, split)``."""
+        from hwave.solver import bond_channels
+        from hwave.solver.offsite import split_locality
+        g = "[mode.param] longitudinal_bond_channels=true (FLEX)"
+        if getattr(self.ham_info, "enable_spin_orbital", False):
+            raise ValueError(g + " does not support enable_spin_orbital.")
+        split = split_locality(self.ham_info, self.lattice)
+        for itype in ("PairHop", "Exchange"):
+            if itype in split.offsite_types:
+                (irvec, orbvec) = next(iter(split.offsite_prefold_tbl[itype]))
+                if itype == "PairHop":
+                    reason = ("no local-pair particle-hole form exists for an inter-site "
+                              "pair hopping (Phase C of GitHub issue #181)")
+                else:
+                    reason = ("exact diagonalization finds no q-representable longitudinal "
+                              "content (#181 Tier 2); its bond-resolved promotion is a "
+                              "recorded follow-up, so the gate refuses it rather than "
+                              "silently dropping it")
+                raise ValueError(
+                    g + " does not support an off-site '{}' declaration (irvec={}, "
+                    "orbvec={} -- the declared displacement and the zero-based orbital "
+                    "pair): {}. Remove those entries from the interaction input."
+                    .format(itype, tuple(irvec), tuple(orbvec), reason))
+        if "PairLift" in split.offsite_types:
+            logger.info(g + ": off-site PairLift declarations carry no longitudinal "
+                        "(spin/charge) content and are ignored by the bond channels.")
+        for itype, tbl in split.offsite_prefold_tbl.items():
+            if itype not in bond_channels._LONGITUDINAL_ACTIVE_TYPES:
+                continue
+            for (irvec, orbvec), v in tbl.items():
+                if not bond_channels.is_real_coefficient(v):
+                    raise ValueError(
+                        g + ": off-site {} coefficients must be real in this version "
+                        "(irvec={}, orbvec={} carries {}); the imaginary direction is not "
+                        "represented by the bond-diagonal Fock rule."
+                        .format(itype, tuple(irvec), tuple(orbvec), complex(v)))
+        interactions = CaseInsensitiveDict(split.whole_tbl)
+        topo = bond_channels.resolve_bond_topology(
+            interactions, np.eye(3), self.norb,
+            max_shells=self.longitudinal_bond_max_shells,
+            active_types=bond_channels._LONGITUDINAL_ACTIVE_TYPES)
+        if int(np.asarray(topo.delta_r).shape[0]) <= 1:
+            raise ValueError(
+                g + " requires at least one declared off-site CoulombInter, Hund or Ising "
+                "shell (a declared-but-zero coefficient counts; the aggregate Coulomb "
+                "table's off-site part counts); none is present after "
+                "longitudinal_bond_max_shells truncation, so the bond channels have "
+                "nothing to represent.")
+        for t, arr in topo.coeffs.items():
+            if np.any(np.abs(np.asarray(arr).imag) > 1e-12):
+                raise ValueError(
+                    g + ": off-site {} coefficients must be real in this version (a "
+                    "complex coefficient was declared).".format(t))
+        return topo, split
+
+    def _bond_memory_preflight(self, topo, split_seed):
+        """The spec 3.6 admission estimate (absolute, ordinary FLEX arrays
+        included), the batch selection and the operation warnings."""
+        from hwave.solver import flex_bond
+        B = int(np.asarray(topo.delta_r).shape[0])
+        n_types = len(getattr(self._hf_tables, "inter_table", {}) or {})
+        est = flex_bond.estimate_bond_memory(
+            nmat=self.nmat, nvol=self.lattice.nvol, norb=self.norb, B=B,
+            depth=self.anderson_depth, output_full=self.longitudinal_bond_output_full,
+            split_seed=split_seed, n_types=n_types,
+            freq_batch=self.longitudinal_bond_freq_batch,
+            cap_gb=self.longitudinal_bond_memory_cap_gb, mixing=self.mixing_scheme)
+        gib = flex_bond._GIB
+        logger.info(
+            "Bond-resolved FLEX preflight (ESTIMATE): B = %d channels %s, ND = %d, nvol = %d, "
+            "Nmat = %d, frequency batch %d; persistent %.4f GiB, peak %.4f GiB = 1.25 * "
+            "(persistent + max phase row) against the cap %.4f GiB\n%s",
+            B, [tuple(int(x) for x in r) for r in np.asarray(topo.delta_r)], est["ND"],
+            est["nvol"], est["nmat"], est["nb"], est["persistent"] / gib, est["peak"] / gib,
+            est["cap_bytes"] / gib, est["table"])
+        if est["dressing_ops"] > flex_bond._DRESSING_OPS_WARN:
+            logger.warning(
+                "longitudinal_bond_channels (FLEX): about %.2e operations per SCF iteration "
+                "for the two dense ND x ND solves over (Nmat, nvol) (ND = %d, nvol = %d, "
+                "Nmat = %d); this run fits the memory cap but may take very long.",
+                est["dressing_ops"], est["ND"], est["nvol"], est["nmat"])
+        if est["transport_ops"] > flex_bond._TRANSPORT_OPS_WARN:
+            logger.warning(
+                "longitudinal_bond_channels (FLEX): about %.2e operations per SCF iteration "
+                "for the bond self-energy transport (B = %d, Nmat = %d, nvol = %d, norb = %d); "
+                "expect long iterations.", est["transport_ops"], B, est["nmat"], est["nvol"],
+                self.norb)
+        return est
+
+    def _phase_b_active_outputs(self, info_outputfile):
+        active = [k for k in ("energy", "sigma", "green") if k in info_outputfile]
+        if self.max_iter > 0:
+            active += ["chiq_s", "chiq_c"]
+            active += [k for k in ("chi0q", "chiq") if k in info_outputfile]
+            if self.longitudinal_bond_channels and self.longitudinal_bond_output_full:
+                active.append("longitudinal_bond")
+        return tuple(active)
+
+    def validate_output_paths(self, info_outputfile=None, path_to_output=None):
+        """Refuse two output artifacts resolving to one file (spec 4.2).
+        Stores the ``[file.output]`` mapping for the solve-entry re-check;
+        a no-op for runs without flex_hartree_fock / the bond gate."""
+        from hwave.solver import flex_bond
+        if not getattr(self, "_phase_b_active", False):
+            return {}
+        if info_outputfile is None:
+            info_outputfile = getattr(self, "_info_outputfile", None)
+        if info_outputfile is None:
+            raise ValueError("validate_output_paths: no [file.output] mapping is stored on the "
+                             "solver; pass info_outputfile explicitly")
+        if path_to_output is None:
+            path_to_output = info_outputfile.get("path_to_output",
+                                                 getattr(self, "_path_to_output", None))
+        if path_to_output is None:
+            raise ValueError("validate_output_paths: path_to_output is not known; pass it "
+                             "explicitly (or a mapping carrying 'path_to_output')")
+        self._info_outputfile = info_outputfile
+        self._path_to_output = path_to_output
+        return flex_bond.resolve_output_paths(info_outputfile, path_to_output,
+                                              self._phase_b_active_outputs(info_outputfile))
+
+    def _phase_b_prepare_vertices(self):
+        """S, C on the bond basis, cached once per solve (spec 3.5)."""
+        from hwave.solver import bond_channels, hartree_fock as _hf
+        from hwave.solver.offsite import sc_matrices_from_split
+        nx, ny, nz = (int(x) for x in self.lattice.shape)
+        nvol, nd = self.lattice.nvol, self.norb ** 2
+        S0, C0 = sc_matrices_from_split(self._bond_split, bond_channels._LONGITUDINAL_ACTIVE_TYPES,
+                                        self.norb, nx, ny, nz)
+        S0 = S0.reshape(nvol, nd, nd)
+        C0 = C0.reshape(nvol, nd, nd)
+        types = tuple(self._bond_topo.coeffs)
+        self._bond_types = types
+        self._bond_S = bond_channels.build_sc_bond_channel(self._bond_topo, S0, "S", types=types)
+        self._bond_C = bond_channels.build_sc_bond_channel(self._bond_topo, C0, "C", types=types)
+        del S0, C0
+        if not (np.all(np.isfinite(self._bond_S)) and np.all(np.isfinite(self._bond_C))):
+            raise _hf.NonFiniteError("non-finite bond vertices S/C")
+
+    def _solve_phase_b(self, green_info, beta, mu, Ncond_target, xp,
+                       green0_tail, green_tail_w, ham_orig):
+        from hwave.solver import flex_bond, hartree_fock as _hf
+        from hwave.solver.flex_mixing import (SplitState, StackedAndersonMixer,
+                                              linear_mix_pair, residuals, PassCounter)
+        nvol, nmat, norb = self.lattice.nvol, self.nmat, self.norb
+        nd = norb * norb
+        shape = tuple(int(x) for x in self.lattice.shape)
+        static0, fluct0 = self._phase_b_seed
+        state = SplitState(static=np.array(static0, copy=True), fluct=np.array(fluct0, copy=True))
         if np.any(state.static != 0) or np.any(state.fluct != 0):
             logger.info("FLEX: warm-starting the Phase B loop from the seed")
         mixer = (StackedAndersonMixer(self.mix, self.anderson_depth)
                  if self.mixing_scheme == "anderson" else None)
-        if self.mixing_scheme == "linear" and self.longitudinal_bond_channels:
+        gate = bool(self.longitudinal_bond_channels)
+        if self.mixing_scheme == "linear" and gate:
             logger.warning("longitudinal_bond_channels with mixing_scheme='linear': "
                            "linear mixing is known to mis-converge near the charge "
                            "instability; consider mixing_scheme='anderson'.")
@@ -1270,112 +1447,215 @@ class FLEX(RPA):
         converged = False
         n_iter_done = 0
         chi0q_out = chi_s = chi_c = None
-        heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], state.static[0, 0])
-        for iteration in range(self.max_iter):
-            logger.info("FLEX iteration {}/{}".format(iteration + 1, self.max_iter))
-            sigma = xp.asarray(state.total())
-            if self.calc_mu:
-                mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
-                self.mu = mu
-            green_kw = self._calc_dressed_green(beta, mu, sigma)
-            dens, sigma_hf, _ = self._phase_b_density_and_hf(green_kw, state.static, mu, beta,
-                                                             Ncond_target)
-            self.hf_density_error_map = abs(2.0 * dens.n_per_spin - self.Ncond) / nvol
-            green_scf = green_kw - green_tail_w if green_tail_w is not None else green_kw
-            if self.longitudinal_bond_channels:
-                chi0q_out, chi_s, chi_c, sigma_fluct = self._phase_b_bond_map(
-                    green_kw, green_scf, green0_tail, beta, iteration + 1)
-            else:
-                chi0q_raw = self._calc_chi0q(green_scf, green0_tail, beta)
-                assert chi0q_raw.shape[0] == 1
-                chi0q_raw = chi0q_raw[0]
-                chi0q_out, v_eff, chi_s, chi_c = \
-                    self._flex_compute_veff_general(chi0q_raw, ham_orig)
-                sigma_fluct = self._calc_self_energy_general(green_kw, v_eff, beta)
-            new_state = SplitState(static=_bk.to_host(sigma_hf),
-                                   fluct=_bk.to_host(sigma_fluct))
-            for name, arr in (("Sigma_HF", new_state.static), ("Sigma_fluct", new_state.fluct)):
-                if not np.all(np.isfinite(arr)):
-                    raise _hf.NonFiniteError("non-finite {} at iteration {}".format(name, iteration + 1))
-            g_new = self._calc_dressed_green(beta, mu, xp.asarray(new_state.total()))
-            res_sigma, res_g, res_comp = residuals(state, new_state, _bk.to_host(green_kw),
-                                                   _bk.to_host(g_new))
-            del g_new
-            self.map_iteration = iteration + 1
-            n_iter_done = iteration + 1
-            self.scf_sigma_residual, self.scf_green_residual, self.scf_component_residual = \
-                res_sigma, res_g, res_comp
-            done, count = counter.update(res_sigma, res_g, res_comp)
-            logger.info("  residuals: sigma {:.3e}  green {:.3e}  component {:.3e}  [pass {}/3]"
-                        .format(res_sigma, res_g, res_comp, count))
-            if self._iteration_hook is not None:
-                self._iteration_hook(dict(
-                    iteration=iteration + 1, mu=float(mu),
-                    static_new=np.array(new_state.static, copy=True),
-                    fluct_new=np.array(new_state.fluct, copy=True),
-                    chi0q=np.array(_bk.to_host(chi0q_out), copy=True),
-                    chiq_s=np.array(_bk.to_host(chi_s), copy=True),
-                    chiq_c=np.array(_bk.to_host(chi_c), copy=True)))
-            if mixer is not None:
-                state = mixer.step(state, new_state)
-            else:
-                state = linear_mix_pair(state, new_state, self.mix)
-            self.state_iteration = iteration + 1
-            ok, err = _hf.is_hermitian_batch(state.static[:, 0], 1e-10)
-            if not ok:
-                raise ValueError("the mixed static self-energy is not Hermitian "
-                                 "(relative deviation {:.3e})".format(err))
+        with contextlib.ExitStack() as stack:
+            store = None
+            if gate:
+                names = ["chibar", "W"]
+                if self.longitudinal_bond_output_full:
+                    names += ["chi_s_w", "chi_c_w"]
+                store = stack.enter_context(flex_bond.BondBlockStore(
+                    nmat, nvol, self._bond_view.n_channels * nd, nd, tuple(names)))
+                self._phase_b_prepare_vertices()
             heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], state.static[0, 0])
-            if done:
-                logger.info("FLEX converged after {} iterations".format(iteration + 1))
-                converged = True
-                break
-        if not converged:
-            logger.warning("FLEX did not converge after {} iterations (residuals sigma={:.3e}, "
-                           "green={:.3e}, component={:.3e}, eps={:.3e})".format(
-                               self.max_iter, self.scf_sigma_residual, self.scf_green_residual,
-                               self.scf_component_residual, self.eps))
-        self.scf_converged = converged
-        self.scf_iterations = n_iter_done
-        # final state: mu, G, density, physics from the (post-mix) state
-        sigma = xp.asarray(state.total())
-        if self.calc_mu:
-            mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
-            self.mu = mu
-        green_kw = self._calc_dressed_green(beta, mu, sigma)
-        dens = _hf.equal_time_density(_bk.to_host(green_kw), heff, mu, beta, shape)
-        self.hf_density_error_state = abs(2.0 * dens.n_per_spin - self.Ncond) / nvol
-        physics = {"NCond": float(2.0 * dens.n_per_spin), "Sz": 0.0, "mu": float(mu)}
-        self.physics = physics
-        logger.info("FLEX: NCond = {}, Sz = {}, ChemicalPotential = {}".format(
-            physics["NCond"], physics["Sz"], physics["mu"]))
-        self.sigma = _bk.to_host(sigma)
-        self.sigma_static = np.array(state.static, copy=True)
-        self.sigma_fluct = np.array(state.fluct, copy=True)
-        self.green_kw = _bk.to_host(green_kw)
-        green_info["sigma"] = self.sigma
-        green_info["sigma_static"] = self.sigma_static
-        green_info["sigma_fluct"] = self.sigma_fluct
-        green_info["green"] = self.green_kw
-        green_info["physics"] = physics
-        if self.max_iter > 0:
-            self.chi_s = _bk.to_host(chi_s)
-            self.chi_c = _bk.to_host(chi_c)
-            green_info["chi0q"] = _bk.to_host(chi0q_out)
-            green_info["chiq_s"] = self.chi_s
-            green_info["chiq_c"] = self.chi_c
-            if self.longitudinal_bond_channels:
-                self._phase_b_publish_bond(green_info)
-        else:
-            logger.info("FLEX IterationMax=0: no map executed; only the final-state "
-                        "outputs (sigma, green, physics) of the seed state are stored.")
+            for iteration in range(self.max_iter):
+                logger.info("FLEX iteration {}/{}".format(iteration + 1, self.max_iter))
+                with self._traced("green_mu"):
+                    sigma = xp.asarray(state.total())
+                    if self.calc_mu:
+                        mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
+                        self.mu = mu
+                    if not np.isfinite(mu):
+                        raise _hf.NonFiniteError("non-finite chemical potential at iteration {}"
+                                                 .format(iteration + 1))
+                    green_kw = self._calc_dressed_green(beta, mu, sigma)
+                    del sigma
+                    if not np.all(np.isfinite(green_kw)):
+                        raise _hf.NonFiniteError("non-finite Green function at iteration {}"
+                                                 .format(iteration + 1))
+                with self._traced("density_hf"):
+                    dens, sigma_hf, _ = self._phase_b_density_and_hf(
+                        green_kw, state.static, mu, beta, Ncond_target)
+                    self.hf_density_error_map = abs(
+                        2.0 * dens.n_per_spin - getattr(self, "Ncond", float("nan"))) / nvol
+                    del dens
+                green_scf = green_kw - green_tail_w if green_tail_w is not None else green_kw
+                if gate:
+                    chi0q_out, chi_s, chi_c, sigma_fluct = self._phase_b_bond_map(
+                        store, green_kw, green_scf, green0_tail, beta, iteration + 1)
+                else:
+                    chi0q_raw = self._calc_chi0q(green_scf, green0_tail, beta)
+                    assert chi0q_raw.shape[0] == 1
+                    chi0q_raw = chi0q_raw[0]
+                    chi0q_out, v_eff, chi_s, chi_c = \
+                        self._flex_compute_veff_general(chi0q_raw, ham_orig)
+                    sigma_fluct = self._calc_self_energy_general(green_kw, v_eff, beta)
+                    del v_eff
+                del green_scf
+                new_state = SplitState(static=_bk.to_host(sigma_hf),
+                                       fluct=_bk.to_host(sigma_fluct))
+                del sigma_hf, sigma_fluct
+                for name, arr in (("Sigma_HF", new_state.static), ("Sigma_fluct", new_state.fluct)):
+                    if not np.all(np.isfinite(arr)):
+                        raise _hf.NonFiniteError("non-finite {} at iteration {}".format(
+                            name, iteration + 1))
+                with self._traced("convergence"):
+                    g_new = self._calc_dressed_green(beta, mu, xp.asarray(new_state.total()))
+                    res_sigma, res_g, res_comp = residuals(state, new_state, _bk.to_host(green_kw),
+                                                           _bk.to_host(g_new))
+                    del g_new
+                del green_kw
+                self.map_iteration = iteration + 1
+                n_iter_done = iteration + 1
+                self.scf_sigma_residual, self.scf_green_residual, self.scf_component_residual = \
+                    res_sigma, res_g, res_comp
+                done, count = counter.update(res_sigma, res_g, res_comp)
+                logger.info("  residuals: sigma {:.3e}  green {:.3e}  component {:.3e}  [pass {}/3]"
+                            .format(res_sigma, res_g, res_comp, count))
+                if self._iteration_hook is not None:
+                    payload = dict(
+                        iteration=iteration + 1, mu=float(mu),
+                        static_new=np.array(new_state.static, copy=True),
+                        fluct_new=np.array(new_state.fluct, copy=True),
+                        chi0q=np.array(_bk.to_host(chi0q_out), copy=True),
+                        chiq_s=np.array(_bk.to_host(chi_s), copy=True),
+                        chiq_c=np.array(_bk.to_host(chi_c), copy=True))
+                    if gate:
+                        payload["bond_static_s"] = np.array(self._bond_last.static_s, copy=True)
+                        payload["bond_static_c"] = np.array(self._bond_last.static_c, copy=True)
+                    self._iteration_hook(payload)
+                with self._traced("mixing"):
+                    if mixer is not None:
+                        state = mixer.step(state, new_state)
+                    else:
+                        state = linear_mix_pair(state, new_state, self.mix)
+                    del new_state
+                self.state_iteration = iteration + 1
+                if not (np.all(np.isfinite(state.static)) and np.all(np.isfinite(state.fluct))):
+                    raise _hf.NonFiniteError("non-finite mixed self-energy at iteration {}"
+                                             .format(iteration + 1))
+                ok, err = _hf.is_hermitian_batch(state.static[:, 0], 1e-10)
+                if not ok:
+                    raise ValueError("the mixed static self-energy is not Hermitian "
+                                     "(relative deviation {:.3e})".format(err))
+                heff = _hf.heff_eigenpairs(np.asarray(self.H0_k)[0], state.static[0, 0])
+                if done:
+                    logger.info("FLEX converged after {} iterations".format(iteration + 1))
+                    converged = True
+                    break
+            if not converged:
+                logger.warning("FLEX did not converge after {} iterations (residuals sigma={:.3e}, "
+                               "green={:.3e}, component={:.3e}, eps={:.3e})".format(
+                                   self.max_iter, self.scf_sigma_residual, self.scf_green_residual,
+                                   self.scf_component_residual, self.eps))
+            self.scf_converged = converged
+            self.scf_iterations = n_iter_done
+            with self._traced("post_scf"):
+                # final state: mu, G, density, physics from the (post-mix) state
+                sigma = xp.asarray(state.total())
+                if self.calc_mu:
+                    mu = self._find_mu_dressed(sigma, beta, Ncond_target, ew_ref=heff[0][None])
+                    self.mu = mu
+                green_kw = self._calc_dressed_green(beta, mu, sigma)
+                dens = _hf.equal_time_density(_bk.to_host(green_kw), heff, mu, beta, shape)
+                self.hf_density_error_state = abs(
+                    2.0 * dens.n_per_spin - getattr(self, "Ncond", float("nan"))) / nvol
+                physics = {"NCond": float(2.0 * dens.n_per_spin), "Sz": 0.0, "mu": float(mu)}
+                self.physics = physics
+                logger.info("FLEX: NCond = {}, Sz = {}, ChemicalPotential = {}".format(
+                    physics["NCond"], physics["Sz"], physics["mu"]))
+                self.sigma = _bk.to_host(sigma)
+                self.sigma_static = np.array(state.static, copy=True)
+                self.sigma_fluct = np.array(state.fluct, copy=True)
+                self.green_kw = _bk.to_host(green_kw)
+                green_info["sigma"] = self.sigma
+                green_info["sigma_static"] = self.sigma_static
+                green_info["sigma_fluct"] = self.sigma_fluct
+                green_info["green"] = self.green_kw
+                green_info["physics"] = physics
+                if self.max_iter > 0:
+                    self.chi_s = _bk.to_host(chi_s)
+                    self.chi_c = _bk.to_host(chi_c)
+                    green_info["chi0q"] = _bk.to_host(chi0q_out)
+                    green_info["chiq_s"] = self.chi_s
+                    green_info["chiq_c"] = self.chi_c
+                    if gate:
+                        self._phase_b_publish_bond(green_info, store)
+                else:
+                    logger.info("FLEX IterationMax=0: no map executed; only the final-state "
+                                "outputs (sigma, green, physics) of the seed state are stored.")
         logger.info("End FLEX calculations")
 
-    def _phase_b_bond_map(self, green_kw, green_scf, green0_tail, beta, iteration):
-        raise NotImplementedError("the bond-resolved map is implemented in a later task")
+    def _phase_b_bond_map(self, store, green_kw, green_scf, green0_tail, beta, iteration):
+        """One bond-resolved map (spec 1, gate on): bubble -> batched
+        dressing / W / collapses -> Sigma_fluct. Returns the three rank-6
+        collapses (``acbd`` layout) and Sigma_fluct."""
+        from hwave.solver import flex_bond
+        nvol, nmat, norb = self.lattice.nvol, self.nmat, self.norb
+        nd = norb * norb
+        shape = tuple(int(x) for x in self.lattice.shape)
+        workers = getattr(self, "fft_workers", 1)
+        with self._traced("bubble"):
+            flex_bond.assemble_bubble(
+                store, _bk.to_host(green_scf),
+                None if green0_tail is None else _bk.to_host(green0_tail),
+                beta, self._bond_view, shape, workers)
+        with self._traced("dressing"):
+            res = flex_bond.dress_and_build_w(
+                store, self._bond_S, self._bond_C, nb=self._bond_nb,
+                output_full=self.longitudinal_bond_output_full, nmat=nmat, nvol=nvol, nd=nd,
+                spatial_shape=shape, iteration=iteration)
+        with self._traced("transport"):
+            sigma_fluct = flex_bond.calc_self_energy_bond(
+                store, _bk.to_host(green_kw), beta, self._bond_view, shape, norb, workers)
+        self._bond_last = res
+        r6 = (nmat, nvol, norb, norb, norb, norb)
+        return (res.collapse0.reshape(r6), res.collapse_s.reshape(r6),
+                res.collapse_c.reshape(r6), sigma_fluct)
 
-    def _phase_b_publish_bond(self, green_info):
-        raise NotImplementedError("the bond-resolved outputs are implemented in a later task")
+    def _phase_b_publish_bond(self, green_info, store):
+        """The sixteen static ``longitudinal_bond_*`` keys of the LAST map
+        (Phase A schema), ``longitudinal_bond_source`` and, with
+        ``longitudinal_bond_output_full``, the detached dynamic channels."""
+        res = self._bond_last
+        topo = self._bond_topo
+        nvol, norb = self.lattice.nvol, self.norb
+        nd = norb * norb
+        delta_r = np.asarray(topo.delta_r, dtype=np.int64)
+        out = {
+            "longitudinal_bond_chi_s": res.static_s,
+            "longitudinal_bond_chi_c": res.static_c,
+            "longitudinal_bond_chiq_s_static": np.ascontiguousarray(
+                res.static_s[:, :nd, :nd]).reshape(nvol, norb, norb, norb, norb),
+            "longitudinal_bond_chiq_c_static": np.ascontiguousarray(
+                res.static_c[:, :nd, :nd]).reshape(nvol, norb, norb, norb, norb),
+            "longitudinal_bond_delta_r": delta_r,
+            "longitudinal_bond_reverse": np.asarray(topo.reverse, dtype=np.int64),
+            "longitudinal_bond_index_order": np.str_("I = m*norb**2 + l1*norb + l2"),
+            "longitudinal_bond_spatial_shape": np.array(self.lattice.shape, dtype=np.int64),
+            "longitudinal_bond_q_convention":
+                np.str_("q = 2*pi*(n_x/N_x, n_y/N_y, n_z/N_z), C-order flattened"),
+            "longitudinal_bond_spin_mode": np.str_(self.spin_mode),
+            "longitudinal_bond_normalization": np.str_("chi_bar = -(T/N) sum_k G G, per site"),
+            "longitudinal_bond_types": np.asarray(self._bond_types),
+            "longitudinal_bond_max_shells": np.int64(
+                -1 if self.longitudinal_bond_max_shells is None
+                else int(self.longitudinal_bond_max_shells)),
+            "longitudinal_bond_cond_min_s": np.float64(res.cond_min_s),
+            "longitudinal_bond_cond_min_c": np.float64(res.cond_min_c),
+            "longitudinal_bond_schema": np.int64(1),
+            "longitudinal_bond_source": np.str_("last_map"),
+        }
+        if self.longitudinal_bond_output_full:
+            out["longitudinal_bond_chi_s_w"] = store.detach("chi_s_w")
+            out["longitudinal_bond_chi_c_w"] = store.detach("chi_c_w")
+        green_info.update(out)
+        logger.info(
+            "longitudinal_bond_channels (FLEX): chi0q/chiq_s/chiq_c are the channel-0 "
+            "collapses of the last map; the bond-resolved static objects are the "
+            "longitudinal_bond_* keys (B = %d channels %s, ND = %d; cond_min spin %.3e, "
+            "charge %.3e).", int(delta_r.shape[0]),
+            [tuple(int(x) for x in r) for r in delta_r], int(res.static_s.shape[1]),
+            res.cond_min_s, res.cond_min_c)
 
     def _ir_setup(self, beta):
         """Build the fermionic/bosonic IR axes once per solve."""
@@ -3222,6 +3502,20 @@ class FLEX(RPA):
         """
         logger.info("Save FLEX results")
         path_to_output = info_outputfile["path_to_output"]
+        _pb = getattr(self, "_phase_b_active", False)
+        _bond_static = {}
+        _last_map_omitted = False
+        if _pb:
+            # backstop of the output-path validation (spec 4.2)
+            self.validate_output_paths(info_outputfile, path_to_output)
+            _bond_static = {k: v for k, v in green_info.items()
+                            if str(k).startswith("longitudinal_bond_")
+                            and not str(k).endswith("_w")}
+            if "chiq_s" not in green_info:
+                _last_map_omitted = True
+                logger.info("save_results: no map was executed (IterationMax=0); the last-map "
+                            "archives chi0q, chiq_s, chiq_c, chiq and the bond archive are "
+                            "omitted.")
 
         self._init_wavevec()
 
@@ -3276,7 +3570,7 @@ class FLEX(RPA):
                     file_name))
 
         # Save chi0q
-        if "chi0q" in info_outputfile:
+        if "chi0q" in info_outputfile and not _last_map_omitted:
             file_name = os.path.join(path_to_output, info_outputfile["chi0q"])
             # coeff_tail provenance (issue #80): the tail correction changes
             # chi0q at O(1); record the producing value. On the IR path the
@@ -3356,10 +3650,21 @@ class FLEX(RPA):
         if getattr(self, "_phase_b_active", False):
             common_meta.update(self._provenance_block("last_map"))
 
+        _bond_into_chiq_s = {}
+        if _bond_static:
+            if "chiq" in info_outputfile:
+                logger.info("save_results: the static longitudinal_bond_* keys are written "
+                            "into the combined chiq archive")
+            else:
+                _bond_into_chiq_s = _bond_static
+                logger.info("save_results: no combined chiq archive is configured; the "
+                            "static longitudinal_bond_* keys (charge channel included) are "
+                            "written into the chiq_s archive")
         if "chiq_s" in green_info:
             file_name = os.path.join(path_to_output,
                                      info_outputfile.get("chiq_s", "chiq_s"))
-            np.savez(file_name, chiq_s=green_info["chiq_s"], **common_meta)
+            np.savez(file_name, chiq_s=green_info["chiq_s"], **common_meta,
+                     **_bond_into_chiq_s)
             logger.info("save_results: save chiq_s in file {}".format(file_name))
 
         if "chiq_c" in green_info:
@@ -3368,9 +3673,10 @@ class FLEX(RPA):
             np.savez(file_name, chiq_c=green_info["chiq_c"], **common_meta)
             logger.info("save_results: save chiq_c in file {}".format(file_name))
 
-        if "chiq" in info_outputfile:
+        if "chiq" in info_outputfile and not _last_map_omitted:
             file_name = os.path.join(path_to_output, info_outputfile["chiq"])
             save_dict = dict(**common_meta)
+            save_dict.update(_bond_static)
             if "chiq_s" in green_info:
                 save_dict["chiq_s"] = green_info["chiq_s"]
             if "chiq_c" in green_info:
@@ -3425,3 +3731,32 @@ class FLEX(RPA):
                      **green_extra,
                      **_freq_meta("F"))
             logger.info("save_results: save green in file {}".format(file_name))
+
+        # Dedicated bond archive (spec 4.2, longitudinal_bond_output_full)
+        if _pb and "longitudinal_bond_chi_s_w" in green_info:
+            file_name = os.path.join(path_to_output,
+                                     info_outputfile.get("longitudinal_bond",
+                                                         "longitudinal_bond.npz"))
+            chi_s_w = green_info["longitudinal_bond_chi_s_w"]
+            chi_c_w = green_info["longitudinal_bond_chi_c_w"]
+            logger.info("save_results: writing the dynamic bond archive {} (%.3f GiB of "
+                        "channel data)".format(file_name), 2 * chi_s_w.nbytes / 1024 ** 3)
+            np.savez(file_name,
+                     bond_archive_schema=np.int64(1),
+                     chi_s_w=chi_s_w,
+                     chi_c_w=chi_c_w,
+                     freq_axis=np.str_("bosonic l -> 2l - nmat"),
+                     beta=1.0 / self.T,
+                     T=self.T,
+                     nmat=self.nmat,
+                     cell_shape=np.array(self.lattice.shape),
+                     momentum_convention=MOMENTUM_CONVENTION,
+                     wavevector_unit=self.kvec,
+                     wavevector_index=self.wavenum_table,
+                     index_order=green_info["longitudinal_bond_index_order"],
+                     delta_r=green_info["longitudinal_bond_delta_r"],
+                     reverse=green_info["longitudinal_bond_reverse"],
+                     types=green_info["longitudinal_bond_types"],
+                     **_bond_static,
+                     **self._provenance_block("last_map"))
+            logger.info("save_results: save the bond archive in file {}".format(file_name))

--- a/src/hwave/solver/flex.py
+++ b/src/hwave/solver/flex.py
@@ -1210,7 +1210,8 @@ class FLEX(RPA):
                 green_info.pop(k, None)
         for attr in ("sigma", "green_kw", "chi_s", "chi_c", "physics", "sigma_static",
                      "sigma_fluct", "_bond_detached", "_bond_static_keys", "_bond_topo",
-                     "_bond_split", "_bond_view", "_bond_S", "_bond_C", "_bond_types",
+                     "_bond_split", "_bond_view", "_bond_S", "_bond_C", "_bond_S_on", "_bond_C_on",
+                     "_bond_types",
                      "_bond_last", "_bond_est", "_bond_nb", "_phase_b_seed", "_hf_tables"):
             if hasattr(self, attr):
                 delattr(self, attr)
@@ -1409,13 +1410,16 @@ class FLEX(RPA):
     def _phase_b_prepare_vertices(self):
         """S, C on the bond basis, cached once per solve (spec 3.5)."""
         from hwave.solver import bond_channels, hartree_fock as _hf
-        from hwave.solver.offsite import sc_matrices_from_split
+        from hwave.solver.offsite import sc_matrices_from_split, sc_matrices_onsite_from_split
         nx, ny, nz = (int(x) for x in self.lattice.shape)
         nvol, nd = self.lattice.nvol, self.norb ** 2
         S0, C0 = sc_matrices_from_split(self._bond_split, bond_channels._LONGITUDINAL_ACTIVE_TYPES,
                                         self.norb, nx, ny, nz)
         S0 = S0.reshape(nvol, nd, nd)
         C0 = C0.reshape(nvol, nd, nd)
+        S_on, C_on = sc_matrices_onsite_from_split(self._bond_split, self.norb, nx, ny, nz)
+        self._bond_S_on = np.ascontiguousarray(S_on.reshape(nvol, nd, nd))
+        self._bond_C_on = np.ascontiguousarray(C_on.reshape(nvol, nd, nd))
         types = tuple(self._bond_topo.coeffs)
         self._bond_types = types
         self._bond_S = bond_channels.build_sc_bond_channel(self._bond_topo, S0, "S", types=types)
@@ -1601,7 +1605,8 @@ class FLEX(RPA):
                 beta, self._bond_view, shape, workers)
         with self._traced("dressing"):
             res = flex_bond.dress_and_build_w(
-                store, self._bond_S, self._bond_C, nb=self._bond_nb,
+                store, self._bond_S, self._bond_C, S_on=self._bond_S_on, C_on=self._bond_C_on,
+                nb=self._bond_nb,
                 output_full=self.longitudinal_bond_output_full, nmat=nmat, nvol=nvol, nd=nd,
                 spatial_shape=shape, iteration=iteration)
         with self._traced("transport"):

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -79,6 +79,10 @@ class BondBlockStore:
         self._arrays.clear()
         self._released = True
 
+    @property
+    def released(self):
+        return self._released
+
 
 def assemble_bubble(store, green_scf, green0_tail, beta, view, spatial_shape, workers):
     """Fill ``store['chibar']`` pair by pair from ``bubble._iter_bond_dynamic``
@@ -100,6 +104,27 @@ from dataclasses import dataclass as _dataclass
 from . import bond_channels as _bc
 
 
+from .hartree_fock import NonFiniteError as _NonFiniteError
+
+
+def _at(iteration):
+    return "" if iteration is None else " (SCF iteration {})".format(iteration)
+
+
+def _dress(cb, V, channel, l0, nmat, spatial_shape, cond_tol, iteration):
+    try:
+        chi_b, cond = _bc.dress_batch(cb, V, channel, l0=l0, nmat=nmat, spatial_shape=spatial_shape,
+                                      cond_tol=cond_tol)
+    except ValueError as exc:
+        if iteration is None:
+            raise
+        raise ValueError("{}{}".format(exc, _at(iteration))) from exc
+    if not np.all(np.isfinite(chi_b)):
+        raise _NonFiniteError("non-finite dressed {} channel in the frequency batch starting "
+                              "at l={}{}".format(channel, l0, _at(iteration)))
+    return chi_b, cond
+
+
 @_dataclass(frozen=True)
 class DressResult:
     collapse0: np.ndarray      # (nmat, nvol, nd, nd)  channel-0 block of chibar
@@ -112,7 +137,7 @@ class DressResult:
 
 
 def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_shape,
-                      cond_tol=_bc._BOND_COND_FLOOR):
+                      cond_tol=_bc._BOND_COND_FLOOR, iteration=None):
     """The spec 3.2 loop: per frequency batch, dress spin then charge (one
     channel batch alive at a time), consume each into W, the channel-0
     collapses, the static slices (slice assignment into preallocated
@@ -130,8 +155,7 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
         l1 = min(nmat, l0 + nb)
         cb = store.get_freq_batch("chibar", l0, l1)
         collapse0[l0:l1] = cb[:, :, :nd, :nd]
-        chi_s_b, cs = _bc.dress_batch(cb, S, "spin", l0=l0, nmat=nmat, spatial_shape=spatial_shape,
-                                      cond_tol=cond_tol)
+        chi_s_b, cs = _dress(cb, S, "spin", l0, nmat, spatial_shape, cond_tol, iteration)
         cond_s = min(cond_s, cs if cs is not None else np.inf)
         W_b = 1.5 * (S[None] @ chi_s_b @ S[None])
         collapse_s[l0:l1] = chi_s_b[:, :, :nd, :nd]
@@ -140,8 +164,7 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
         if output_full:
             store.put_freq_batch("chi_s_w", l0, l1, chi_s_b)
         del chi_s_b
-        chi_c_b, cc = _bc.dress_batch(cb, C, "charge", l0=l0, nmat=nmat, spatial_shape=spatial_shape,
-                                      cond_tol=cond_tol)
+        chi_c_b, cc = _dress(cb, C, "charge", l0, nmat, spatial_shape, cond_tol, iteration)
         cond_c = min(cond_c, cc if cc is not None else np.inf)
         W_b += 0.5 * (C[None] @ chi_c_b @ C[None])
         collapse_c[l0:l1] = chi_c_b[:, :, :nd, :nd]
@@ -151,6 +174,9 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
             store.put_freq_batch("chi_c_w", l0, l1, chi_c_b)
         del chi_c_b
         W_b -= 0.25 * (SpC[None] @ cb @ SpC[None])
+        if not np.all(np.isfinite(W_b)):
+            raise _NonFiniteError("non-finite effective interaction W in the frequency batch "
+                                  "[{}, {}){}".format(l0, l1, _at(iteration)))
         store.put_freq_batch("W", l0, l1, W_b)
         del W_b
     return DressResult(collapse0=collapse0, collapse_s=collapse_s, collapse_c=collapse_c,
@@ -162,16 +188,22 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
 # Bond-aware self-energy transport (spec 3.4)
 # =============================================================================
 
-_TRANSPORT_COST_WARN = 1.0e11
 
 
 def calc_self_energy_bond(store, green_kw, beta, view, shape, norb, workers):
     """Sigma_fluct(k, iw) from the bond-resolved effective interaction ``W``
-    in ``store`` (spec 3.4, normative equation with the momentum phases
-    e^{+ik.R_alpha} e^{-i(k-q).R_beta} realised as real-space rolls):
+    in ``store`` (spec 3.4, normative equation):
 
         Sigma_ab(k) = T/N sum_{q,nu} sum_{alpha,beta,c,d}
-            e^{+ik.R_alpha} W_{(alpha,c,a),(beta,d,b)}(q) e^{-i(k-q).R_beta} G_cd(k-q)
+            e^{+i(k-q).(R_alpha - R_beta)} W_{(alpha,c,a),(beta,d,b)}(q) G_cd(k-q)
+
+    The bond form factor sits on the internal leg k - q on BOTH ends of W
+    (the bubble's pair operator carries its phase on the reversed
+    propagator, so chibar_{alpha beta}(q) = -(T/N) sum_k e^{i(k-q).(R_alpha
+    - R_beta)} G(k) G(k-q)); with this assignment chibar(q, i nu)^dagger =
+    chibar(q, -i nu) and W inherit the plain matrix conjugation symmetry
+    and Sigma(k, i w)^dagger = Sigma(k, -i w) holds to round-off.  In real
+    space the phase is G(r + R_alpha - R_beta), a roll of G by R_beta - R_alpha.
 
     ``green_kw`` is rank five `(1, nmat, nvol, norb, norb)`; the result has
     the same shape.  With a single on-site channel this reproduces
@@ -182,35 +214,31 @@ def calc_self_energy_bond(store, green_kw, beta, view, shape, norb, workers):
     P = norb
     nd = norb * norb
     B = view.n_channels
-    cost = float(B * B) * nmat * nvol * (P ** 2 * np.log2(max(nmat * nvol, 2)) + P ** 3)
-    if cost > _TRANSPORT_COST_WARN:
-        logger.warning("bond self-energy transport cost estimate %.2e exceeds %.0e "
-                       "(B=%d, Nmat=%d, Nvol=%d, norb=%d); expect long iterations",
-                       cost, _TRANSPORT_COST_WARN, B, nmat, nvol, norb)
     G_kw = green_kw[0]
     G_rt = _bk.spatial_ifftn(
         _ms.fermion_to_tau(G_kw.reshape(nmat, nvol * P * P), axis=0).reshape(nmat, nx, ny, nz, P * P),
-        axes=(1, 2, 3), workers=workers).reshape(nmat, nvol, P, P)
+        axes=(1, 2, 3), workers=workers).reshape(nmat, nx, ny, nz, P, P)
     Sigma_rt = np.zeros((nmat, nvol, P, P), dtype=np.complex128)
     axes = (1, 2, 3)
     for alpha in range(B):
         Ra = np.asarray(view.delta_r[alpha], dtype=int)
         for bt in range(B):
             Rb = np.asarray(view.delta_r[bt], dtype=int)
+            shift = tuple(int(x) for x in (Rb - Ra))   # e^{+ik'.(R_a - R_b)} G(k') = G(r + R_a - R_b)
+            if shift == (0, 0, 0):
+                G_sh = G_rt.reshape(nmat, nvol, P, P)
+            else:
+                G_sh = np.roll(G_rt, shift, axis=axes).reshape(nmat, nvol, P, P)
             blk = np.ascontiguousarray(store.get_pair("W", alpha, bt))               # (nmat, nvol, nd, nd)
             blk_qt = _ms.boson_to_tau(blk.reshape(nmat, nvol * nd * nd), axis=0)
             del blk
             Wab_rt = _bk.spatial_ifftn(blk_qt.reshape(nmat, nx, ny, nz, nd * nd),
-                                       axes=axes, workers=workers)
+                                       axes=axes, workers=workers).reshape(nmat, nvol, P, P, P, P)
             del blk_qt
-            Wab_rt = np.roll(Wab_rt, tuple(-Rb), axis=axes).reshape(nmat, nvol, P, P, P, P)
-            A = np.einsum('frcadb,frcd->frab', Wab_rt, G_rt)
-            del Wab_rt
-            A_rolled = np.roll(A.reshape(nmat, nx, ny, nz, P, P), tuple(Rb - Ra), axis=axes
-                               ).reshape(nmat, nvol, P, P)
+            A = np.einsum('frcadb,frcd->frab', Wab_rt, G_sh)
+            del Wab_rt, G_sh
+            Sigma_rt += A
             del A
-            Sigma_rt += A_rolled
-            del A_rolled
     del G_rt
     tmp = _bk.spatial_fftn(Sigma_rt.reshape(nmat, nx, ny, nz, P * P), axes=axes, workers=workers)
     del Sigma_rt
@@ -219,3 +247,152 @@ def calc_self_energy_bond(store, green_kw, beta, view, shape, norb, workers):
     sigma = sigma.reshape(1, nmat, nvol, P, P)
     sigma *= 1.0 / beta
     return sigma
+
+
+# =============================================================================
+# Memory preflight (spec 3.6) and output-path resolution (spec 4.2)
+# =============================================================================
+
+import os as _os
+
+_DRESSING_OPS_WARN = 1.0e12
+_TRANSPORT_OPS_WARN = 1.0e11
+_GIB = float(1024 ** 3)
+
+
+def dressing_ops(nmat, nvol, ND):
+    """Operation count of the two dense ND x ND solves over all (l, q)."""
+    return 2.0 * nmat * nvol * float(ND) ** 3
+
+
+def transport_ops(B, nmat, nvol, norb):
+    """Operation count of the bond self-energy transport (transforms plus
+    the orbital contraction, P^3 = norb^6)."""
+    P = norb ** 2
+    return float(B * B) * nmat * nvol * (P ** 2 * np.log2(max(nmat * nvol, 2)) + P ** 3)
+
+
+def estimate_bond_memory(*, nmat, nvol, norb, B, depth, output_full, split_seed, n_types,
+                         freq_batch, cap_gb, mixing):
+    """The named-buffer lifetime table of spec 3.6 (every row raw), the
+    batch selection and the admission decision against ``cap_gb`` (binary
+    GiB). Returns a dict with ``persistent_rows``, ``phase_rows`` (at the
+    selected ``nb``), ``persistent``, ``nb``, ``peak`` and the symbols;
+    raises ``ValueError`` naming every row when even ``nb = 1`` exceeds
+    the cap, or when ``freq_batch`` does."""
+    nmat, nvol, norb, B = int(nmat), int(nvol), int(norb), int(B)
+    depth = int(depth) if mixing == "anderson" else 0
+    it = 16
+    P = norb * norb
+    ND = B * P
+    U = nmat * nvol * ND * ND * it
+    G = nmat * nvol * P * it
+    C = nmat * nvol * P * P * it
+    S = nvol * ND * ND * it
+    H = nvol * P * it
+    persistent_rows = {
+        "chibar_W": 2 * U,
+        "chi_sc_w": 2 * U if output_full else 0,
+        "vertices_static": 5 * S,
+        "state": G + H,
+        "seed_envelope": (2 * G + H) if split_seed else 0,
+        "anderson_history": 2 * depth * 2 * G,
+        "collapses": 3 * C,
+        "eigenpairs_hf": 5 * H,
+        "flex_arrays": 5 * G,
+        "hf_tables": int(n_types) * H,
+    }
+    persistent = sum(persistent_rows.values())
+    prep = it * nvol * (ND ** 2 + 4 * P * (nmat + 2))
+    pair = it * nvol * (2 * ND ** 2 + 3 * nmat * P ** 2 + 2 * nmat * P + 8 * P)
+    per_batch = 6 * nvol * ND * ND * it
+
+    def _phase_rows(nb):
+        return {
+            "green_mu": 6 * G + H,
+            "density_hf": 2 * H + 8 * H + 20 * H + H,
+            "bubble": max(prep, pair),
+            "dressing": per_batch * nb,
+            "transport": 4 * G + 4 * C,
+            "convergence": 6 * G + H,
+            "mixing": (2 * depth * 2 * G + 4 * G) if mixing == "anderson" else 2 * G,
+            "post_scf": G + (U if output_full else C),
+        }
+
+    def _peak(nb):
+        return 1.25 * (persistent + max(_phase_rows(nb).values()))
+
+    cap_bytes = float(cap_gb) * _GIB
+
+    def _table(nb):
+        rows = ["  persistent {:>18s}: {:10.4f} GiB".format(k, v / _GIB)
+                for k, v in persistent_rows.items()]
+        rows += ["  phase      {:>18s}: {:10.4f} GiB".format(k, v / _GIB)
+                 for k, v in _phase_rows(nb).items()]
+        return "\n".join(rows)
+
+    if freq_batch is not None:
+        nb = int(freq_batch)
+        if not 1 <= nb <= nmat:
+            raise ValueError("longitudinal_bond_freq_batch must be in [1, Nmat={}], got {}"
+                             .format(nmat, nb))
+        if _peak(nb) > cap_bytes:
+            raise ValueError(
+                "[mode.param] longitudinal_bond_freq_batch = {} gives an estimated peak of "
+                "{:.4f} GiB = 1.25 * (persistent + max phase row) above "
+                "longitudinal_bond_memory_cap_gb = {:.4f} GiB (B = {}, ND = {}, nvol = {}, "
+                "Nmat = {}); the rows are\n{}\nReduce the batch, the k mesh or Nmat, drop "
+                "declared-zero outer shells with longitudinal_bond_max_shells, or raise the cap."
+                .format(nb, _peak(nb) / _GIB, cap_bytes / _GIB, B, ND, nvol, nmat, _table(nb)))
+    else:
+        if _peak(1) > cap_bytes:
+            raise ValueError(
+                "[mode.param] longitudinal_bond_channels=true: the estimated peak host memory "
+                "{:.4f} GiB (frequency batch 1) = 1.25 * (persistent + max phase row) exceeds "
+                "longitudinal_bond_memory_cap_gb = {:.4f} GiB (B = {}, ND = {}, nvol = {}, "
+                "Nmat = {}); the rows are\n{}\nReduce the k mesh or Nmat, drop declared-zero "
+                "outer shells with longitudinal_bond_max_shells, disable "
+                "longitudinal_bond_output_full, lower the Anderson depth, or raise the cap."
+                .format(_peak(1) / _GIB, cap_bytes / _GIB, B, ND, nvol, nmat, _table(1)))
+        nb = 1
+        for cand in range(nmat, 0, -1):
+            if _peak(cand) <= cap_bytes:
+                nb = cand
+                break
+    phase_rows = _phase_rows(nb)
+    return dict(persistent_rows=persistent_rows, phase_rows=phase_rows, persistent=persistent,
+                nb=nb, peak=_peak(nb), cap_bytes=cap_bytes, U=U, G_bytes=G, C_bytes=C,
+                S_bytes=S, H_bytes=H, B=B, ND=ND, nvol=nvol, nmat=nmat, table=_table(nb),
+                dressing_ops=dressing_ops(nmat, nvol, ND),
+                transport_ops=transport_ops(B, nmat, nvol, norb))
+
+
+_NPZ_ARTIFACTS = ("chi0q", "chiq_s", "chiq_c", "chiq", "sigma", "green", "longitudinal_bond")
+_DEFAULT_FILES = {"chiq_s": "chiq_s", "chiq_c": "chiq_c",
+                  "longitudinal_bond": "longitudinal_bond.npz"}
+
+
+def resolve_output_paths(info_outputfile, path_to_output, active_outputs):
+    """``{name: absolute path}`` for the artifacts in ``active_outputs``
+    that will actually be written (spec 4.2): joins with ``path_to_output``,
+    applies the ``.npz`` suffix rule of ``numpy.savez`` to the archive
+    artifacts only, normalises to absolute paths (symlink equivalence is
+    not checked) and refuses two artifacts resolving to one file."""
+    out = {}
+    for name in active_outputs:
+        fn = info_outputfile.get(name, _DEFAULT_FILES.get(name))
+        if fn is None:
+            continue
+        p = _os.path.join(str(path_to_output), str(fn))
+        if name in _NPZ_ARTIFACTS and not p.endswith(".npz"):
+            p += ".npz"
+        out[name] = _os.path.abspath(_os.path.normpath(p))
+    seen = {}
+    for name, p in out.items():
+        if p in seen:
+            raise ValueError(
+                "[file.output] the artifacts '{}' and '{}' resolve to the same file {}; "
+                "give them distinct file names (numpy appends '.npz' to archive names "
+                "without that suffix).".format(seen[p], name, p))
+        seen[p] = name
+    return out

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -1,0 +1,90 @@
+"""The dynamic bond pipeline of the Phase B FLEX solver (GitHub issue
+#181; spec docs/superpowers/specs/2026-09-06-flex-bond-sigma-phase-b-181-design.md,
+section 3): the dense bond-block store, the bubble assembly, the batched
+dressing, the bond-aware self-energy transport, the memory preflight and
+the output helpers.
+"""
+import numpy as np
+
+from . import backend as _bk
+from . import bubble as _bubble
+
+
+class BondBlockStore:
+    """Owner of the dense ``(nmat, nvol, ND, ND)`` bond arrays (spec 3.5).
+
+    A context manager: construction allocates every named array (rolling
+    back on a partial failure), ``release()`` runs on every exit of the
+    ``with`` block. Pair access (``put_pair`` / ``get_pair``: a view
+    ``(nmat, nvol, nd, nd)`` onto channel pair ``(alpha, beta)``) and
+    frequency-batch access (``put_freq_batch`` / ``get_freq_batch``: a
+    contiguous ``(nb, nvol, ND, ND)`` view) are the only ways in and out;
+    ``detach(name)`` transfers ownership of one array to the caller.
+    A future streaming store implements the same five methods.
+    """
+
+    def __init__(self, nmat, nvol, ND, nd, names):
+        names = tuple(names)
+        if len(set(names)) != len(names):
+            raise ValueError("BondBlockStore: duplicate array names {}".format(names))
+        if ND % nd != 0:
+            raise ValueError("BondBlockStore: ND={} is not a multiple of nd={}".format(ND, nd))
+        self.nmat, self.nvol, self.ND, self.nd = int(nmat), int(nvol), int(ND), int(nd)
+        self.B = self.ND // self.nd
+        self._arrays = {}
+        try:
+            for name in names:
+                self._arrays[name] = np.zeros((self.nmat, self.nvol, self.ND, self.ND),
+                                              dtype=np.complex128)
+        except MemoryError:
+            self._arrays.clear()
+            raise
+        self._released = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.release()
+        return False
+
+    def _arr(self, name):
+        if self._released:
+            raise RuntimeError("BondBlockStore: released")
+        return self._arrays[name]
+
+    def put_pair(self, name, alpha, beta, block):
+        a = self._arr(name)
+        nd = self.nd
+        a[:, :, alpha * nd:(alpha + 1) * nd, beta * nd:(beta + 1) * nd] = block
+
+    def get_pair(self, name, alpha, beta):
+        a = self._arr(name)
+        nd = self.nd
+        return a[:, :, alpha * nd:(alpha + 1) * nd, beta * nd:(beta + 1) * nd]
+
+    def put_freq_batch(self, name, l0, l1, batch):
+        self._arr(name)[l0:l1] = batch
+
+    def get_freq_batch(self, name, l0, l1):
+        return self._arr(name)[l0:l1]
+
+    def detach(self, name):
+        a = self._arr(name)
+        del self._arrays[name]
+        return a
+
+    def release(self):
+        self._arrays.clear()
+        self._released = True
+
+
+def assemble_bubble(store, green_scf, green0_tail, beta, view, spatial_shape, workers):
+    """Fill ``store['chibar']`` pair by pair from ``bubble._iter_bond_dynamic``
+    (spec 3.1). ``green_scf`` is the TAIL-SUBTRACTED single-block Green
+    function the general bubble consumes; ``green0_tail`` its tail."""
+    for (alpha, beta_), block in _bubble._iter_bond_dynamic(
+            green_scf, green0_tail, beta, view, spatial_shape=tuple(spatial_shape),
+            workers=workers):
+        store.put_pair("chibar", alpha, beta_, _bk.to_host(block))
+        del block

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -136,14 +136,28 @@ class DressResult:
     cond_min_c: float
 
 
-def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_shape,
+def dress_and_build_w(store, S, C, *, S_on, C_on, nb, output_full, nmat, nvol, nd, spatial_shape,
                       cond_tol=_bc._BOND_COND_FLOOR, iteration=None):
-    """The spec 3.2 loop: per frequency batch, dress spin then charge (one
-    channel batch alive at a time), consume each into W, the channel-0
-    collapses, the static slices (slice assignment into preallocated
-    buffers) and, with ``output_full``, the store's ``chi_s_w``/``chi_c_w``."""
+    """The spec 3.2-3.3 loop (rev 19): per frequency batch, dress spin then
+    charge (one channel batch alive at a time) and consume each into the
+    effective interaction
+
+        W = 3/2 S (chi_s - chibar) S + 1/2 C (chi_c - chibar) C + W2
+
+    whose second-order part ``W2`` is exact for the off-site content and
+    reduces to the general path's for the on-site content:
+    channel-0 block ``[3/2 S chibar S + 1/2 C chibar C]_00 - 1/4 (S_on +
+    C_on) chibar_00 (S_on + C_on)`` (the general path's subtraction
+    restricted to the ON-SITE vertices ``S_on``, ``C_on``: a spin-
+    independent density interaction is counted once by the ring),
+    mixed channel-0/bond blocks ``1/4 (S chibar S + C chibar C)`` (the
+    exchange skeleton, once) and bond-bond blocks ``0`` (their ring
+    second order is the direct skeleton again). Also collects the
+    channel-0 collapses, the static slices (slice assignment into
+    preallocated buffers) and, with ``output_full``, the store's
+    ``chi_s_w``/``chi_c_w``."""
     ND = S.shape[-1]
-    SpC = S + C
+    SpC_on = np.asarray(S_on) + np.asarray(C_on)
     collapse0 = np.empty((nmat, nvol, nd, nd), dtype=np.complex128)
     collapse_s = np.empty_like(collapse0)
     collapse_c = np.empty_like(collapse0)
@@ -151,29 +165,46 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
     static_c = np.zeros((nvol, ND, ND), dtype=np.complex128)
     l_static = nmat // 2
     cond_s = cond_c = np.inf
+    # block weights of the second-order term: 1 on channel-0, 1/2 on the
+    # mixed blocks, 0 on bond-bond (applied to the half-sum below)
+    mask = np.zeros((ND, ND))
+    mask[:nd, :] = 0.5
+    mask[:, :nd] = 0.5
+    mask[:nd, :nd] = 0.0
     for l0 in range(0, nmat, nb):
         l1 = min(nmat, l0 + nb)
         cb = store.get_freq_batch("chibar", l0, l1)
         collapse0[l0:l1] = cb[:, :, :nd, :nd]
         chi_s_b, cs = _dress(cb, S, "spin", l0, nmat, spatial_shape, cond_tol, iteration)
         cond_s = min(cond_s, cs if cs is not None else np.inf)
-        W_b = 1.5 * (S[None] @ chi_s_b @ S[None])
         collapse_s[l0:l1] = chi_s_b[:, :, :nd, :nd]
         if l0 <= l_static < l1:
             static_s[...] = chi_s_b[l_static - l0]
         if output_full:
             store.put_freq_batch("chi_s_w", l0, l1, chi_s_b)
+        chi_s_b -= cb
+        W_b = 1.5 * (S[None] @ chi_s_b @ S[None])
         del chi_s_b
         chi_c_b, cc = _dress(cb, C, "charge", l0, nmat, spatial_shape, cond_tol, iteration)
         cond_c = min(cond_c, cc if cc is not None else np.inf)
-        W_b += 0.5 * (C[None] @ chi_c_b @ C[None])
         collapse_c[l0:l1] = chi_c_b[:, :, :nd, :nd]
         if l0 <= l_static < l1:
             static_c[...] = chi_c_b[l_static - l0]
         if output_full:
             store.put_freq_batch("chi_c_w", l0, l1, chi_c_b)
+        chi_c_b -= cb
+        W_b += 0.5 * (C[None] @ chi_c_b @ C[None])
         del chi_c_b
-        W_b -= 0.25 * (SpC[None] @ cb @ SpC[None])
+        # second-order term
+        A = S[None] @ cb @ S[None]
+        Bc = C[None] @ cb @ C[None]
+        W_b[:, :, :nd, :nd] += 1.5 * A[:, :, :nd, :nd] + 0.5 * Bc[:, :, :nd, :nd]
+        W_b[:, :, :nd, :nd] -= 0.25 * (SpC_on[None] @ cb[:, :, :nd, :nd] @ SpC_on[None])
+        A += Bc
+        del Bc
+        A *= 0.5 * mask
+        W_b += A
+        del A
         if not np.all(np.isfinite(W_b)):
             raise _NonFiniteError("non-finite effective interaction W in the frequency batch "
                                   "[{}, {}){}".format(l0, l1, _at(iteration)))
@@ -192,18 +223,23 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
 
 def calc_self_energy_bond(store, green_kw, beta, view, shape, norb, workers):
     """Sigma_fluct(k, iw) from the bond-resolved effective interaction ``W``
-    in ``store`` (spec 3.4, normative equation):
+    in ``store`` (spec 3.4 rev 19, normative equation):
 
         Sigma_ab(k) = T/N sum_{q,nu} sum_{alpha,beta,c,d}
-            e^{+i(k-q).(R_alpha - R_beta)} W_{(alpha,c,a),(beta,d,b)}(q) G_cd(k-q)
+            e^{+i(k-q).(R_beta - R_alpha)} W_{(alpha,c,a),(beta,d,b)}(q) G_cd(k-q)
 
-    The bond form factor sits on the internal leg k - q on BOTH ends of W
-    (the bubble's pair operator carries its phase on the reversed
-    propagator, so chibar_{alpha beta}(q) = -(T/N) sum_k e^{i(k-q).(R_alpha
-    - R_beta)} G(k) G(k-q)); with this assignment chibar(q, i nu)^dagger =
-    chibar(q, -i nu) and W inherit the plain matrix conjugation symmetry
-    and Sigma(k, i w)^dagger = Sigma(k, -i w) holds to round-off.  In real
-    space the phase is G(r + R_alpha - R_beta), a roll of G by R_beta - R_alpha.
+    The bond form factor sits on the internal leg k - q at both ends of W,
+    with the block (alpha, beta) of W paired with the bubble block
+    (beta, alpha)'s phase: the bubble is chibar_{alpha beta}(q) = -(T/N)
+    sum_k e^{i(k-q).(R_alpha - R_beta)} G(k) G(k-q) and both functional
+    derivatives of the ring functional with respect to G carry the phase
+    of the differentiated (transposed) block (pinned by the second-order
+    skeletons: with this transport the channel-0, mixed and bond-bond
+    blocks of 1/2 (S chibar S + C chibar C) are the direct skeleton, twice
+    the exchange skeleton and half the direct skeleton to 1e-15).  With
+    chibar(q, i nu)^dagger = chibar(q, -i nu) the symmetry
+    Sigma(k, i w)^dagger = Sigma(k, -i w) holds to round-off.  In real
+    space the phase is G(r + R_beta - R_alpha), a roll of G by R_alpha - R_beta.
 
     ``green_kw`` is rank five `(1, nmat, nvol, norb, norb)`; the result has
     the same shape.  With a single on-site channel this reproduces
@@ -224,7 +260,7 @@ def calc_self_energy_bond(store, green_kw, beta, view, shape, norb, workers):
         Ra = np.asarray(view.delta_r[alpha], dtype=int)
         for bt in range(B):
             Rb = np.asarray(view.delta_r[bt], dtype=int)
-            shift = tuple(int(x) for x in (Rb - Ra))   # e^{+ik'.(R_a - R_b)} G(k') = G(r + R_a - R_b)
+            shift = tuple(int(x) for x in (Ra - Rb))   # e^{+ik'.(R_b - R_a)} G(k') = G(r + R_b - R_a)
             if shift == (0, 0, 0):
                 G_sh = G_rt.reshape(nmat, nvol, P, P)
             else:

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -88,3 +88,70 @@ def assemble_bubble(store, green_scf, green0_tail, beta, view, spatial_shape, wo
             workers=workers):
         store.put_pair("chibar", alpha, beta_, _bk.to_host(block))
         del block
+
+
+# =============================================================================
+# Batched dressing, effective interaction and collapses (spec 3.2-3.3)
+# =============================================================================
+
+from dataclasses import dataclass as _dataclass
+
+from . import bond_channels as _bc
+
+
+@_dataclass(frozen=True)
+class DressResult:
+    collapse0: np.ndarray      # (nmat, nvol, nd, nd)  channel-0 block of chibar
+    collapse_s: np.ndarray     # (nmat, nvol, nd, nd)  channel-0 block of chi_s
+    collapse_c: np.ndarray
+    static_s: np.ndarray       # (nvol, ND, ND) at Omega = 0
+    static_c: np.ndarray
+    cond_min_s: float
+    cond_min_c: float
+
+
+def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_shape,
+                      cond_tol=_bc._BOND_COND_FLOOR):
+    """The spec 3.2 loop: per frequency batch, dress spin then charge (one
+    channel batch alive at a time), consume each into W, the channel-0
+    collapses, the static slices (slice assignment into preallocated
+    buffers) and, with ``output_full``, the store's ``chi_s_w``/``chi_c_w``."""
+    ND = S.shape[-1]
+    SpC = S + C
+    collapse0 = np.empty((nmat, nvol, nd, nd), dtype=np.complex128)
+    collapse_s = np.empty_like(collapse0)
+    collapse_c = np.empty_like(collapse0)
+    static_s = np.zeros((nvol, ND, ND), dtype=np.complex128)
+    static_c = np.zeros((nvol, ND, ND), dtype=np.complex128)
+    l_static = nmat // 2
+    cond_s = cond_c = np.inf
+    for l0 in range(0, nmat, nb):
+        l1 = min(nmat, l0 + nb)
+        cb = store.get_freq_batch("chibar", l0, l1)
+        collapse0[l0:l1] = cb[:, :, :nd, :nd]
+        chi_s_b, cs = _bc.dress_batch(cb, S, "spin", l0=l0, nmat=nmat, spatial_shape=spatial_shape,
+                                      cond_tol=cond_tol)
+        cond_s = min(cond_s, cs if cs is not None else np.inf)
+        W_b = 1.5 * (S[None] @ chi_s_b @ S[None])
+        collapse_s[l0:l1] = chi_s_b[:, :, :nd, :nd]
+        if l0 <= l_static < l1:
+            static_s[...] = chi_s_b[l_static - l0]
+        if output_full:
+            store.put_freq_batch("chi_s_w", l0, l1, chi_s_b)
+        del chi_s_b
+        chi_c_b, cc = _bc.dress_batch(cb, C, "charge", l0=l0, nmat=nmat, spatial_shape=spatial_shape,
+                                      cond_tol=cond_tol)
+        cond_c = min(cond_c, cc if cc is not None else np.inf)
+        W_b += 0.5 * (C[None] @ chi_c_b @ C[None])
+        collapse_c[l0:l1] = chi_c_b[:, :, :nd, :nd]
+        if l0 <= l_static < l1:
+            static_c[...] = chi_c_b[l_static - l0]
+        if output_full:
+            store.put_freq_batch("chi_c_w", l0, l1, chi_c_b)
+        del chi_c_b
+        W_b -= 0.25 * (SpC[None] @ cb @ SpC[None])
+        store.put_freq_batch("W", l0, l1, W_b)
+        del W_b
+    return DressResult(collapse0=collapse0, collapse_s=collapse_s, collapse_c=collapse_c,
+                       static_s=static_s, static_c=static_c,
+                       cond_min_s=float(cond_s), cond_min_c=float(cond_c))

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -88,10 +88,14 @@ def assemble_bubble(store, green_scf, green0_tail, beta, view, spatial_shape, wo
     """Fill ``store['chibar']`` pair by pair from ``bubble._iter_bond_dynamic``
     (spec 3.1). ``green_scf`` is the TAIL-SUBTRACTED single-block Green
     function the general bubble consumes; ``green0_tail`` its tail."""
+    from .hartree_fock import NonFiniteError
     for (alpha, beta_), block in _bubble._iter_bond_dynamic(
             green_scf, green0_tail, beta, view, spatial_shape=tuple(spatial_shape),
             workers=workers):
-        store.put_pair("chibar", alpha, beta_, _bk.to_host(block))
+        block = _bk.to_host(block)
+        if not np.all(np.isfinite(block)):
+            raise NonFiniteError("non-finite bond bubble block ({}, {})".format(alpha, beta_))
+        store.put_pair("chibar", alpha, beta_, block)
         del block
 
 

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -321,7 +321,7 @@ def estimate_bond_memory(*, nmat, nvol, norb, B, depth, output_full, split_seed,
     raises ``ValueError`` naming every row when even ``nb = 1`` exceeds
     the cap, or when ``freq_batch`` does."""
     nmat, nvol, norb, B = int(nmat), int(nvol), int(norb), int(B)
-    depth = int(depth) if mixing == "anderson" else 0
+    depth = max(1, int(depth)) if mixing == "anderson" else 0      # the mixer's effective depth
     it = 16
     P = norb * norb
     ND = B * P
@@ -337,6 +337,7 @@ def estimate_bond_memory(*, nmat, nvol, norb, B, depth, output_full, split_seed,
         "state": G + H,
         "seed_envelope": (2 * G + H) if split_seed else 0,
         "anderson_history": 2 * depth * 2 * G,
+        "anderson_work": 2 * max(depth - 1, 0) * 2 * G,       # the mixer's retained dR/dX stacks
         "collapses": 3 * C,
         "eigenpairs_hf": 5 * H,
         "flex_arrays": 5 * G,
@@ -350,12 +351,20 @@ def estimate_bond_memory(*, nmat, nvol, norb, B, depth, output_full, split_seed,
     def _phase_rows(nb):
         return {
             "green_mu": 6 * G + H,
-            "density_hf": 2 * H + 8 * H + 20 * H + H,
+            # the evaluator's G_ref and G - G_ref (2 G), the Heff eigenpairs and
+            # their workspace (4 H), rho_k/rho_r (2 H), rho_so/out (8 H), the
+            # kernel's spin-major temporaries (20 H), the owning Sigma_HF copy (H)
+            "density_hf": 2 * G + 4 * H + 2 * H + 8 * H + 20 * H + H,
             "bubble": max(prep, pair),
             "dressing": per_batch * nb,
             "transport": 4 * G + 4 * C,
-            "convergence": 6 * G + H,
-            "mixing": (2 * depth * 2 * G + 4 * G) if mixing == "anderson" else 2 * G,
+            # materialised new total, green_inv + inverse + workspace, the G
+            # difference, the two frequency-broadcast static stacks of the
+            # component residual (7 G), the new static pair (H)
+            "convergence": 7 * G + H,
+            # anderson: residual + output (the history and work stacks are
+            # persistent); linear: the difference, the scaled step, the new pair
+            "mixing": 4 * G if mixing == "anderson" else 3 * G + H,
             "post_scf": G + (U if output_full else C),
         }
 

--- a/src/hwave/solver/flex_bond.py
+++ b/src/hwave/solver/flex_bond.py
@@ -7,6 +7,7 @@ the output helpers.
 import numpy as np
 
 from . import backend as _bk
+from . import matsubara as _ms
 from . import bubble as _bubble
 
 
@@ -155,3 +156,66 @@ def dress_and_build_w(store, S, C, *, nb, output_full, nmat, nvol, nd, spatial_s
     return DressResult(collapse0=collapse0, collapse_s=collapse_s, collapse_c=collapse_c,
                        static_s=static_s, static_c=static_c,
                        cond_min_s=float(cond_s), cond_min_c=float(cond_c))
+
+
+# =============================================================================
+# Bond-aware self-energy transport (spec 3.4)
+# =============================================================================
+
+_TRANSPORT_COST_WARN = 1.0e11
+
+
+def calc_self_energy_bond(store, green_kw, beta, view, shape, norb, workers):
+    """Sigma_fluct(k, iw) from the bond-resolved effective interaction ``W``
+    in ``store`` (spec 3.4, normative equation with the momentum phases
+    e^{+ik.R_alpha} e^{-i(k-q).R_beta} realised as real-space rolls):
+
+        Sigma_ab(k) = T/N sum_{q,nu} sum_{alpha,beta,c,d}
+            e^{+ik.R_alpha} W_{(alpha,c,a),(beta,d,b)}(q) e^{-i(k-q).R_beta} G_cd(k-q)
+
+    ``green_kw`` is rank five `(1, nmat, nvol, norb, norb)`; the result has
+    the same shape.  With a single on-site channel this reproduces
+    `FLEX._calc_self_energy_general` byte for byte."""
+    nx, ny, nz = (int(x) for x in shape)
+    nvol = nx * ny * nz
+    nmat = green_kw.shape[1]
+    P = norb
+    nd = norb * norb
+    B = view.n_channels
+    cost = float(B * B) * nmat * nvol * (P ** 2 * np.log2(max(nmat * nvol, 2)) + P ** 3)
+    if cost > _TRANSPORT_COST_WARN:
+        logger.warning("bond self-energy transport cost estimate %.2e exceeds %.0e "
+                       "(B=%d, Nmat=%d, Nvol=%d, norb=%d); expect long iterations",
+                       cost, _TRANSPORT_COST_WARN, B, nmat, nvol, norb)
+    G_kw = green_kw[0]
+    G_rt = _bk.spatial_ifftn(
+        _ms.fermion_to_tau(G_kw.reshape(nmat, nvol * P * P), axis=0).reshape(nmat, nx, ny, nz, P * P),
+        axes=(1, 2, 3), workers=workers).reshape(nmat, nvol, P, P)
+    Sigma_rt = np.zeros((nmat, nvol, P, P), dtype=np.complex128)
+    axes = (1, 2, 3)
+    for alpha in range(B):
+        Ra = np.asarray(view.delta_r[alpha], dtype=int)
+        for bt in range(B):
+            Rb = np.asarray(view.delta_r[bt], dtype=int)
+            blk = np.ascontiguousarray(store.get_pair("W", alpha, bt))               # (nmat, nvol, nd, nd)
+            blk_qt = _ms.boson_to_tau(blk.reshape(nmat, nvol * nd * nd), axis=0)
+            del blk
+            Wab_rt = _bk.spatial_ifftn(blk_qt.reshape(nmat, nx, ny, nz, nd * nd),
+                                       axes=axes, workers=workers)
+            del blk_qt
+            Wab_rt = np.roll(Wab_rt, tuple(-Rb), axis=axes).reshape(nmat, nvol, P, P, P, P)
+            A = np.einsum('frcadb,frcd->frab', Wab_rt, G_rt)
+            del Wab_rt
+            A_rolled = np.roll(A.reshape(nmat, nx, ny, nz, P, P), tuple(Rb - Ra), axis=axes
+                               ).reshape(nmat, nvol, P, P)
+            del A
+            Sigma_rt += A_rolled
+            del A_rolled
+    del G_rt
+    tmp = _bk.spatial_fftn(Sigma_rt.reshape(nmat, nx, ny, nz, P * P), axes=axes, workers=workers)
+    del Sigma_rt
+    sigma = _ms.tau_to_fermion(tmp.reshape(nmat, nvol * P * P), axis=0)
+    del tmp
+    sigma = sigma.reshape(1, nmat, nvol, P, P)
+    sigma *= 1.0 / beta
+    return sigma

--- a/src/hwave/solver/flex_hf.py
+++ b/src/hwave/solver/flex_hf.py
@@ -65,3 +65,81 @@ def hf_map(rho_r, tables, shape, norb, *, block_tol=1e-12, herm_tol=1e-10):
             "hf_map: Sigma_HF(k) is not Hermitian (relative deviation {:.3e}); "
             "the density matrix violates rho_ab(r) = conj(rho_ba(-r))".format(err))
     return sigma
+
+
+# =============================================================================
+# Self-energy seeds (spec section 2.3)
+# =============================================================================
+
+from dataclasses import dataclass as _dataclass
+
+
+@_dataclass(frozen=True)
+class SigmaSeedEnvelope:
+    """An UNVALIDATED self-energy seed as loaded from a ``sigma.npz``:
+    every required member materialised and read-only, the convention
+    marker (``"split"``, ``"total"`` or ``None`` for a legacy file), the
+    IR metadata (``None`` for uniform files) and the file name for
+    diagnostics. Semantic validation happens in ``solve`` at refusal
+    precedence step 5 (:func:`validate_split_seed`)."""
+    sigma: np.ndarray
+    sigma_static: object
+    sigma_fluct: object
+    marker: object
+    ir_meta: object
+    file_name: str
+
+
+def _readonly(a):
+    a = np.array(a, dtype=np.complex128, copy=True)
+    a.flags.writeable = False
+    return a
+
+
+def make_seed_envelope(data, file_name, sigma, ir_meta):
+    """Build the envelope from an opened npz ``data`` (its ``sigma`` and
+    ``ir_meta`` already extracted by the caller)."""
+    marker = None
+    if "sigma_convention" in data.files:
+        marker = str(np.asarray(data["sigma_convention"]).ravel()[0])
+    st = _readonly(data["sigma_static"]) if "sigma_static" in data.files else None
+    fl = _readonly(data["sigma_fluct"]) if "sigma_fluct" in data.files else None
+    return SigmaSeedEnvelope(sigma=_readonly(sigma), sigma_static=st, sigma_fluct=fl,
+                             marker=marker, ir_meta=ir_meta, file_name=str(file_name))
+
+
+def validate_split_seed(env, expected_shape, *, sum_tol=1e-12, herm_tol=1e-10):
+    """Semantic validation of a ``"split"`` seed (spec 2.3): marker, exact
+    shapes, finiteness, singleton frequency axis of ``sigma_static``, the
+    sum identity, Hermiticity of ``sigma_static``. Returns the components
+    EXACTLY as stored (copies)."""
+    f = env.file_name
+    if env.marker != "split":
+        raise ValueError(
+            "sigma_init '{}': sigma_convention must be \"split\" for a run with "
+            "flex_hartree_fock=true (got {!r}); convert a total archive with "
+            "hwave_sigma_split".format(f, env.marker))
+    if env.sigma_static is None or env.sigma_fluct is None:
+        raise ValueError("sigma_init '{}': a split archive needs sigma_static and sigma_fluct".format(f))
+    expected = tuple(int(x) for x in expected_shape)
+    nb, nmat, nvol, n1, n2 = expected
+    if tuple(env.sigma.shape) != expected:
+        raise ValueError("sigma_init '{}': sigma shape {} != expected {}".format(f, env.sigma.shape, expected))
+    if tuple(env.sigma_fluct.shape) != expected:
+        raise ValueError("sigma_init '{}': sigma_fluct shape {} != expected {}".format(f, env.sigma_fluct.shape, expected))
+    if tuple(env.sigma_static.shape) != (nb, 1, nvol, n1, n2):
+        raise ValueError(
+            "sigma_init '{}': sigma_static shape {} != {} (it must be frequency independent, "
+            "singleton frequency axis)".format(f, env.sigma_static.shape, (nb, 1, nvol, n1, n2)))
+    for name, a in (("sigma", env.sigma), ("sigma_static", env.sigma_static), ("sigma_fluct", env.sigma_fluct)):
+        if not np.all(np.isfinite(a)):
+            raise ValueError("sigma_init '{}': {} has non-finite entries".format(f, name))
+    scale = max(1.0, float(np.max(np.abs(env.sigma))))
+    dev = float(np.max(np.abs(env.sigma - (env.sigma_static + env.sigma_fluct))))
+    if dev > sum_tol * scale:
+        raise ValueError(
+            "sigma_init '{}': sigma != sigma_static + sigma_fluct (max deviation {:.3e})".format(f, dev))
+    ok, err = _hf.is_hermitian_batch(env.sigma_static[:, 0], herm_tol)
+    if not ok:
+        raise ValueError("sigma_init '{}': sigma_static is not Hermitian (relative deviation {:.3e})".format(f, err))
+    return (np.array(env.sigma_static, copy=True), np.array(env.sigma_fluct, copy=True))

--- a/src/hwave/solver/flex_hf.py
+++ b/src/hwave/solver/flex_hf.py
@@ -143,3 +143,177 @@ def validate_split_seed(env, expected_shape, *, sum_tol=1e-12, herm_tol=1e-10):
     if not ok:
         raise ValueError("sigma_init '{}': sigma_static is not Hermitian (relative deviation {:.3e})".format(f, err))
     return (np.array(env.sigma_static, copy=True), np.array(env.sigma_fluct, copy=True))
+
+
+# =============================================================================
+# hwave_sigma_split converter (spec 2.3)
+# =============================================================================
+
+_SPLIT_FIELDS = ("sigma_convention", "sigma_static", "sigma_fluct")
+_STATIC_META = ("cell_shape", "momentum_convention", "wavevector_unit", "wavevector_index")
+
+
+def _spin_reduce(h, norb, label):
+    """(nvol, 2 norb, 2 norb) spin-major -> (nvol, norb, norb); refuses a
+    spin-mixing or unequal-block matrix (Phase B is spin-free)."""
+    nvol = h.shape[0]
+    h5 = h.reshape(nvol, 2, norb, 2, norb)
+    scale = max(1.0, float(np.max(np.abs(h5))))
+    off = max(float(np.max(np.abs(h5[:, 0, :, 1, :]))), float(np.max(np.abs(h5[:, 1, :, 0, :]))))
+    diff = float(np.max(np.abs(h5[:, 0, :, 0, :] - h5[:, 1, :, 1, :])))
+    if off > 1e-12 * scale or diff > 1e-12 * scale:
+        raise ValueError("{}: the spin-major matrix is spin-mixing ({:.3e}) or has unequal spin "
+                         "blocks ({:.3e}); a Phase B seed must be spin-free".format(label, off, diff))
+    return np.ascontiguousarray(h5[:, 0, :, 0, :])
+
+
+def _bare_transfer_k(transfer_file, cell_shape, norb):
+    """H0_bare(k) from a Transfer input (Wannier90-style text or the .npz
+    form) exactly as the k-space reader assembles it (e^{+ikR}, C-order
+    momentum layout), (nvol, norb, norb)."""
+    nx, ny, nz = (int(x) for x in cell_shape)
+    nvol = nx * ny * nz
+    if str(transfer_file).endswith(".npz"):
+        data = np.load(transfer_file)
+        if "Transfer" not in data:
+            raise ValueError("--bare-transfer {}: the archive carries no 'Transfer' member"
+                             .format(transfer_file))
+        tab_r = np.asarray(data["Transfer"], dtype=np.complex128)
+        if tab_r.shape not in ((nvol, norb, norb), (nx, ny, nz, norb, norb)):
+            raise ValueError("--bare-transfer {}: Transfer shape {} does not match cell {} and "
+                             "norb {}".format(transfer_file, tab_r.shape, list(cell_shape), norb))
+        tab_r = tab_r.reshape(nx, ny, nz, norb, norb)
+    else:
+        from hwave.qlmsio.wan90 import read_w90
+        table = read_w90(str(transfer_file))
+        tab_r = np.zeros((nx, ny, nz, norb, norb), dtype=np.complex128)
+        for (irvec, orbvec), v in table.items():
+            if orbvec[0] < norb and orbvec[1] < norb:
+                tab_r[(*irvec, *orbvec)] += v
+            else:
+                raise ValueError("--bare-transfer {}: orbital index {} exceeds norb {} of the "
+                                 "total archive (a spin-dependent Transfer file is not a bare "
+                                 "one-body transfer)".format(transfer_file, orbvec, norb))
+    return (np.fft.ifftn(tab_r, axes=(0, 1, 2)) * nvol).reshape(nvol, norb, norb)
+
+
+def _static_from_uhfk_trans_mod(trans_mod_file, transfer_file, cell_shape, norb):
+    """Delta H = H_mod(k) - H0_bare(k) from a native UHFk ``trans_mod``
+    archive (real-space, spin-major ``(nvol, 2 norb, 2 norb)``), with the
+    solver's own Fourier convention (``RPA._read_trans_mod``)."""
+    data = np.load(trans_mod_file)
+    if "trans_mod" not in data:
+        raise ValueError("--uhfk-trans-mod {}: no 'trans_mod' member".format(trans_mod_file))
+    tab_r = np.asarray(data["trans_mod"], dtype=np.complex128)
+    nx, ny, nz = (int(x) for x in cell_shape)
+    nvol = nx * ny * nz
+    nd = 2 * norb
+    if tab_r.shape != (nvol, nd, nd):
+        raise ValueError("--uhfk-trans-mod {}: trans_mod shape {} does not match (nvol, 2 norb, "
+                         "2 norb) = {} of the total archive (a sublattice run must be converted "
+                         "on its deflated cell)".format(trans_mod_file, tab_r.shape, (nvol, nd, nd)))
+    h_mod = (np.fft.ifftn(tab_r.reshape(nx, ny, nz, nd, nd), axes=(0, 1, 2)) * nvol
+             ).reshape(nvol, nd, nd)
+    h_mod = _spin_reduce(h_mod, norb, "--uhfk-trans-mod")
+    h0 = _bare_transfer_k(transfer_file, cell_shape, norb)
+    return (h_mod - h0)[None, None]
+
+
+def _static_from_file(static_file, total, norb, nvol, spin_major, log):
+    data = np.load(static_file)
+    if "sigma_static" in data:
+        st = np.asarray(data["sigma_static"])
+    elif "sigma" in data:
+        log.info("--static {}: no 'sigma_static' member; using 'sigma' as the static correction"
+                 .format(static_file))
+        st = np.asarray(data["sigma"])
+    else:
+        raise ValueError("--static {}: neither 'sigma_static' nor 'sigma' is present".format(static_file))
+    for key in _STATIC_META:
+        if key not in data or key not in total:
+            raise ValueError("--static {}: the mandatory metadata member '{}' must be present in "
+                             "both the static and the total archive".format(static_file, key))
+        a, b = data[key], total[key]
+        same = (str(a) == str(b)) if key == "momentum_convention" else (
+            np.asarray(a).shape == np.asarray(b).shape and np.array_equal(np.asarray(a), np.asarray(b)))
+        if not same:
+            raise ValueError("--static {}: metadata '{}' differs from the total archive ({!r} vs "
+                             "{!r})".format(static_file, key, a, b))
+    if spin_major:
+        if st.shape != (nvol, 2 * norb, 2 * norb):
+            raise ValueError("--static --uhfk-spin-major: expected shape {} , got {}".format(
+                (nvol, 2 * norb, 2 * norb), st.shape))
+        st = _spin_reduce(np.asarray(st, dtype=np.complex128), norb, "--static")[None, None]
+    elif st.ndim == 4:
+        if st.shape != (1, nvol, norb, norb):
+            raise ValueError("--static: rank-4 sigma_static must be (1, nvol, norb, norb) = {}, got {}"
+                             .format((1, nvol, norb, norb), st.shape))
+        st = st[:, None]
+    elif st.shape != (1, 1, nvol, norb, norb):
+        raise ValueError("--static: sigma_static must be (1, 1, nvol, norb, norb) = {} (or rank 4 "
+                         "without the frequency axis), got {}".format((1, 1, nvol, norb, norb), st.shape))
+    return np.array(st, dtype=np.complex128, copy=True)
+
+
+def sigma_split_convert(total_path, out_path, *, static_path=None, zero_static=False,
+                        uhfk_trans_mod=None, bare_transfer=None, uhfk_spin_major=False,
+                        force=False, logger=None):
+    """Write a ``"split"`` self-energy archive from a total-form one (spec
+    2.3). Exactly one static source: ``static_path`` (the static.npz
+    contract), ``zero_static`` or ``uhfk_trans_mod`` + ``bare_transfer``.
+    Returns a summary dict; raises ``ValueError`` / ``FileExistsError`` on
+    any refusal (nothing is written then)."""
+    import logging
+    import os
+    log = logger or logging.getLogger(__name__)
+    n_src = int(static_path is not None) + int(zero_static) + int(uhfk_trans_mod is not None)
+    if n_src != 1:
+        raise ValueError("exactly one static source is required (--static, --zero-static or "
+                         "--uhfk-trans-mod)")
+    if (uhfk_trans_mod is not None) != (bare_transfer is not None):
+        raise ValueError("--bare-transfer is required with --uhfk-trans-mod and accepted only with it")
+    if uhfk_spin_major and static_path is None:
+        raise ValueError("--uhfk-spin-major applies to --static only")
+    if os.path.exists(out_path) and not force:
+        raise FileExistsError("output '{}' exists; pass --force to overwrite".format(out_path))
+    total = np.load(total_path)
+    marker = str(total["sigma_convention"]) if "sigma_convention" in total else None
+    if marker not in (None, "total"):
+        raise ValueError("'{}' carries sigma_convention={!r}; only a total-form archive (no "
+                         "marker or \"total\") can be converted".format(total_path, marker))
+    if "sigma" not in total:
+        raise ValueError("'{}' has no 'sigma' member".format(total_path))
+    sigma = np.asarray(total["sigma"], dtype=np.complex128)
+    if sigma.ndim != 5 or sigma.shape[0] != 1 or sigma.shape[-1] != sigma.shape[-2]:
+        raise ValueError("'{}': sigma must be rank 5 (1, nmat, nvol, norb, norb), got {}".format(
+            total_path, sigma.shape))
+    _, nmat, nvol, norb, _ = sigma.shape
+    if "cell_shape" in total:
+        cs = tuple(int(x) for x in total["cell_shape"])
+        if int(np.prod(cs)) != nvol:
+            raise ValueError("'{}': cell_shape {} does not match nvol {}".format(total_path, cs, nvol))
+    if zero_static:
+        static = np.zeros((1, 1, nvol, norb, norb), dtype=np.complex128)
+    elif static_path is not None:
+        static = _static_from_file(static_path, total, norb, nvol, uhfk_spin_major, log)
+    else:
+        if "cell_shape" not in total:
+            raise ValueError("--uhfk-trans-mod needs the cell_shape member of the total archive")
+        static = _static_from_uhfk_trans_mod(uhfk_trans_mod, bare_transfer, total["cell_shape"], norb)
+    if not np.all(np.isfinite(static)):
+        raise ValueError("the static correction is not finite")
+    from hwave.solver.hartree_fock import is_hermitian_batch
+    ok, err = is_hermitian_batch(static[:, 0], 1e-10)
+    if not ok:
+        raise ValueError("the static correction is not Hermitian (relative deviation {:.3e})".format(err))
+    fluct = sigma - static
+    members = {k: total[k] for k in total.files if k not in _SPLIT_FIELDS and k != "sigma"}
+    members.update(sigma=sigma, sigma_convention=np.str_("split"), sigma_static=static,
+                   sigma_fluct=fluct)
+    np.savez(out_path, **members)
+    # validate what was written through the solver's own seed validation
+    data = np.load(out_path)
+    env = make_seed_envelope(data, out_path, data["sigma"], None)
+    validate_split_seed(env, sigma.shape)
+    return dict(out=out_path, nmat=nmat, nvol=nvol, norb=norb,
+                static_max=float(np.max(np.abs(static))), fluct_max=float(np.max(np.abs(fluct))))

--- a/src/hwave/solver/flex_hf.py
+++ b/src/hwave/solver/flex_hf.py
@@ -108,6 +108,27 @@ def make_seed_envelope(data, file_name, sigma, ir_meta):
                              marker=marker, ir_meta=ir_meta, file_name=str(file_name))
 
 
+def split_tail_diagnostic(fluct, nmat):
+    """D11 tail check of a split seed: on the outer 25 % of the positive
+    Matsubara window, the pair-even part ``e(n) = [s(n) + s(-n)]/2`` (zero for a
+    pure ``1/iw`` tail, constant for a frequency-independent remainder) is
+    compared with the pair-odd part ``o(n)``. Returns ``(r, e_max)`` with
+    ``r = max_n |e(n)| / max(max_n |o(n)|, 1e-300)``, or ``None`` when
+    ``nmat < 32`` (no window)."""
+    nmat = int(nmat)
+    if nmat < 32:
+        return None
+    f = np.asarray(fluct)
+    n_outer = max(nmat // 8, 1)
+    hi = np.arange(nmat - n_outer, nmat)
+    lo = nmat - 1 - hi
+    e = 0.5 * (f[:, hi] + f[:, lo])
+    o = 0.5 * (f[:, hi] - f[:, lo])
+    e_max = float(np.max(np.abs(e))) if e.size else 0.0
+    o_max = float(np.max(np.abs(o))) if o.size else 0.0
+    return e_max / max(o_max, 1e-300), e_max
+
+
 def validate_split_seed(env, expected_shape, *, sum_tol=1e-12, herm_tol=1e-10):
     """Semantic validation of a ``"split"`` seed (spec 2.3): marker, exact
     shapes, finiteness, singleton frequency axis of ``sigma_static``, the
@@ -274,6 +295,9 @@ def sigma_split_convert(total_path, out_path, *, static_path=None, zero_static=F
         raise ValueError("--bare-transfer is required with --uhfk-trans-mod and accepted only with it")
     if uhfk_spin_major and static_path is None:
         raise ValueError("--uhfk-spin-major applies to --static only")
+    out_path = str(out_path)
+    if not out_path.endswith(".npz"):
+        out_path += ".npz"          # numpy.savez appends it; check and report the real name
     if os.path.exists(out_path) and not force:
         raise FileExistsError("output '{}' exists; pass --force to overwrite".format(out_path))
     total = np.load(total_path)
@@ -287,6 +311,8 @@ def sigma_split_convert(total_path, out_path, *, static_path=None, zero_static=F
     if sigma.ndim != 5 or sigma.shape[0] != 1 or sigma.shape[-1] != sigma.shape[-2]:
         raise ValueError("'{}': sigma must be rank 5 (1, nmat, nvol, norb, norb), got {}".format(
             total_path, sigma.shape))
+    if not np.all(np.isfinite(sigma)):
+        raise ValueError("'{}': sigma is not finite".format(total_path))
     _, nmat, nvol, norb, _ = sigma.shape
     if "cell_shape" in total:
         cs = tuple(int(x) for x in total["cell_shape"])
@@ -307,13 +333,19 @@ def sigma_split_convert(total_path, out_path, *, static_path=None, zero_static=F
     if not ok:
         raise ValueError("the static correction is not Hermitian (relative deviation {:.3e})".format(err))
     fluct = sigma - static
+    if not np.all(np.isfinite(fluct)):
+        raise ValueError("the fluctuation part sigma - sigma_static is not finite")
+    # the solver's own seed validation, IN MEMORY, before anything is written
+    env = SigmaSeedEnvelope(sigma=_readonly(sigma), sigma_static=_readonly(static),
+                            sigma_fluct=_readonly(fluct), marker="split", ir_meta=None,
+                            file_name=out_path)
+    validate_split_seed(env, sigma.shape)
     members = {k: total[k] for k in total.files if k not in _SPLIT_FIELDS and k != "sigma"}
     members.update(sigma=sigma, sigma_convention=np.str_("split"), sigma_static=static,
                    sigma_fluct=fluct)
     np.savez(out_path, **members)
-    # validate what was written through the solver's own seed validation
+    # read-back check of the written archive
     data = np.load(out_path)
-    env = make_seed_envelope(data, out_path, data["sigma"], None)
-    validate_split_seed(env, sigma.shape)
+    validate_split_seed(make_seed_envelope(data, out_path, data["sigma"], None), sigma.shape)
     return dict(out=out_path, nmat=nmat, nvol=nvol, norb=norb,
                 static_max=float(np.max(np.abs(static))), fluct_max=float(np.max(np.abs(fluct))))

--- a/src/hwave/solver/flex_hf.py
+++ b/src/hwave/solver/flex_hf.py
@@ -1,0 +1,67 @@
+"""FLEX-side Hartree-Fock adapter (GitHub issue #181, Tier 3 Phase B; spec
+docs/superpowers/specs/2026-09-06-flex-bond-sigma-phase-b-181-design.md,
+section 2.2).
+
+The spin-free FLEX density ``rho_ab(r)`` (one spin block, per spin) is
+embedded paramagnetically into UHFk's spin-major layout and passed through
+the shared kernel (:mod:`hwave.solver.hartree_fock`); the up block of the
+result is the static Hartree-Fock self-energy ``Sigma_HF(k)``. Every
+accepted interaction entry reaches the kernel (the table builder's
+``discarded`` report is turned into a refusal here); a contraction may be
+symmetry-zero (PairLift, D12).
+"""
+import numpy as np
+
+from . import hartree_fock as _hf
+
+
+def build_flex_hf_tables(param_ham, norb, shape):
+    """The shared interaction tables for the FLEX HF map. Refuses
+    (``ValueError``) when the per-type semantics would drop a declared
+    entry, naming the first one, so that D4's "every accepted term" holds."""
+    tabs = _hf.build_interaction_tables(param_ham, norb, shape)
+    if tabs.discarded:
+        t, irvec, orbvec, v = tabs.discarded[0]
+        raise ValueError(
+            "flex_hartree_fock: the '{}' entry at irvec={}, orbvec={} (value "
+            "{!r}) has no Hartree-Fock representation in this solver ({} "
+            "entries must be on-site and orbital-diagonal) and would be "
+            "silently dropped; remove or correct the declaration ({} "
+            "such entries).".format(t, irvec, orbvec, v, t, len(tabs.discarded)))
+    return tabs
+
+
+def hf_map(rho_r, tables, shape, norb, *, block_tol=1e-12, herm_tol=1e-10):
+    """``Sigma_HF(k)`` `(nvol, norb, norb)` from the per-spin real-space
+    density ``rho_r`` `(nvol, norb, norb)` (spec 2.2): paramagnetic
+    embedding ``rho_so[:, s, a, t, b] = delta_st rho_ab``, the kernel with
+    the Fock term, then the spin-block checks (up == down, spin-off-
+    diagonal zero, both to ``block_tol`` relative -- a violation is a bug
+    and is refused) and the k-space Hermiticity check (``herm_tol``).
+    Returns an OWNING copy."""
+    rho_r = np.asarray(rho_r)
+    nvol = rho_r.shape[0]
+    rho_so = np.zeros((nvol, 2, norb, 2, norb), dtype=np.complex128)
+    rho_so[:, 0, :, 0, :] = rho_r
+    rho_so[:, 1, :, 1, :] = rho_r
+    out = np.zeros((nvol, 2 * norb, 2 * norb), dtype=np.complex128)
+    _hf.accumulate_hf(out, rho_so, tables.inter_table, tables.spin_table,
+                      tuple(shape), include_fock=True)
+    if not np.all(np.isfinite(out)):
+        raise _hf.NonFiniteError("hf_map: non-finite Hartree-Fock term")
+    o = out.reshape(nvol, 2, norb, 2, norb)
+    scale = max(1.0, float(np.max(np.abs(o))))
+    d_blocks = float(np.max(np.abs(o[:, 0, :, 0, :] - o[:, 1, :, 1, :])))
+    d_off = float(max(np.max(np.abs(o[:, 0, :, 1, :])), np.max(np.abs(o[:, 1, :, 0, :]))))
+    if d_blocks > block_tol * scale or d_off > block_tol * scale:
+        raise ValueError(
+            "hf_map: the paramagnetic embedding produced unequal spin blocks "
+            "({:.3e}) or a spin-off-diagonal term ({:.3e}); this is a "
+            "kernel/embedding defect, not a physical signal".format(d_blocks, d_off))
+    sigma = np.array(o[:, 0, :, 0, :], copy=True)
+    ok, err = _hf.is_hermitian_batch(sigma, herm_tol)
+    if not ok:
+        raise ValueError(
+            "hf_map: Sigma_HF(k) is not Hermitian (relative deviation {:.3e}); "
+            "the density matrix violates rho_ab(r) = conj(rho_ba(-r))".format(err))
+    return sigma

--- a/src/hwave/solver/flex_hf.py
+++ b/src/hwave/solver/flex_hf.py
@@ -300,7 +300,8 @@ def sigma_split_convert(total_path, out_path, *, static_path=None, zero_static=F
         out_path += ".npz"          # numpy.savez appends it; check and report the real name
     if os.path.exists(out_path) and not force:
         raise FileExistsError("output '{}' exists; pass --force to overwrite".format(out_path))
-    total = np.load(total_path)
+    with np.load(total_path) as total_npz:
+        total = {k: total_npz[k] for k in total_npz.files}       # materialised; handle closed
     marker = str(total["sigma_convention"]) if "sigma_convention" in total else None
     if marker not in (None, "total"):
         raise ValueError("'{}' carries sigma_convention={!r}; only a total-form archive (no "
@@ -340,12 +341,12 @@ def sigma_split_convert(total_path, out_path, *, static_path=None, zero_static=F
                             sigma_fluct=_readonly(fluct), marker="split", ir_meta=None,
                             file_name=out_path)
     validate_split_seed(env, sigma.shape)
-    members = {k: total[k] for k in total.files if k not in _SPLIT_FIELDS and k != "sigma"}
+    members = {k: v for k, v in total.items() if k not in _SPLIT_FIELDS and k != "sigma"}
     members.update(sigma=sigma, sigma_convention=np.str_("split"), sigma_static=static,
                    sigma_fluct=fluct)
     np.savez(out_path, **members)
     # read-back check of the written archive
-    data = np.load(out_path)
-    validate_split_seed(make_seed_envelope(data, out_path, data["sigma"], None), sigma.shape)
+    with np.load(out_path) as data:
+        validate_split_seed(make_seed_envelope(data, out_path, data["sigma"], None), sigma.shape)
     return dict(out=out_path, nmat=nmat, nvol=nvol, norb=norb,
                 static_max=float(np.max(np.abs(static))), fluct_max=float(np.max(np.abs(fluct))))

--- a/src/hwave/solver/flex_mixing.py
+++ b/src/hwave/solver/flex_mixing.py
@@ -112,8 +112,11 @@ class StackedAndersonMixer:
 def residuals(state, new, G_state, G_new, eps_den=1e-300):
     """``(res_sigma, res_G, res_component)`` of spec 5.6, all before mixing."""
     tot, tot_new = state.total(), new.total()
-    res_sigma = float(np.linalg.norm((tot_new - tot).ravel())
-                      / max(float(np.linalg.norm(tot.ravel())), eps_den))
+    # res_sigma: exactly FLEX._calc_convergence (diff / ||sigma_new||, the
+    # bare difference when ||sigma_new|| < 1e-30)
+    diff = float(np.linalg.norm((tot_new - tot).ravel()))
+    norm_new = float(np.linalg.norm(tot_new.ravel()))
+    res_sigma = diff if norm_new < 1.0e-30 else diff / norm_new
     res_G = float(np.linalg.norm((np.asarray(G_new) - np.asarray(G_state)).ravel())
                   / max(float(np.linalg.norm(np.asarray(G_state).ravel())), eps_den))
     nmat = state.nmat

--- a/src/hwave/solver/flex_mixing.py
+++ b/src/hwave/solver/flex_mixing.py
@@ -1,0 +1,142 @@
+"""The provenance-split self-energy state of the Phase B FLEX loop and its
+mixing (GitHub issue #181; spec 2026-09-06 sections 2.4 and 5.6).
+
+``sigma = sigma_static + sigma_fluct``: the Hartree-Fock map and the
+static mean-field seed are ``static`` (frequency independent, a singleton
+frequency axis), the W map is ``fluct``. Both components are mixed with
+the SAME affine coefficients: linear mixing component-wise, and a stacked
+Anderson mixer whose least-squares system uses REAL coefficients (the
+Gram matrix and right-hand side are the real parts of the complex inner
+products), so a real affine combination of Hermitian static matrices
+stays Hermitian. The legacy ``flex._AndersonMixer`` (total sigma, HF off)
+is untouched.
+"""
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SplitState:
+    """``static`` `(nb, 1, nvol, n, n)`, ``fluct`` `(nb, nmat, nvol, n, n)`."""
+    static: np.ndarray
+    fluct: np.ndarray
+
+    def total(self):
+        return self.static + self.fluct           # broadcast over frequency
+
+    @property
+    def nmat(self):
+        return int(self.fluct.shape[1])
+
+
+def linear_mix_pair(state, new, mix):
+    """``(1 - mix) state + mix new`` on both components."""
+    return SplitState(static=(1.0 - mix) * state.static + mix * new.static,
+                      fluct=(1.0 - mix) * state.fluct + mix * new.fluct)
+
+
+class StackedAndersonMixer:
+    """Anderson acceleration on the stacked vector
+    ``[broadcast(static); fluct]`` with real coefficients (spec 2.4).
+
+    Same update, Tikhonov guard, fallback-to-linear and history restart
+    as ``flex._AndersonMixer``; the ``dR``/``dX`` stacks are two
+    preallocated ``(depth - 1, N)`` arrays filled in place (spec 3.6).
+    """
+
+    def __init__(self, mix, depth):
+        self.mix = float(mix)
+        self.depth = max(1, int(depth))
+        self._xs = []
+        self._rs = []
+        self._dR = None
+        self._dX = None
+        self.last_gamma = None
+
+    def stack(self, state):
+        nmat = state.nmat
+        return np.concatenate([np.repeat(state.static, nmat, axis=1).reshape(-1),
+                               state.fluct.reshape(-1)])
+
+    def _unstack(self, vec, like):
+        n_static_b = like.static.size * like.nmat
+        st = vec[:n_static_b].reshape(like.fluct.shape)[:, :1]
+        fl = vec[n_static_b:].reshape(like.fluct.shape)
+        return SplitState(static=np.ascontiguousarray(st), fluct=np.ascontiguousarray(fl))
+
+    def _reset(self):
+        self._xs = []
+        self._rs = []
+
+    def step(self, state, new):
+        x = self.stack(state)
+        r = self.stack(new) - x
+        self._xs.append(x)
+        self._rs.append(r)
+        if len(self._xs) > self.depth:
+            self._xs.pop(0)
+            self._rs.pop(0)
+        m = len(self._xs)
+        self.last_gamma = None
+        if m == 1:
+            return self._unstack(x + self.mix * r, state)
+        N = x.size
+        if self._dR is None or self._dR.shape != (self.depth - 1, N):
+            self._dR = np.empty((self.depth - 1, N), dtype=np.complex128)
+            self._dX = np.empty((self.depth - 1, N), dtype=np.complex128)
+        dR = self._dR[:m - 1]
+        dX = self._dX[:m - 1]
+        for i in range(m - 1):
+            np.subtract(self._rs[i + 1], self._rs[i], out=dR[i])
+            np.subtract(self._xs[i + 1], self._xs[i], out=dX[i])
+        G = (dR.conj() @ dR.T).real
+        b = (dR.conj() @ r).real
+        lam = 1.0e-10 * max(float(np.trace(G)) / (m - 1), 1.0e-300)
+        try:
+            gamma = np.linalg.solve(G + lam * np.eye(m - 1), b)
+        except np.linalg.LinAlgError:
+            gamma = None
+        if gamma is not None:
+            x_next = x + self.mix * r - (dX + self.mix * dR).T @ gamma
+            if np.all(np.isfinite(x_next)):
+                self.last_gamma = gamma
+                return self._unstack(x_next, state)
+        # singular / non-finite history: plain linear step and restart
+        self._reset()
+        self._xs.append(x)
+        self._rs.append(r)
+        return self._unstack(x + self.mix * r, state)
+
+
+def residuals(state, new, G_state, G_new, eps_den=1e-300):
+    """``(res_sigma, res_G, res_component)`` of spec 5.6, all before mixing."""
+    tot, tot_new = state.total(), new.total()
+    res_sigma = float(np.linalg.norm((tot_new - tot).ravel())
+                      / max(float(np.linalg.norm(tot.ravel())), eps_den))
+    res_G = float(np.linalg.norm((np.asarray(G_new) - np.asarray(G_state)).ravel())
+                  / max(float(np.linalg.norm(np.asarray(G_state).ravel())), eps_den))
+    nmat = state.nmat
+    d_static = np.repeat(new.static - state.static, nmat, axis=1).ravel()
+    d_fluct = (new.fluct - state.fluct).ravel()
+    n_static = np.repeat(new.static, nmat, axis=1).ravel()
+    num = np.sqrt(float(np.vdot(d_static, d_static).real + np.vdot(d_fluct, d_fluct).real))
+    den = np.sqrt(float(np.vdot(n_static, n_static).real + np.vdot(new.fluct.ravel(), new.fluct.ravel()).real))
+    res_component = num / max(den, eps_den)
+    return res_sigma, res_G, res_component
+
+
+class PassCounter:
+    """Three consecutive iterations with every residual below ``eps``."""
+
+    def __init__(self, eps, needed=3):
+        self.eps = float(eps)
+        self.needed = int(needed)
+        self.count = 0
+
+    def update(self, res_sigma, res_G, res_component):
+        if res_sigma < self.eps and res_G < self.eps and res_component < self.eps:
+            self.count += 1
+        else:
+            self.count = 0
+        return (self.count >= self.needed), self.count

--- a/src/hwave/solver/hartree_fock.py
+++ b/src/hwave/solver/hartree_fock.py
@@ -188,7 +188,7 @@ def build_interaction_tables(param_ham, norb, shape):
 
 
 def accumulate_hf(out, rho_so_r, inter_table, spin_table, shape, *,
-                  include_fock):
+                  include_fock, debug=None):
     """Add the Hartree (+ Fock) mean-field terms of every type onto ``out``
     IN PLACE (UHFk's ``_make_ham`` interaction loop, normal mode, verbatim
     expressions and order). ``rho_so_r`` is the real-space equal-time
@@ -205,6 +205,8 @@ def accumulate_hf(out, rho_so_r, inter_table, spin_table, shape, *,
     ham = out
     for type in ['CoulombIntra', 'CoulombInter', 'Hund', 'Ising', 'PairLift', 'Exchange']:
         if inter_table[type] is not None:
+            if debug is not None:
+                debug(type)
             jab_r = inter_table[type].reshape(nvol, norb_inter, norb_inter)
             spin = spin_table[type]
             hh0 = np.einsum('uvb, suvt -> stb', gbb, spin)
@@ -219,6 +221,8 @@ def accumulate_hf(out, rho_so_r, inter_table, spin_table, shape, *,
                 ham -= hh5.reshape(nvol, nd, nd)
     for type in ['PairHop']:
         if inter_table[type] is not None:
+            if debug is not None:
+                debug(type)
             jab_r = inter_table[type].reshape(nvol, norb_inter, norb_inter)
             spin = spin_table[type]
             if include_fock:

--- a/src/hwave/solver/hartree_fock.py
+++ b/src/hwave/solver/hartree_fock.py
@@ -1,0 +1,234 @@
+"""The Hartree-Fock (mean-field) kernel shared by UHFk and FLEX
+(GitHub issue #181, Tier 3 Phase B; spec
+docs/superpowers/specs/2026-09-06-flex-bond-sigma-phase-b-181-design.md,
+section 2.2).
+
+Two pure functions carry the interaction part of ``UHFk._make_ham_inter``
+and ``UHFk._make_ham`` (NORMAL spin-major mode; UHFk's ``enable_spin_orbital``
+branch is not shared in this version):
+
+* :func:`build_interaction_tables` -- the raw pre-fold interaction dict ->
+  per-type reversal-symmetrised real-space coefficient tables and the
+  ``(2, 2, 2, 2)`` spin tables, plus a ``discarded`` report of every entry
+  the per-type semantics drop (UHFk ignores it, FLEX refuses on it);
+* :func:`accumulate_hf` -- the Hartree (+ Fock) contributions of every
+  type added IN PLACE, in the original order and with the original
+  expressions, onto the caller's ``(nvol, 2*norb, 2*norb)`` accumulator
+  (UHFk starts it from the transfer Hamiltonian, FLEX from zero), so
+  UHFk's per-iteration Hamiltonian is bit-identical to the pre-refactor
+  code (tests/test_hartree_fock_kernel.py carries that code verbatim).
+
+The FLEX-side density evaluator of the same spec lives here too
+(:func:`equal_time_density`, section 2.1).
+"""
+from collections import namedtuple
+from dataclasses import dataclass
+
+import numpy as np
+
+from .kgrid import reverse_fft_axes
+from ..qlmsio import wan90
+
+InteractionTables = namedtuple("InteractionTables",
+                               ["inter_table", "spin_table", "discarded"])
+
+# The fixed type order of UHFk's interaction loop (accumulate_hf) and of
+# the discarded report.
+HF_TYPE_ORDER = ("CoulombIntra", "CoulombInter", "Hund", "Ising",
+                 "PairLift", "Exchange", "PairHop")
+
+
+class NonFiniteError(FloatingPointError):
+    """A numerical checkpoint found a non-finite value (spec section 6)."""
+
+
+def is_hermitian_batch(a, rel=1e-10):
+    """``(ok, err)`` for a batch ``(..., n, n)``: ``err = max|a - a^dag|``
+    relative to ``max(1, max|a|)``; ``ok`` iff ``err <= rel``."""
+    a = np.asarray(a)
+    err = float(np.max(np.abs(a - np.conj(np.swapaxes(a, -1, -2)))))
+    scale = max(1.0, float(np.max(np.abs(a)))) if a.size else 1.0
+    err = err / scale
+    return (err <= rel), err
+
+
+def _reverse_closed(tab_r):
+    """``(V + V_ba(-r)^*) / 2`` -- UHFk's reversal/Hermitian symmetrisation."""
+    tba = np.conjugate(
+        np.transpose(
+            reverse_fft_axes(tab_r, (0, 1, 2)),
+            (0, 1, 2, 4, 3)
+        )
+    )
+    return (tab_r + tba) / 2
+
+
+def build_interaction_tables(param_ham, norb, shape):
+    """UHFk's ``_make_ham_inter`` (normal mode) as a pure function.
+
+    Returns :class:`InteractionTables`; ``inter_table[type]`` is ``None``
+    for an absent type. The ambiguous aggregate ``Coulomb`` +
+    ``CoulombIntra``/``CoulombInter`` case raises ``ValueError`` (UHFk's
+    wrapper turns it into its legacy ``logger.error`` + ``SystemExit``).
+    ``discarded`` lists, in :data:`HF_TYPE_ORDER` and insertion order,
+    every declared entry the per-type semantics drop -- today the
+    ``CoulombIntra`` entries that are not ``r = 0, a == b``.
+    """
+    nx, ny, nz = shape
+    inter_table = {}
+    spin_table = {}
+    discarded = []
+
+    def _zeros():
+        return np.zeros((nx, ny, nz, norb, norb), dtype=np.complex128)
+
+    if 'Coulomb' in param_ham.keys():
+        if ('CoulombIntra' in param_ham.keys()
+                or 'CoulombInter' in param_ham.keys()):
+            raise ValueError(
+                "Coulomb cannot be specified together with "
+                "CoulombIntra or CoulombInter")
+        coulomb_intra, coulomb_inter = wan90.split_coulomb(
+            param_ham["Coulomb"])
+        uab_r = _zeros()
+        vab_r = _zeros()
+        for (irvec, orbvec), v in coulomb_intra.items():
+            uab_r[(*irvec, *orbvec)] += v
+        for (irvec, orbvec), v in coulomb_inter.items():
+            vab_r[(*irvec, *orbvec)] += v
+        inter_table["CoulombIntra"] = uab_r  # r=0 component
+        spin_table["CoulombIntra"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["CoulombIntra"][0, 1, 1, 0] = 1
+        spin_table["CoulombIntra"][1, 0, 0, 1] = 1
+        inter_table["CoulombInter"] = _reverse_closed(vab_r)
+        spin_table["CoulombInter"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["CoulombInter"][0, 0, 0, 0] = 1
+        spin_table["CoulombInter"][1, 1, 1, 1] = 1
+        spin_table["CoulombInter"][0, 1, 1, 0] = 1
+        spin_table["CoulombInter"][1, 0, 0, 1] = 1
+    else:
+        inter_table["CoulombIntra"] = None
+        inter_table["CoulombInter"] = None
+        if 'CoulombIntra' in param_ham.keys():
+            uab_r = _zeros()
+            for (irvec, orbvec), v in param_ham["CoulombIntra"].items():
+                alpha, beta = orbvec
+                if irvec == (0, 0, 0) and alpha == beta:
+                    uab_r[(*irvec, *orbvec)] += v
+                else:
+                    discarded.append(("CoulombIntra", tuple(irvec),
+                                      tuple(orbvec), v))
+            inter_table["CoulombIntra"] = uab_r
+            spin_table["CoulombIntra"] = np.zeros((2, 2, 2, 2), dtype=int)
+            spin_table["CoulombIntra"][0, 1, 1, 0] = 1
+            spin_table["CoulombIntra"][1, 0, 0, 1] = 1
+        if 'CoulombInter' in param_ham.keys():
+            vab_r = _zeros()
+            for (irvec, orbvec), v in param_ham["CoulombInter"].items():
+                vab_r[(*irvec, *orbvec)] += v
+            inter_table["CoulombInter"] = _reverse_closed(vab_r)
+            spin_table["CoulombInter"] = np.zeros((2, 2, 2, 2), dtype=int)
+            spin_table["CoulombInter"][0, 0, 0, 0] = 1
+            spin_table["CoulombInter"][1, 1, 1, 1] = 1
+            spin_table["CoulombInter"][0, 1, 1, 0] = 1
+            spin_table["CoulombInter"][1, 0, 0, 1] = 1
+    if 'Hund' in param_ham.keys():
+        jab_r = _zeros()
+        for (irvec, orbvec), v in param_ham["Hund"].items():
+            jab_r[(*irvec, *orbvec)] += v
+        inter_table["Hund"] = -_reverse_closed(jab_r)
+        spin_table["Hund"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["Hund"][0, 0, 0, 0] = 1
+        spin_table["Hund"][1, 1, 1, 1] = 1
+    else:
+        inter_table["Hund"] = None
+    if 'Ising' in param_ham.keys():
+        jab_r = _zeros()
+        for (irvec, orbvec), v in param_ham["Ising"].items():
+            jab_r[(*irvec, *orbvec)] += v
+        inter_table["Ising"] = _reverse_closed(jab_r)
+        spin_table["Ising"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["Ising"][0, 0, 0, 0] = 1
+        spin_table["Ising"][1, 1, 1, 1] = 1
+        spin_table["Ising"][0, 1, 1, 0] = -1
+        spin_table["Ising"][1, 0, 0, 1] = -1
+    else:
+        inter_table["Ising"] = None
+    if 'PairLift' in param_ham.keys():
+        jab_r = _zeros()
+        for (irvec, orbvec), v in param_ham["PairLift"].items():
+            jab_r[(*irvec, *orbvec)] += v
+        inter_table["PairLift"] = _reverse_closed(jab_r)
+        spin_table["PairLift"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["PairLift"][0, 0, 1, 1] = 1
+        spin_table["PairLift"][1, 1, 0, 0] = 1
+    else:
+        inter_table["PairLift"] = None
+    if 'Exchange' in param_ham.keys():
+        jab_r = _zeros()
+        for (irvec, orbvec), v in param_ham["Exchange"].items():
+            jab_r[(*irvec, *orbvec)] += v
+        inter_table["Exchange"] = -_reverse_closed(jab_r)
+        spin_table["Exchange"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["Exchange"][0, 1, 0, 1] = 1
+        spin_table["Exchange"][1, 0, 1, 0] = 1
+    else:
+        inter_table["Exchange"] = None
+    if 'PairHop' in param_ham.keys():
+        jab_r = _zeros()
+        for (irvec, orbvec), v in param_ham["PairHop"].items():
+            jab_r[(*irvec, *orbvec)] += v
+        inter_table["PairHop"] = _reverse_closed(jab_r)
+        spin_table["PairHop"] = np.zeros((2, 2, 2, 2), dtype=int)
+        spin_table["PairHop"][0, 1, 1, 0] = 1
+        spin_table["PairHop"][1, 0, 0, 1] = 1
+    else:
+        inter_table["PairHop"] = None
+    return InteractionTables(inter_table, spin_table, tuple(discarded))
+
+
+def accumulate_hf(out, rho_so_r, inter_table, spin_table, shape, *,
+                  include_fock):
+    """Add the Hartree (+ Fock) mean-field terms of every type onto ``out``
+    IN PLACE (UHFk's ``_make_ham`` interaction loop, normal mode, verbatim
+    expressions and order). ``rho_so_r`` is the real-space equal-time
+    density ``(nvol, 2, norb, 2, norb)``, ``rho[r, s, a, t, b] =
+    <c^dag_{s a}(0) c_{t b}(r)>`` (UHFk's ``Green``); ``out`` is
+    ``(nvol, 2*norb, 2*norb)`` complex128. Returns ``out``."""
+    nx, ny, nz = shape
+    nvol = int(nx * ny * nz)
+    gab_r = rho_so_r
+    norb_inter = gab_r.shape[2]
+    nd = 2 * norb_inter
+    nd_virt = nd
+    gbb = np.diagonal(gab_r, axis1=2, axis2=4)[0, :, :, :]
+    ham = out
+    for type in ['CoulombIntra', 'CoulombInter', 'Hund', 'Ising', 'PairLift', 'Exchange']:
+        if inter_table[type] is not None:
+            jab_r = inter_table[type].reshape(nvol, norb_inter, norb_inter)
+            spin = spin_table[type]
+            hh0 = np.einsum('uvb, suvt -> stb', gbb, spin)
+            hh1 = np.einsum('rab, stb -> rsta', jab_r, hh0)
+            hh2 = np.einsum('rsta, ab -> rsatb', hh1, np.eye(norb_inter, norb_inter))
+            hh3 = np.sum(hh2, axis=0)  # shape: (2, norb_inter, 2, norb_inter)
+            hh3_nd = np.broadcast_to(hh3.reshape(nd, nd), (nvol, nd, nd))
+            ham += hh3_nd
+            if include_fock:
+                hh4 = np.einsum('rab, rubva, sutv -> rsatb', jab_r, gab_r, spin, optimize=True)
+                hh5 = np.fft.ifftn(hh4.reshape(nx, ny, nz, nd_virt, nd_virt), axes=(0, 1, 2), norm='forward')
+                ham -= hh5.reshape(nvol, nd, nd)
+    for type in ['PairHop']:
+        if inter_table[type] is not None:
+            jab_r = inter_table[type].reshape(nvol, norb_inter, norb_inter)
+            spin = spin_table[type]
+            if include_fock:
+                hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
+                hh2 = np.einsum('rvbua, sutv -> rsbta', np.conjugate(gab_r), spin)
+                hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, (hh1 - hh2))
+                hh4 = np.fft.ifftn(hh3.reshape(nx, ny, nz, nd_virt, nd_virt), axes=(0, 1, 2), norm='forward')
+            else:
+                hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
+                hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, hh1)
+                hh4 = np.fft.ifftn(hh3.reshape(nx, ny, nz, nd_virt, nd_virt), axes=(0, 1, 2), norm='forward')
+            ham += hh4.reshape(nvol, nd, nd)
+    return out

--- a/src/hwave/solver/hartree_fock.py
+++ b/src/hwave/solver/hartree_fock.py
@@ -232,3 +232,107 @@ def accumulate_hf(out, rho_so_r, inter_table, spin_table, shape, *,
                 hh4 = np.fft.ifftn(hh3.reshape(nx, ny, nz, nd_virt, nd_virt), axes=(0, 1, 2), norm='forward')
             ham += hh4.reshape(nvol, nd, nd)
     return out
+
+
+# =============================================================================
+# The Heff-referenced equal-time density (spec section 2.1)
+# =============================================================================
+
+def masked_fermi(t, mu, ev, ene_cutoff=1.0e2):
+    """Fermi function with the overflow guard of ``RPA._find_mu`` /
+    ``FLEX._fermi_occupation`` (same arithmetic)."""
+    w = (ev - mu) / t
+    mask = w < ene_cutoff
+    w1 = np.where(mask, w, 0.0)
+    v1 = 1.0 / (1.0 + np.exp(w1))
+    return np.where(mask, v1, 0.0)
+
+
+@dataclass(frozen=True)
+class DensityResult:
+    """The projected (exactly Hermitian) real-space equal-time density
+    ``rho_r[r, a, b] = <c^dag_a(0) c_b(r)>`` (per spin, per cell), its
+    reciprocal-space form reconstructed from the projected ``rho_r``, and
+    the per-spin particle number ``n_per_spin = Nvol * Re Tr rho_r(0)``.
+    Arrays are private, non-aliased and read-only."""
+    rho_k: np.ndarray
+    rho_r: np.ndarray
+    n_per_spin: float
+
+
+def heff_eigenpairs(H0_k, sigma_static, rel=1e-10):
+    """Eigenpairs of ``Heff(k) = H0(k) + sigma_static(k)``, ``(e (nvol, n),
+    U (nvol, n, n))`` with ``Heff = U diag(e) U^dag``; refused
+    (``ValueError``) unless ``Heff`` is Hermitian to ``rel``."""
+    heff = np.asarray(H0_k) + np.asarray(sigma_static)
+    ok, err = is_hermitian_batch(heff, rel)
+    if not ok:
+        raise ValueError(
+            "H0 + sigma_static is not Hermitian (relative deviation {:.3e} "
+            "> {:.1e}); the static self-energy or the seed is corrupt"
+            .format(err, rel))
+    e, U = np.linalg.eigh(heff)
+    return e, U
+
+
+def equal_time_density(green_kw, heff_eig, mu, beta, shape, *, sym_tol=1e-8):
+    """``rho`` from the dressed Matsubara Green function (spec 2.1):
+
+        D_ab(k) = D^ref_ab(k) + T sum_n [ G_ab(k, i w_n) - G^ref_ab(k, i w_n) ]
+        G^ref   = U diag(1 / (i w_n + mu - e_j)) U^dag,  D^ref_ab = sum_j U_aj conj(U_bj) f(e_j - mu)
+        rho_k   = D^T (last two axes);  rho_r = fftn(rho_k, norm="forward")
+
+    ``green_kw`` is ``(1, nmat, nvol, n, n)`` (the block axis of the SCF
+    state); ``heff_eig`` the pair from :func:`heff_eigenpairs`. The
+    Hermitian symmetry ``rho_ab(r) = conj(rho_ba(-r))`` is validated
+    (relative Frobenius error ``<= sym_tol``, else ``ValueError``) and
+    projected; non-finite input raises :class:`NonFiniteError`.
+    """
+    G = np.asarray(green_kw)
+    if G.ndim != 5 or G.shape[0] != 1:
+        raise ValueError(
+            "equal_time_density: green_kw must be (1, nmat, nvol, n, n), got {}"
+            .format(G.shape))
+    if not np.all(np.isfinite(G)):
+        raise NonFiniteError("equal_time_density: non-finite Green function")
+    nmat, nvol, n = G.shape[1], G.shape[2], G.shape[3]
+    nx, ny, nz = (int(x) for x in shape)
+    if nx * ny * nz != nvol:
+        raise ValueError("equal_time_density: prod(shape) != nvol")
+    e, U = heff_eig
+    T = 1.0 / beta
+    f = masked_fermi(T, mu, e)                                   # (nvol, n)
+    D_ref = np.einsum('kaj,kj,kbj->kab', U, f, U.conj())         # sum_j U_aj f_j conj(U_bj)
+    iw = 1j * (2 * np.arange(nmat) + 1 - nmat) * np.pi / beta
+    inv = 1.0 / (iw[:, None, None] + mu - e[None, :, :])         # (nmat, nvol, n)
+    G_ref = np.einsum('kaj,wkj,kbj->wkab', U, inv, U.conj())     # (nmat, nvol, n, n)
+    D = D_ref + T * (G[0] - G_ref).sum(axis=0)
+    rho_k = np.swapaxes(D, -1, -2)
+    rho_r = np.fft.fftn(rho_k.reshape(nx, ny, nz, n, n), axes=(0, 1, 2),
+                        norm="forward").reshape(nvol, n, n)
+    # Hermitian symmetry rho_ab(r) = conj(rho_ba(-r))
+    rev = np.conj(np.swapaxes(rho_r, -1, -2)).reshape(nx, ny, nz, n, n)
+    for ax in (0, 1, 2):
+        rev = np.flip(np.roll(rev, -1, axis=ax), axis=ax)       # r -> -r on a periodic axis
+    rev = rev.reshape(nvol, n, n)
+    err = float(np.linalg.norm((rho_r - rev).ravel())) / max(1.0, float(np.linalg.norm(rho_r.ravel())))
+    if not np.isfinite(err):
+        raise NonFiniteError("equal_time_density: non-finite density")
+    if err > sym_tol:
+        raise ValueError(
+            "equal_time_density: the equal-time density violates rho_ab(r) = "
+            "conj(rho_ba(-r)) (relative deviation {:.3e} > {:.1e}); the Green "
+            "function is not the Green function of a Hermitian problem"
+            .format(err, sym_tol))
+    rho_r = 0.5 * (rho_r + rev)
+    rho_k = np.fft.ifftn(rho_r.reshape(nx, ny, nz, n, n), axes=(0, 1, 2),
+                         norm="forward").reshape(nvol, n, n)
+    tr0 = complex(np.trace(rho_r[0]))
+    if abs(tr0.imag) > 1e-10 * max(1.0, abs(tr0.real)):
+        raise ValueError(
+            "equal_time_density: Tr rho(0) has a non-negligible imaginary part "
+            "({:.3e})".format(tr0.imag))
+    n_per_spin = float(nvol * tr0.real)
+    rho_k.flags.writeable = False
+    rho_r.flags.writeable = False
+    return DensityResult(rho_k=rho_k, rho_r=rho_r, n_per_spin=n_per_spin)

--- a/src/hwave/solver/offsite.py
+++ b/src/hwave/solver/offsite.py
@@ -131,6 +131,23 @@ def split_locality(ham_info, lattice):
                          offsite_prefold_tbl, tuple(offsite_tbl), has_fold)
 
 
+def sc_matrices_onsite_from_split(split, norb, nx, ny, nz):
+    """The pair-space S/C matrices of the ON-SITE (``R == 0`` pre-fold)
+    declarations only, each ``(nx, ny, nz, norb**2, norb**2)`` and
+    q-independent: the same builder as :func:`sc_matrices_from_split`
+    with the on-site table as the whole table and no off-site part. The
+    bond-resolved FLEX uses them for the second-order double-counting
+    subtraction of the on-site content (spec 2026-09-06 rev 19, 3.3)."""
+    from hwave.sc import _build_interaction_k
+    from hwave.solver._sc_matrices_myo import build_sc_matrices_locality_split
+    kx = np.linspace(0, 2.0 * np.pi, nx, endpoint=False)
+    ky = np.linspace(0, 2.0 * np.pi, ny, endpoint=False)
+    kz = np.linspace(0, 2.0 * np.pi, nz, endpoint=False)
+    inter_k_onsite = _build_interaction_k(kx, ky, kz, split.onsite_tbl, norb)
+    return build_sc_matrices_locality_split(
+        inter_k_onsite, inter_k_onsite, {}, norb, nx, ny, nz)
+
+
 def sc_matrices_from_split(split, offsite_types, norb, nx, ny, nz):
     """The Tier-1 locality-split pair-space S/C matrices, each
     ``(nx, ny, nz, norb**2, norb**2)``.

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -3660,6 +3660,32 @@ class RPA:
 
         return green_sub
 
+    def _calc_trans_mod_copy(self, g0):
+        """``_calc_trans_mod`` on a COPY of ``ham_trans_r`` (the legacy
+        helper adds into a view of the shared array): the HF-on seed path
+        of the FLEX solver (#181 Phase B) uses this so that neither
+        ``ham_trans_r`` nor the user's arrays are mutated. Same arithmetic
+        and result as the legacy helper."""
+        nx, ny, nz = self.lattice.shape
+        nvol = self.lattice.nvol
+        nd = self.nd
+        norb = self.norb
+        gg = np.asarray(g0)[0]
+        ww = self.ham_info.ham_inter_r.reshape(nvol, nd, nd, nd, nd)
+        hh1 = np.einsum('rbacd,cd->rab', ww, gg)
+        hh2 = np.einsum('rcdab,dc->rab', ww, gg)
+        hh3 = np.sum(hh1 + hh2, axis=0) / 2
+        if self.ham_info.enable_spin_orbital:
+            H0r = np.array(self.ham_info.ham_trans_r, copy=True).reshape(nvol, nd, nd)
+        else:
+            H0r = np.einsum('kab,st->ksatb',
+                            np.asarray(self.ham_info.ham_trans_r).reshape(nvol, norb, norb),
+                            np.eye(2)).reshape(nvol, nd, nd)
+        H0r[0] += hh3
+        H0 = (np.fft.ifftn(H0r.reshape(nx, ny, nz, nd, nd), axes=(0, 1, 2))
+              * nvol).reshape(nvol, nd, nd)
+        return H0
+
     def _calc_trans_mod(self, g0):
         logger.debug(">>> RPA._calc_trans_mod")
 

--- a/src/hwave/solver/rpa.py
+++ b/src/hwave/solver/rpa.py
@@ -1971,6 +1971,18 @@ class RPA:
         _lbc_keys = ("longitudinal_bond_channels",
                      "longitudinal_bond_max_shells",
                      "longitudinal_bond_memory_cap_gb")
+        # FLEX-only Phase B keys (#181): warned-and-ignored in every other
+        # mode (the FLEX subclass parses them itself, before this runs)
+        if not getattr(self, "_accepts_flex_keys", False):
+            _flex_only = [k for k in ("flex_hartree_fock",
+                                      "longitudinal_bond_output_full",
+                                      "longitudinal_bond_freq_batch")
+                          if k in self.param_mod]
+            if _flex_only:
+                logger.warning(
+                    "[mode.param] %s: FLEX-only key(s), ignored in mode "
+                    "'%s'.", ", ".join(_flex_only),
+                    getattr(self, "_mode_name", "RPA"))
         _flag = self.param_mod.get("longitudinal_bond_channels", False)
         if not isinstance(_flag, (bool, np.bool_)):
             raise ValueError(

--- a/src/hwave/solver/uhfk.py
+++ b/src/hwave/solver/uhfk.py
@@ -1369,7 +1369,7 @@ class UHFk(solver_base):
             # with the original expressions (bit-identical; #181 Phase B)
             hartree_fock.accumulate_hf(
                 ham, gab_r, self.inter_table, self.spin_table, self.shape,
-                include_fock=self.iflag_fock)
+                include_fock=self.iflag_fock, debug=logger.debug)
         else:
             for type in ['CoulombIntra', 'CoulombInter', 'Hund', 'Ising', 'PairLift', 'Exchange']:
                 if self.inter_table[type] is not None:

--- a/src/hwave/solver/uhfk.py
+++ b/src/hwave/solver/uhfk.py
@@ -6,6 +6,7 @@ from .base import solver_base
 from .perf import do_profile
 from . import fold
 from .kgrid import reverse_fft_axes
+from . import hartree_fock
 from ..qlmsio import wan90
 
 logger = logging.getLogger("qlms").getChild("uhfk")
@@ -1055,261 +1056,26 @@ class UHFk(solver_base):
 
     @do_profile
     def _make_ham_inter(self):
+        """Build the per-type interaction and spin tables.
+
+        The normal (spin-major) mode delegates to the shared kernel
+        ``hartree_fock.build_interaction_tables`` (#181 Phase B); the
+        ``discarded`` report it returns (declared entries the per-type
+        semantics drop, e.g. a CoulombIntra entry that is not r = 0,
+        a == b) is ignored here exactly as those entries were silently
+        skipped before, and the ambiguous aggregate/explicit Coulomb case
+        keeps its legacy logger.error + exit(1).
+        """
         logger.debug(">>> _make_ham_inter")
-
-        nx,ny,nz = self.shape
-        nvol     = self.nvol
-        # In spin-orbital mode, interaction arrays use physical orbital count
-        norb     = self.norb_phys if self.enable_spin_orbital else self.norb
-        nd       = self.nd
-
-        #----------------
-        # interaction table
-        #----------------
-        self.inter_table = {}
-        self.spin_table = {}
-
-        #----------------
-        # Coulomb Intra and Coulomb Inter
-        #----------------
-        if 'Coulomb' in self.param_ham.keys():
-            # The aggregate 'Coulomb' input already provides both the intra and
-            # inter parts; combining it with explicit CoulombIntra/CoulombInter
-            # is ambiguous (the explicit terms would be silently dropped).
-            if ('CoulombIntra' in self.param_ham.keys()
-                    or 'CoulombInter' in self.param_ham.keys()):
-                logger.error(
-                    "Coulomb cannot be specified together with "
-                    "CoulombIntra or CoulombInter")
-                exit(1)
-
-            # assume zvo_ur.dat
-            # divide into r=0 (coulomb intra) and r!=0 (coulomb inter)
-            # via the decomposition shared with RPA/FLEX
-            coulomb_intra, coulomb_inter = wan90.split_coulomb(
-                self.param_ham["Coulomb"])
-
-            # coulomb intra: diagonal part of r=0 cell
-            uab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            # coulomb inter: off-diagonal part
-            vab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            for (irvec,orbvec), v in coulomb_intra.items():
-                uab_r[(*irvec,*orbvec)] += v
-            for (irvec,orbvec), v in coulomb_inter.items():
-                vab_r[(*irvec,*orbvec)] += v
-
-            # coulomb intra
-            # interaction coeffs
-            self.inter_table["CoulombIntra"] = uab_r # r=0 component
-            # spin combination
-            self.spin_table["CoulombIntra"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["CoulombIntra"][0,1,1,0] = 1
-            self.spin_table["CoulombIntra"][1,0,0,1] = 1
-
-            #XXX
-            # n_up n_up = n_up -> include in one-body term
-
-            # coulomb inter
-            # J~ab(r) = Jab(r) + Jba(-r)
-            vba = np.conjugate(
-                np.transpose(
-                    reverse_fft_axes(vab_r, (0, 1, 2)),
-                    (0,1,2,4,3)
-                )
-            )
-
-            # interaction coeffs
-            self.inter_table["CoulombInter"] = (vab_r + vba)/2
-            # spin combination
-            self.spin_table["CoulombInter"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["CoulombInter"][0,0,0,0] = 1
-            self.spin_table["CoulombInter"][1,1,1,1] = 1
-            self.spin_table["CoulombInter"][0,1,1,0] = 1
-            self.spin_table["CoulombInter"][1,0,0,1] = 1
-
-        else:
-            self.inter_table["CoulombIntra"] = None
-            self.inter_table["CoulombInter"] = None
-
-            # coulomb intra
-            if 'CoulombIntra' in self.param_ham.keys():
-                uab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-                # only r=0 and a=b component
-                for (irvec,orbvec), v in self.param_ham["CoulombIntra"].items():
-                    alpha, beta = orbvec
-                    if irvec == (0,0,0) and alpha == beta:
-                        uab_r[(*irvec, *orbvec)] += v
-
-                # interaction coeffs
-                self.inter_table["CoulombIntra"] = uab_r
-                # spin combination
-                self.spin_table["CoulombIntra"] = np.zeros((2,2,2,2), dtype=int)
-                self.spin_table["CoulombIntra"][0,1,1,0] = 1
-                self.spin_table["CoulombIntra"][1,0,0,1] = 1
-
-            if 'CoulombInter' in self.param_ham.keys():
-                vab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-                for (irvec,orbvec), v in self.param_ham["CoulombInter"].items():
-#                    if irvec != (0,0,0):
-                        vab_r[(*irvec, *orbvec)] += v
-
-                vba = np.conjugate(
-                    np.transpose(
-                        reverse_fft_axes(vab_r, (0, 1, 2)),
-                        (0,1,2,4,3)
-                    )
-                )
-
-                # interaction coeffs
-                self.inter_table["CoulombInter"] = (vab_r + vba)/2
-                # spin combination
-                self.spin_table["CoulombInter"] = np.zeros((2,2,2,2), dtype=int)
-                self.spin_table["CoulombInter"][0,0,0,0] = 1
-                self.spin_table["CoulombInter"][1,1,1,1] = 1
-                self.spin_table["CoulombInter"][0,1,1,0] = 1
-                self.spin_table["CoulombInter"][1,0,0,1] = 1
-
-        #----------------
-        # Hund
-        #----------------        
-        if 'Hund' in self.param_ham.keys():
-            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            for (irvec,orbvec), v in self.param_ham["Hund"].items():
-                jab_r[(*irvec, *orbvec)] += v
-
-            # J~ab(r) = Jab(r) + Jba(-r)
-            jba = np.conjugate(
-                np.transpose(
-                    reverse_fft_axes(jab_r, (0, 1, 2)),
-                    (0,1,2,4,3)
-                )
-            )
-
-            # interaction coeffs : -J^{Hund} by convention
-            self.inter_table["Hund"] = -(jab_r + jba)/2
-            # spin combination
-            self.spin_table["Hund"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["Hund"][0,0,0,0] = 1
-            self.spin_table["Hund"][1,1,1,1] = 1
-        else:
-            self.inter_table["Hund"] = None
-
-        #----------------
-        # Ising
-        #----------------
-        if 'Ising' in self.param_ham.keys():
-            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            for (irvec,orbvec), v in self.param_ham["Ising"].items():
-                jab_r[(*irvec, *orbvec)] += v
-
-            # J~ab(r) = Jab(r) + Jba(-r)
-            jba = np.conjugate(
-                np.transpose(
-                    reverse_fft_axes(jab_r, (0, 1, 2)),
-                    (0,1,2,4,3)
-                )
-            )
-
-            # interaction coeffs -- no 1/4: the documented Hamiltonian is
-            # J (n_up - n_down)(n_up - n_down), and the RPA/FLEX vertex
-            # content was adjudicated by exact diagonalization against
-            # exactly that operator (#106); the historical /4 read the
-            # file as J S^z S^z instead, so the same Ising file meant
-            # couplings differing by 4 between UHFk and RPA/FLEX
-            self.inter_table["Ising"] = (jab_r + jba)/2
-            # spin combination
-            self.spin_table["Ising"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["Ising"][0,0,0,0] = 1
-            self.spin_table["Ising"][1,1,1,1] = 1
-            self.spin_table["Ising"][0,1,1,0] = -1
-            self.spin_table["Ising"][1,0,0,1] = -1
-        else:
-            self.inter_table["Ising"] = None
-
-        #----------------
-        # PairLift
-        #----------------
-        if 'PairLift' in self.param_ham.keys():
-            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            for (irvec,orbvec), v in self.param_ham["PairLift"].items():
-                jab_r[(*irvec, *orbvec)] += v
-
-            # J~ab(r) = Jab(r) + Jba(-r)
-            jba = np.conjugate(
-                np.transpose(
-                    reverse_fft_axes(jab_r, (0, 1, 2)),
-                    (0,1,2,4,3)
-                )
-            )
-
-            # interaction coeffs
-            self.inter_table["PairLift"] = (jab_r + jba)/2
-            # spin combination
-            self.spin_table["PairLift"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["PairLift"][0,0,1,1] = 1
-            self.spin_table["PairLift"][1,1,0,0] = 1
-        else:
-            self.inter_table["PairLift"] = None
-
-        #----------------
-        # Exchange
-        #----------------
-        if 'Exchange' in self.param_ham.keys():
-            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            for (irvec,orbvec), v in self.param_ham["Exchange"].items():
-                jab_r[(*irvec, *orbvec)] += v
-
-            # J~ab(r) = Jab(r) + Jba(-r)
-            jba = np.conjugate(
-                np.transpose(
-                    reverse_fft_axes(jab_r, (0, 1, 2)),
-                    (0,1,2,4,3)
-                )
-            )
-
-            # interaction coeffs : -J^{Ex} by convention
-            self.inter_table["Exchange"] = -(jab_r + jba)/2
-            # spin combination
-            self.spin_table["Exchange"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["Exchange"][0,1,0,1] = 1
-            self.spin_table["Exchange"][1,0,1,0] = 1
-        else:
-            self.inter_table["Exchange"] = None
-
-        #----------------
-        # PairHop
-        #----------------
-        if 'PairHop' in self.param_ham.keys():
-            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
-
-            for (irvec,orbvec), v in self.param_ham["PairHop"].items():
-                jab_r[(*irvec, *orbvec)] += v
-
-            # J~ab(r) = Jab(r) + Jba(-r)
-            jba = np.conjugate(
-                np.transpose(
-                    reverse_fft_axes(jab_r, (0, 1, 2)),
-                    (0,1,2,4,3)
-                )
-            )
-
-            # interaction coeffs
-            self.inter_table["PairHop"] = (jab_r + jba)/2
-            # spin combination
-            self.spin_table["PairHop"] = np.zeros((2,2,2,2), dtype=int)
-            self.spin_table["PairHop"][0,1,1,0] = 1
-            self.spin_table["PairHop"][1,0,0,1] = 1
-        else:
-            self.inter_table["PairHop"] = None
-
+        norb = self.norb_phys if self.enable_spin_orbital else self.norb
+        try:
+            tables = hartree_fock.build_interaction_tables(
+                self.param_ham, norb, self.shape)
+        except ValueError as exc:
+            logger.error(str(exc))
+            exit(1)
+        self.inter_table = tables.inter_table
+        self.spin_table = tables.spin_table
     @do_profile
     def _detect_blocks(self):
         """Detect block-diagonal structure from transfer and interaction terms.
@@ -1597,79 +1363,87 @@ class UHFk(solver_base):
         ham += self.ham_trans
 
         # interaction term: Coulomb type
-        for type in ['CoulombIntra', 'CoulombInter', 'Hund', 'Ising', 'PairLift', 'Exchange']:
-            if self.inter_table[type] is not None:
-                logger.debug(type)
+        if not self.enable_spin_orbital:
+            # normal (spin-major) mode: the shared kernel adds every
+            # interaction contribution IN PLACE, in the original order and
+            # with the original expressions (bit-identical; #181 Phase B)
+            hartree_fock.accumulate_hf(
+                ham, gab_r, self.inter_table, self.spin_table, self.shape,
+                include_fock=self.iflag_fock)
+        else:
+            for type in ['CoulombIntra', 'CoulombInter', 'Hund', 'Ising', 'PairLift', 'Exchange']:
+                if self.inter_table[type] is not None:
+                    logger.debug(type)
 
-                # coefficient of interaction term J_{ab}(r)
-                jab_r = self.inter_table[type].reshape(nvol,norb_inter,norb_inter)
-                # and its spin combination  Spin(s1,s2,s3,s4)
-                spin = self.spin_table[type]
+                    # coefficient of interaction term J_{ab}(r)
+                    jab_r = self.inter_table[type].reshape(nvol,norb_inter,norb_inter)
+                    # and its spin combination  Spin(s1,s2,s3,s4)
+                    spin = self.spin_table[type]
 
-                # non-cross term
-                #   sum_r J_{ab}(r) G_{bb,uv}(0) Spin{s,u,v,t}
-                hh0 = np.einsum('uvb, suvt -> stb', gbb, spin)
-                hh1 = np.einsum('rab, stb -> rsta', jab_r, hh0)
-                hh2 = np.einsum('rsta, ab -> rsatb', hh1, np.eye(norb_inter, norb_inter))
-                hh3 = np.sum(hh2, axis=0)  # shape: (2, norb_inter, 2, norb_inter)
-
-                if self.enable_spin_orbital:
-                    hh3_nd = self._virtual_ham_to_so(
-                        np.broadcast_to(hh3.reshape(1, 2, norb_inter, 2, norb_inter),
-                                       (nvol, 2, norb_inter, 2, norb_inter)).copy()
-                    )
-                else:
-                    hh3_nd = np.broadcast_to(hh3.reshape(nd, nd), (nvol, nd, nd))
-
-                ham += hh3_nd
-
-                # cross term
-                #   - sum_r J_{ab}(r) G_{ba,uv}(r) Spin{s,u,t,v} e^{ikr}
-                if self.iflag_fock:
-                    hh4 = np.einsum('rab, rubva, sutv -> rsatb', jab_r, gab_r, spin, optimize=True)
-
-                    #   fourier transform: sum_r (*) e^{ikr}
-                    hh5 = np.fft.ifftn(hh4.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+                    # non-cross term
+                    #   sum_r J_{ab}(r) G_{bb,uv}(0) Spin{s,u,v,t}
+                    hh0 = np.einsum('uvb, suvt -> stb', gbb, spin)
+                    hh1 = np.einsum('rab, stb -> rsta', jab_r, hh0)
+                    hh2 = np.einsum('rsta, ab -> rsatb', hh1, np.eye(norb_inter, norb_inter))
+                    hh3 = np.sum(hh2, axis=0)  # shape: (2, norb_inter, 2, norb_inter)
 
                     if self.enable_spin_orbital:
-                        ham -= self._virtual_ham_to_so(
-                            hh5.reshape(nvol, 2, norb_inter, 2, norb_inter)
+                        hh3_nd = self._virtual_ham_to_so(
+                            np.broadcast_to(hh3.reshape(1, 2, norb_inter, 2, norb_inter),
+                                           (nvol, 2, norb_inter, 2, norb_inter)).copy()
                         )
                     else:
-                        ham -= hh5.reshape(nvol, nd, nd)
+                        hh3_nd = np.broadcast_to(hh3.reshape(nd, nd), (nvol, nd, nd))
 
-        # interaction term: PairHop type
-        for type in ['PairHop']:
-            if self.inter_table[type] is not None:
-                logger.debug(type)
+                    ham += hh3_nd
 
-                # coefficient of interaction term J_{ab}(r)
-                jab_r = self.inter_table[type].reshape(nvol,norb_inter,norb_inter)
-                # and its spin combination  Spin(s1,s2,s3,s4)
-                spin = self.spin_table[type]
+                    # cross term
+                    #   - sum_r J_{ab}(r) G_{ba,uv}(r) Spin{s,u,t,v} e^{ikr}
+                    if self.iflag_fock:
+                        hh4 = np.einsum('rab, rubva, sutv -> rsatb', jab_r, gab_r, spin, optimize=True)
 
-                # non-cross and cross term
-                #   + sum_r J_{ab}(r) G_{ab,uv}(-r) Spin{s,u,v,t} e^{ikr}
-                #   - sum_r J_{ab}(r) G_{ab,uv}(-r) Spin{s,u,t,v} e^{ikr}
+                        #   fourier transform: sum_r (*) e^{ikr}
+                        hh5 = np.fft.ifftn(hh4.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
 
-                if self.iflag_fock:
-                    hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
-                    hh2 = np.einsum('rvbua, sutv -> rsbta', np.conjugate(gab_r), spin)
-                    hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, (hh1 - hh2))
-                    hh4 = np.fft.ifftn(hh3.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
-                else:
-                    hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
-                    hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, hh1)
-                    hh4 = np.fft.ifftn(hh3.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+                        if self.enable_spin_orbital:
+                            ham -= self._virtual_ham_to_so(
+                                hh5.reshape(nvol, 2, norb_inter, 2, norb_inter)
+                            )
+                        else:
+                            ham -= hh5.reshape(nvol, nd, nd)
 
-                if self.enable_spin_orbital:
-                    ham += self._virtual_ham_to_so(
-                        hh4.reshape(nvol, 2, norb_inter, 2, norb_inter)
-                    )
-                else:
-                    ham += hh4.reshape(nvol, nd, nd)
+            # interaction term: PairHop type
+            for type in ['PairHop']:
+                if self.inter_table[type] is not None:
+                    logger.debug(type)
 
-        # Enforce block structure: zero out cross-block entries
+                    # coefficient of interaction term J_{ab}(r)
+                    jab_r = self.inter_table[type].reshape(nvol,norb_inter,norb_inter)
+                    # and its spin combination  Spin(s1,s2,s3,s4)
+                    spin = self.spin_table[type]
+
+                    # non-cross and cross term
+                    #   + sum_r J_{ab}(r) G_{ab,uv}(-r) Spin{s,u,v,t} e^{ikr}
+                    #   - sum_r J_{ab}(r) G_{ab,uv}(-r) Spin{s,u,t,v} e^{ikr}
+
+                    if self.iflag_fock:
+                        hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
+                        hh2 = np.einsum('rvbua, sutv -> rsbta', np.conjugate(gab_r), spin)
+                        hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, (hh1 - hh2))
+                        hh4 = np.fft.ifftn(hh3.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+                    else:
+                        hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
+                        hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, hh1)
+                        hh4 = np.fft.ifftn(hh3.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+
+                    if self.enable_spin_orbital:
+                        ham += self._virtual_ham_to_so(
+                            hh4.reshape(nvol, 2, norb_inter, 2, norb_inter)
+                        )
+                    else:
+                        ham += hh4.reshape(nvol, nd, nd)
+
+            # Enforce block structure: zero out cross-block entries
         if len(self.block_info) > 1:
             mask = np.zeros((nd, nd), dtype=bool)
             for blk in self.block_info:

--- a/tests/heavy_tests.py
+++ b/tests/heavy_tests.py
@@ -154,6 +154,11 @@ HEAVY_TESTS = (
      "bond-resolved FLEX peak RSS of a subprocess vs the preflight estimate "
      "plus the calibrated interpreter baseline (6x6, Nmat=64, depth 8, "
      "full output)"),
+    # --- tests/test_flex_bond_onari_trend.py -- #181 Phase B trend milestone --
+    ("test_flex_bond_onari_trend", "TestFlexBondOnariTrend",
+     "test_regenerated_greens_reproduce_the_pinned_lambda",
+     "regenerate the Hartree-Fock bond FLEX greens of the Onari-type trend "
+     "milestone (hours; HWAVE_RUN_SLOW_FIXTURES=1) and re-derive lambda_t"),
     # --- tests/test_offsite_exchange_ed_longitudinal.py -- #181 Tier 2 ---
     ("test_offsite_exchange_ed_longitudinal",
      "TestOffsiteExchangeLongitudinalControls",

--- a/tests/heavy_tests.py
+++ b/tests/heavy_tests.py
@@ -148,6 +148,12 @@ HEAVY_TESTS = (
      "test_matches_direct_lehmann_sum",
      "IR bond bubble vs a direct Lehmann sum -- 171 s on its own, the "
      "single most expensive test in the suite"),
+    # --- tests/test_flex_bond_memory.py -- #181 Phase B memory validation --
+    ("test_flex_bond_memory", "TestSubprocessRSS",
+     "test_subprocess_rss_below_estimate_plus_allowance",
+     "bond-resolved FLEX peak RSS of a subprocess vs the preflight estimate "
+     "plus the calibrated interpreter baseline (6x6, Nmat=64, depth 8, "
+     "full output)"),
     # --- tests/test_offsite_exchange_ed_longitudinal.py -- #181 Tier 2 ---
     ("test_offsite_exchange_ed_longitudinal",
      "TestOffsiteExchangeLongitudinalControls",

--- a/tests/sc/onari_bond/flex_bond_observables.json
+++ b/tests/sc/onari_bond/flex_bond_observables.json
@@ -1,0 +1,228 @@
+{
+ "lambda_t": {
+  "cold": {
+   "0.00": 0.07975703202716758,
+   "0.40": 0.08178290472738786,
+   "0.80": 0.09940861974554759,
+   "1.00": 0.13084753641943114,
+   "1.20": 0.20422236554811116
+  },
+  "warm": {
+   "1.00": 0.13084753627067508,
+   "1.20": 0.20422236555197928
+  }
+ },
+ "records": [
+  {
+   "V": 0.0,
+   "cond_min_c": 0.50164121809674,
+   "cond_min_s": 0.1938267829395366,
+   "green": "green_flexbond_L16_V0.00_cold.npz",
+   "hf_density_error": 2.220446049250313e-16,
+   "legacy_seed_iterations": 20,
+   "maxrss_mb": 2588.46875,
+   "mu": 4.3125110953768475,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 10
+   },
+   "scf_component_residual": 1.1755499134514694e-11,
+   "scf_converged": true,
+   "scf_green_residual": 4.6420187889491694e-09,
+   "scf_iterations": 10,
+   "scf_sigma_residual": 1.1734043035910601e-11,
+   "seed": "cold",
+   "sha256": "3ebf1eae3b2b179b448e337340e89a0da99667c037baf10a478d35386eb05705",
+   "symmetrization_residual": 1.0496883226366375e-11,
+   "wall_s": 43.726016998291016
+  },
+  {
+   "V": 0.4,
+   "cond_min_c": 0.425745492060051,
+   "cond_min_s": 0.20300692732612893,
+   "green": "green_flexbond_L16_V0.40_cold.npz",
+   "hf_density_error": 0.0,
+   "legacy_seed_iterations": 18,
+   "maxrss_mb": 3051.453125,
+   "mu": 6.556206148003984,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 21
+   },
+   "scf_component_residual": 1.4117487437732432e-13,
+   "scf_converged": true,
+   "scf_green_residual": 9.379625103290998e-11,
+   "scf_iterations": 21,
+   "scf_sigma_residual": 1.4027939926756523e-13,
+   "seed": "cold",
+   "sha256": "13b78c0d4a9d57610b13ac283118c5683f622e3b4a082a01ade854ee310bf109",
+   "symmetrization_residual": 1.3642555661335167e-11,
+   "wall_s": 110.13151168823242
+  },
+  {
+   "V": 0.8,
+   "cond_min_c": 0.32373304999828284,
+   "cond_min_s": 0.2119861741940967,
+   "green": "green_flexbond_L16_V0.80_cold.npz",
+   "hf_density_error": 0.0,
+   "legacy_seed_iterations": 17,
+   "maxrss_mb": 3051.453125,
+   "mu": 8.82852480381652,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 25
+   },
+   "scf_component_residual": 2.0336343381080736e-12,
+   "scf_converged": true,
+   "scf_green_residual": 2.7640704712582804e-09,
+   "scf_iterations": 25,
+   "scf_sigma_residual": 2.011506070480373e-12,
+   "seed": "cold",
+   "sha256": "f2f421e6b88afc5da33f849001f6bfef6e8159f37c9f4bd838198cfefd7deb87",
+   "symmetrization_residual": 1.8447384683473294e-11,
+   "wall_s": 141.23018383979797
+  },
+  {
+   "V": 1.0,
+   "cond_min_c": 0.2887031694936967,
+   "cond_min_s": 0.21732135273548545,
+   "green": "green_flexbond_L16_V1.00_cold.npz",
+   "hf_density_error": 2.220446049250313e-16,
+   "legacy_seed_iterations": 18,
+   "maxrss_mb": 3085.25,
+   "mu": 9.982649674956852,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 25
+   },
+   "scf_component_residual": 7.503415915270265e-13,
+   "scf_converged": true,
+   "scf_green_residual": 1.5100035520572415e-09,
+   "scf_iterations": 25,
+   "scf_sigma_residual": 7.54610108381812e-13,
+   "seed": "cold",
+   "sha256": "a42b0696c0d4b370d82bc53e0188c28eeeb3d2dccf56f2755da7851ebeb0f5cb",
+   "symmetrization_residual": 2.097038586549053e-11,
+   "wall_s": 130.43084120750427
+  },
+  {
+   "V": 1.2,
+   "cond_min_c": 0.26121742410364585,
+   "cond_min_s": 0.22073163809813443,
+   "green": "green_flexbond_L16_V1.20_cold.npz",
+   "hf_density_error": 2.220446049250313e-16,
+   "legacy_seed_iterations": 18,
+   "maxrss_mb": 3259.171875,
+   "mu": 11.157323458106337,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 25
+   },
+   "scf_component_residual": 5.286806301680234e-13,
+   "scf_converged": true,
+   "scf_green_residual": 1.7283102304459746e-10,
+   "scf_iterations": 25,
+   "scf_sigma_residual": 5.25401921732787e-13,
+   "seed": "cold",
+   "sha256": "d234976e65f144f181d3ebfa46d3e0ea275fb3f6303cd1738e88905d956ef94e",
+   "symmetrization_residual": 2.3004972784263047e-11,
+   "wall_s": 134.8565318584442
+  },
+  {
+   "V": 1.0,
+   "cond_min_c": 0.2887031697979552,
+   "cond_min_s": 0.2173213527797744,
+   "green": "green_flexbond_L16_V1.00_warm_from_V0.80.npz",
+   "hf_density_error": 2.220446049250313e-16,
+   "maxrss_mb": 3259.171875,
+   "mu": 9.982649674961655,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 22
+   },
+   "scf_component_residual": 3.809000483015011e-13,
+   "scf_converged": true,
+   "scf_green_residual": 7.375501888052984e-10,
+   "scf_iterations": 22,
+   "scf_sigma_residual": 3.802899155016972e-13,
+   "seed": "warm_from_V0.80",
+   "sha256": "ef7b7a85a5d1aa99b9d8004cdf52f32de34f8d2dd512ac9ac72b01fc9475fdc6",
+   "symmetrization_residual": 2.0969518208719792e-11,
+   "wall_s": 108.64053988456726
+  },
+  {
+   "V": 1.2,
+   "cond_min_c": 0.26121742414936117,
+   "cond_min_s": 0.22073163811979352,
+   "green": "green_flexbond_L16_V1.20_warm_from_V1.00.npz",
+   "hf_density_error": 0.0,
+   "maxrss_mb": 3259.171875,
+   "mu": 11.157323458103715,
+   "qlms_result": {
+    "scf_converged": true,
+    "scf_iterations": 23
+   },
+   "scf_component_residual": 1.6449111281307728e-13,
+   "scf_converged": true,
+   "scf_green_residual": 7.987968590173348e-11,
+   "scf_iterations": 23,
+   "scf_sigma_residual": 1.6398796417978751e-13,
+   "seed": "warm_from_V1.00",
+   "sha256": "a68644bc48a4eddda4ea0daf4b2f65ffecd96809f991d86f5c1e7505d922c858",
+   "symmetrization_residual": 2.2916645939066903e-11,
+   "wall_s": 111.38986706733704
+  }
+ ],
+ "settings": {
+  "EPS": 8,
+  "IterationMax": 1500,
+  "L": 16,
+  "Mix": 0.2,
+  "Nmat": 2048,
+  "T": 0.02,
+  "U": 4.0,
+  "V_grid": [
+   0.0,
+   0.4,
+   0.8,
+   1.0,
+   1.2
+  ],
+  "anderson_depth": 8,
+  "filling": 0.7,
+  "flex_hartree_fock": true,
+  "longitudinal_bond_channels": true,
+  "scheme": "general",
+  "warm_from": {
+   "1.0": 0.8,
+   "1.2": 1.0
+  }
+ },
+ "tracking": [
+  {
+   "V": 0.0,
+   "dim": 2,
+   "overlap": 0.19492638138689403
+  },
+  {
+   "V": 0.4,
+   "dim": 2,
+   "overlap": 0.943891622429138
+  },
+  {
+   "V": 0.8,
+   "dim": 2,
+   "overlap": 0.8123010082887123
+  },
+  {
+   "V": 1.0,
+   "dim": 2,
+   "overlap": 0.9459006565073295
+  },
+  {
+   "V": 1.2,
+   "dim": 2,
+   "overlap": 0.9533662348236458
+  }
+ ]
+}

--- a/tests/sc/onari_bond/generate_flex_bond_fixtures.py
+++ b/tests/sc/onari_bond/generate_flex_bond_fixtures.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Regenerate the bond-resolved Hartree-Fock FLEX (#181 Phase B) Green
+functions of the Onari-type trend milestone
+(``tests/test_flex_bond_onari_trend.py``) and the compact observables file
+``flex_bond_observables.json`` that is committed in their place.
+
+Setting (frozen, spec 2026-09-06 section 5 "Onari-type trend milestone")
+------------------------------------------------------------------------
+Single-band square lattice, ``t = 1`` nearest neighbour only, ``U = 4``,
+``V`` on the four nearest-neighbour bonds, filling ``n = 0.7``, ``T = 0.02``,
+``L = 16``, ``Nmat = 2048``, ``V in {0, 0.4, 0.8, 1.0, 1.2}``; FLEX
+``calc_scheme = "general"`` with ``flex_hartree_fock = true`` and
+``longitudinal_bond_channels = true``, Anderson mixing (depth 8), ``Mix =
+0.2``, ``EPS = 8`` (the three residuals of the split state, three
+consecutive passes), ``IterationMax = 1500``.  Every V point is an
+independent start from the converged self-energy of the standard general
+FLEX at the same V ("cold" below: at ``U = 4``, ``beta = 50`` the bare Green
+function is inside the RPA spin instability and the bond path's conditioning
+check refuses a bare start, so the legacy solution -- no Hartree-Fock term,
+Hartree-only vertex -- is converted with ``hwave_sigma_split --zero-static``
+and used as the seed); the two points nearest the d-to-f crossing
+(``V = 1.0``, ``1.2``) are ALSO run warm-started from the converged split
+self-energy of the adjacent lower V (the two-seed check against metastable
+SCF branches).
+
+Consumer: the EXISTING static bond Eliashberg chain
+(``sc._build_bond_operator`` fed with the FLEX-bond ``green.npz``, exactly
+as ``[eliashberg] bond_green`` does), tracked through the odd-parity f-like
+triplet subspace with the milestone's own helpers.
+
+What is committed
+-----------------
+Only ``flex_bond_observables.json`` (a few kB): the settings, per run the
+convergence record (iterations, the three residuals, the density-closure
+error, the chemical potential, the conditioning minima, wall time and peak
+RSS) and the tracked ``lambda_t``.  The Green functions (~1 MB each) are
+regenerated on demand into ``tests/sc/onari_bond/_regenerated_flexbond/``
+(git-ignored; override with ``HWAVE_FLEXBOND_DIR``) by::
+
+    HWAVE_RUN_SLOW_FIXTURES=1 python3 -m unittest tests.test_flex_bond_onari_trend
+
+or directly with ``python3 tests/sc/onari_bond/generate_flex_bond_fixtures.py``.
+Neither FLEX nor ``np.savez_compressed`` is bit-reproducible, so regenerated
+files are not hash-pinned; the physics is pinned by the lambda table in the
+test at ``LAMBDA_RTOL``.
+"""
+import argparse
+import hashlib
+import json
+import os
+import resource
+import shutil
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+from tests.sc.onari_bond.generate_fixtures import _write_inputs, _symmetrize   # noqa: E402
+
+U = 4.0
+T = 0.02
+FILLING = 0.7
+L = 16
+NMAT = 2048
+V_GRID = (0.0, 0.4, 0.8, 1.0, 1.2)
+WARM_FROM = {1.0: 0.8, 1.2: 1.0}
+EPS = 8
+ITERATION_MAX = 1500
+MIX = 0.2
+DEPTH = 8
+
+SETTINGS = dict(U=U, T=T, filling=FILLING, L=L, Nmat=NMAT, V_grid=list(V_GRID),
+                warm_from={str(k): v for k, v in WARM_FROM.items()}, EPS=EPS,
+                IterationMax=ITERATION_MAX, Mix=MIX, anderson_depth=DEPTH,
+                scheme="general", flex_hartree_fock=True, longitudinal_bond_channels=True)
+
+OBSERVABLES = "flex_bond_observables.json"
+DEFAULT_DIR = os.environ.get("HWAVE_FLEXBOND_DIR",
+                             os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                          "_regenerated_flexbond"))
+
+
+def green_name(V, seed):
+    return "green_flexbond_L{}_V{:.2f}_{}.npz".format(L, V, seed)
+
+
+def _flex_input(indir, outdir, sigma_init=None, iteration_max=ITERATION_MAX, phase_b=True):
+    inp = {"path_to_input": "",
+           "interaction": {"path_to_input": indir, "Geometry": "geom.dat",
+                           "Transfer": "transfer.dat", "CoulombIntra": "coulombintra.dat",
+                           "CoulombInter": "coulombinter.dat"}}
+    if sigma_init is not None:
+        inp["path_to_input"] = os.path.dirname(sigma_init)
+        inp["sigma_init"] = os.path.basename(sigma_init)
+    param = {"T": T, "filling": FILLING, "CellShape": [L, L, 1], "SubShape": [1, 1, 1],
+             "Nmat": NMAT, "IterationMax": iteration_max, "Mix": MIX, "EPS": EPS,
+             "mixing_scheme": "anderson", "anderson_depth": DEPTH}
+    if phase_b:
+        param.update(flex_hartree_fock=True, longitudinal_bond_channels=True)
+    return {
+        "log": {"print_level": 1},
+        "mode": {"mode": "FLEX", "calc_scheme": "general", "param": param},
+        "file": {"input": inp,
+                 "output": {"path_to_output": outdir, "green": "green", "sigma": "sigma",
+                            "energy": "energy.dat"}},
+    }
+
+
+def legacy_seed(V, outdir, iteration_max=ITERATION_MAX):
+    """The 'cold' start of the Phase B run: at U = 4, beta = 50 the BARE
+    Green function sits inside the RPA spin instability (the bond path's
+    conditioning check refuses the very first map), so every V point is
+    seeded from the converged self-energy of the standard general FLEX at
+    the same V (no Hartree-Fock term, Hartree-only vertex), converted to
+    the split form with a zero static part by the hwave_sigma_split
+    machinery.  Returns (seed path, legacy iteration count)."""
+    import hwave.qlms as qlms
+    from hwave.solver.flex_hf import sigma_split_convert
+    work = tempfile.mkdtemp(prefix="flexbond_legacy_")
+    try:
+        indir = os.path.join(work, "in")
+        _write_inputs(indir, V)
+        result = qlms.run(input_dict=_flex_input(indir, work, None, iteration_max, phase_b=False))
+        assert result.get("scf_converged"), "legacy FLEX did not converge at V={}".format(V)
+        os.makedirs(outdir, exist_ok=True)
+        seed = os.path.join(outdir, "seed_legacy_L{}_V{:.2f}.npz".format(L, V))
+        sigma_split_convert(os.path.join(work, "sigma.npz"), seed, zero_static=True, force=True)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+    return seed, int(result.get("scf_iterations", -1))
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_point(V, outdir, seed="cold", sigma_init=None, iteration_max=ITERATION_MAX):
+    """One FLEX run; writes the symmetrised green and returns (record, sigma_path)."""
+    import hwave.qlms as qlms
+    work = tempfile.mkdtemp(prefix="flexbond_")
+    t0 = time.time()
+    try:
+        indir = os.path.join(work, "in")
+        _write_inputs(indir, V)
+        result = qlms.run(input_dict=_flex_input(indir, work, sigma_init, iteration_max))
+        raw = np.load(os.path.join(work, "green.npz"))
+        prov = {k: raw[k] for k in ("scf_converged", "scf_iterations", "scf_sigma_residual",
+                                    "scf_green_residual", "scf_component_residual",
+                                    "hf_density_error")}
+        cs = np.load(os.path.join(work, "chiq_s.npz"))
+        cond = {"cond_min_s": float(cs["longitudinal_bond_cond_min_s"]),
+                "cond_min_c": float(cs["longitudinal_bond_cond_min_c"])}
+        mu = None
+        with open(os.path.join(work, "energy.dat")) as f:
+            for ln in f:
+                if ln.startswith("ChemicalPotential"):
+                    mu = float(ln.split("=")[1])
+        green, delta = _symmetrize(raw["green"], L)
+        os.makedirs(outdir, exist_ok=True)
+        gpath = os.path.join(outdir, green_name(V, seed))
+        np.savez_compressed(gpath, green=green, L=L, V=V, U=U, T=T, filling=FILLING, nmat=NMAT,
+                            seed=seed, symmetrization_residual=delta, **prov)
+        spath = os.path.join(outdir, "sigma_L{}_V{:.2f}_{}.npz".format(L, V, seed))
+        shutil.copy(os.path.join(work, "sigma.npz"), spath)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+    wall = time.time() - t0
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform != "darwin":
+        rss *= 1024
+    rec = dict(V=V, seed=seed, green=os.path.basename(gpath), sha256=_sha256(gpath),
+               scf_converged=bool(prov["scf_converged"]), scf_iterations=int(prov["scf_iterations"]),
+               scf_sigma_residual=float(prov["scf_sigma_residual"]),
+               scf_green_residual=float(prov["scf_green_residual"]),
+               scf_component_residual=float(prov["scf_component_residual"]),
+               hf_density_error=float(prov["hf_density_error"]), mu=mu,
+               symmetrization_residual=float(delta), wall_s=wall, maxrss_mb=rss / 2 ** 20,
+               qlms_result={k: (bool(v) if isinstance(v, (bool, np.bool_)) else int(v))
+                            for k, v in result.items()}, **cond)
+    return rec, spath
+
+
+def generate(outdir=DEFAULT_DIR, iteration_max=ITERATION_MAX, v_grid=V_GRID, warm=True):
+    """Run every point (cold, then the warm starts) and write the observables."""
+    from tests.test_flex_bond_onari_trend import lambda_sweep
+    records = []
+    sigmas = {}
+    for V in v_grid:
+        seed, legacy_iterations = legacy_seed(V, outdir, iteration_max)
+        rec, spath = run_point(V, outdir, "cold", seed, iteration_max)
+        rec["legacy_seed_iterations"] = legacy_iterations
+        assert rec["scf_converged"], "FLEX did not converge at V={} ({} iterations)".format(
+            V, rec["scf_iterations"])
+        records.append(rec)
+        sigmas[V] = spath
+        print("V={:.2f} cold: {} iterations, {:.0f} s, lambda pending".format(
+            V, rec["scf_iterations"], rec["wall_s"]), flush=True)
+    if warm:
+        for V, V0 in WARM_FROM.items():
+            if V not in v_grid or V0 not in sigmas:
+                continue
+            rec, _ = run_point(V, outdir, "warm_from_V{:.2f}".format(V0), sigmas[V0], iteration_max)
+            assert rec["scf_converged"], "warm FLEX did not converge at V={}".format(V)
+            records.append(rec)
+            print("V={:.2f} warm from {:.2f}: {} iterations, {:.0f} s".format(
+                V, V0, rec["scf_iterations"], rec["wall_s"]), flush=True)
+    lam_cold = lambda_sweep([os.path.join(outdir, green_name(V, "cold")) for V in v_grid], list(v_grid))
+    lam = {"cold": {"{:.2f}".format(V): lam_cold["lambda"][i] for i, V in enumerate(v_grid)},
+           "warm": {}}
+    for rec in records:
+        if rec["seed"] != "cold":
+            V = rec["V"]
+            # track the warm green as the last point of the sweep up to V
+            seq = [os.path.join(outdir, green_name(v, "cold")) for v in v_grid if v < V]
+            seq.append(os.path.join(outdir, rec["green"]))
+            vs = [v for v in v_grid if v < V] + [V]
+            lam["warm"]["{:.2f}".format(V)] = lambda_sweep(seq, vs)["lambda"][-1]
+    obs = dict(settings=SETTINGS, records=records, lambda_t=lam, tracking=lam_cold["tracking"])
+    with open(os.path.join(outdir, OBSERVABLES), "w") as f:
+        json.dump(obs, f, indent=1, sort_keys=True)
+    print(json.dumps(lam, indent=1))
+    return obs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("outdir", nargs="?", default=DEFAULT_DIR)
+    parser.add_argument("--iteration-max", type=int, default=ITERATION_MAX)
+    parser.add_argument("--only", type=float, nargs="*", default=None, help="restrict the V grid")
+    parser.add_argument("--no-warm", action="store_true")
+    a = parser.parse_args()
+    generate(a.outdir, a.iteration_max, tuple(a.only) if a.only else V_GRID, warm=not a.no_warm)

--- a/tests/sc/onari_bond/generate_flex_bond_fixtures.py
+++ b/tests/sc/onari_bond/generate_flex_bond_fixtures.py
@@ -171,7 +171,7 @@ def run_point(V, outdir, seed="cold", sigma_init=None, iteration_max=ITERATION_M
     finally:
         shutil.rmtree(work, ignore_errors=True)
     wall = time.time() - t0
-    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss      # process high-water mark so far
     if sys.platform != "darwin":
         rss *= 1024
     rec = dict(V=V, seed=seed, green=os.path.basename(gpath), sha256=_sha256(gpath),
@@ -180,7 +180,8 @@ def run_point(V, outdir, seed="cold", sigma_init=None, iteration_max=ITERATION_M
                scf_green_residual=float(prov["scf_green_residual"]),
                scf_component_residual=float(prov["scf_component_residual"]),
                hf_density_error=float(prov["hf_density_error"]), mu=mu,
-               symmetrization_residual=float(delta), wall_s=wall, maxrss_mb=rss / 2 ** 20,
+               symmetrization_residual=float(delta), wall_s=wall,
+               maxrss_mb=rss / 2 ** 20,          # process high-water mark up to this run (not per run)
                qlms_result={k: (bool(v) if isinstance(v, (bool, np.bool_)) else int(v))
                             for k, v in result.items()}, **cond)
     return rec, spath

--- a/tests/test_flex_bond_dressing.py
+++ b/tests/test_flex_bond_dressing.py
@@ -53,12 +53,24 @@ class TestDressAndBuildW(unittest.TestCase):
             names = ("chibar", "W") + (("chi_s_w", "chi_c_w") if output_full else ())
             with BondBlockStore(nmat, nvol, ND, nd, names) as store:
                 store.put_freq_batch("chibar", 0, nmat, chi_bar)
-                res = dress_and_build_w(store, S, C, nb=4, output_full=output_full, nmat=nmat,
+                S_on = np.ascontiguousarray(S[:1, :nd, :nd]).repeat(nvol, axis=0) * 0.7
+                C_on = np.ascontiguousarray(C[:1, :nd, :nd]).repeat(nvol, axis=0) * 0.3
+                res = dress_and_build_w(store, S, C, S_on=S_on, C_on=C_on, nb=4,
+                                        output_full=output_full, nmat=nmat,
                                         nvol=nvol, nd=nd, spatial_shape=(4, 1, 1))
                 I = np.eye(ND)
                 chi_s = np.linalg.solve(I - chi_bar @ S, chi_bar)
                 chi_c = np.linalg.solve(I + chi_bar @ C, chi_bar)
-                W_ref = 1.5 * S @ chi_s @ S + 0.5 * C @ chi_c @ C - 0.25 * (S + C) @ chi_bar @ (S + C)
+                # spec 3.3 rev 19: ring beyond second order + the exact second order
+                W_ref = 1.5 * S @ (chi_s - chi_bar) @ S + 0.5 * C @ (chi_c - chi_bar) @ C
+                A = S @ chi_bar @ S
+                Bc = C @ chi_bar @ C
+                W2 = np.zeros_like(W_ref)
+                W2[:, :, :nd, :nd] = (1.5 * A + 0.5 * Bc)[:, :, :nd, :nd] \
+                    - 0.25 * (S_on + C_on) @ chi_bar[:, :, :nd, :nd] @ (S_on + C_on)
+                W2[:, :, :nd, nd:] = 0.25 * (A + Bc)[:, :, :nd, nd:]
+                W2[:, :, nd:, :nd] = 0.25 * (A + Bc)[:, :, nd:, :nd]
+                W_ref = W_ref + W2
                 np.testing.assert_allclose(store.get_freq_batch("W", 0, nmat), W_ref, rtol=1e-12, atol=1e-13)
                 np.testing.assert_allclose(res.collapse0, chi_bar[:, :, :nd, :nd], atol=1e-14)
                 np.testing.assert_allclose(res.collapse_s, chi_s[:, :, :nd, :nd], atol=1e-12)

--- a/tests/test_flex_bond_dressing.py
+++ b/tests/test_flex_bond_dressing.py
@@ -73,14 +73,14 @@ class TestDressAndBuildW(unittest.TestCase):
                 W_ref = W_ref + W2
                 np.testing.assert_allclose(store.get_freq_batch("W", 0, nmat), W_ref, rtol=1e-12, atol=1e-13)
                 np.testing.assert_allclose(res.collapse0, chi_bar[:, :, :nd, :nd], rtol=0, atol=1e-14)
-                np.testing.assert_allclose(res.collapse_s, chi_s[:, :, :nd, :nd], atol=1e-12)
-                np.testing.assert_allclose(res.collapse_c, chi_c[:, :, :nd, :nd], atol=1e-12)
-                np.testing.assert_allclose(res.static_s, chi_s[nmat // 2], atol=1e-12)
-                np.testing.assert_allclose(res.static_c, chi_c[nmat // 2], atol=1e-12)
+                np.testing.assert_allclose(res.collapse_s, chi_s[:, :, :nd, :nd], rtol=0, atol=1e-12)
+                np.testing.assert_allclose(res.collapse_c, chi_c[:, :, :nd, :nd], rtol=0, atol=1e-12)
+                np.testing.assert_allclose(res.static_s, chi_s[nmat // 2], rtol=0, atol=1e-12)
+                np.testing.assert_allclose(res.static_c, chi_c[nmat // 2], rtol=0, atol=1e-12)
                 self.assertTrue(res.static_s.flags.owndata)
                 self.assertGreater(res.cond_min_s, 0.0)
                 if output_full:
-                    np.testing.assert_allclose(store.get_freq_batch("chi_s_w", 0, nmat), chi_s, atol=1e-12)
+                    np.testing.assert_allclose(store.get_freq_batch("chi_s_w", 0, nmat), chi_s, rtol=0, atol=1e-12)
                     np.testing.assert_allclose(store.get_freq_batch("chi_s_w", nmat // 2, nmat // 2 + 1)[0],
                                                res.static_s, atol=0)
                 else:

--- a/tests/test_flex_bond_dressing.py
+++ b/tests/test_flex_bond_dressing.py
@@ -1,0 +1,80 @@
+"""Frequency-batched bond dressing, the effective interaction and the
+collapses (spec 2026-09-06 sections 3.2-3.3)."""
+import unittest
+
+import numpy as np
+
+
+def _problem(nmat=6, nvol=4, nd=4, B=3, seed=0):
+    rng = np.random.default_rng(seed)
+    ND = B * nd
+    chi_bar = 0.05 * (rng.normal(size=(nmat, nvol, ND, ND)) + 1j * rng.normal(size=(nmat, nvol, ND, ND)))
+    S = 0.4 * rng.normal(size=(nvol, ND, ND)); S = 0.5 * (S + np.swapaxes(S, 1, 2))
+    C = 0.3 * rng.normal(size=(nvol, ND, ND)); C = 0.5 * (C + np.swapaxes(C, 1, 2))
+    return chi_bar, S + 0j, C + 0j
+
+
+class TestDressBatch(unittest.TestCase):
+
+    def test_equals_per_frequency_dress_channel(self):
+        from hwave.solver import bond_channels as bc
+        chi_bar, S, C = _problem()
+        nmat, nvol = chi_bar.shape[:2]
+        for channel, W in (("spin", S), ("charge", C)):
+            chi_b, cond = bc.dress_batch(chi_bar[1:4], W, channel, l0=1, nmat=nmat, spatial_shape=(4, 1, 1))
+            for i, l in enumerate(range(1, 4)):
+                ref, c_ref = bc.dress_channel(chi_bar[l], W, channel, spatial_shape=(4, 1, 1))
+                np.testing.assert_array_equal(chi_b[i], ref)
+            self.assertIsInstance(cond, float)
+
+    def test_refusal_names_frequency_and_q(self):
+        from hwave.solver import bond_channels as bc
+        chi_bar, S, C = _problem(nmat=4, nvol=2, nd=1, B=1)
+        chi_bar[:] = 0.0
+        chi_bar[2, 1, 0, 0] = 1.0                            # l=2, q index 1: 1 - 1*1 = 0
+        W = np.ones((2, 1, 1), complex)
+        with self.assertRaises(ValueError) as cm:
+            bc.dress_batch(chi_bar[2:4], W, "spin", l0=2, nmat=4, spatial_shape=(2, 1, 1))
+        msg = str(cm.exception)
+        self.assertIn("bosonic", msg)
+        self.assertIn(str(2 * 2 - 4), msg)                     # 2l - nmat = 0
+        self.assertIn("(1, 0, 0)", msg)
+        self.assertIn("spin", msg)
+
+
+class TestDressAndBuildW(unittest.TestCase):
+
+    def test_w_and_collapses_and_static(self):
+        from hwave.solver.flex_bond import BondBlockStore, dress_and_build_w
+        chi_bar, S, C = _problem(nmat=6, nvol=4, nd=4, B=3)
+        nmat, nvol, ND = chi_bar.shape[:3]
+        nd = 4
+        for output_full in (False, True):
+            names = ("chibar", "W") + (("chi_s_w", "chi_c_w") if output_full else ())
+            with BondBlockStore(nmat, nvol, ND, nd, names) as store:
+                store.put_freq_batch("chibar", 0, nmat, chi_bar)
+                res = dress_and_build_w(store, S, C, nb=4, output_full=output_full, nmat=nmat,
+                                        nvol=nvol, nd=nd, spatial_shape=(4, 1, 1))
+                I = np.eye(ND)
+                chi_s = np.linalg.solve(I - chi_bar @ S, chi_bar)
+                chi_c = np.linalg.solve(I + chi_bar @ C, chi_bar)
+                W_ref = 1.5 * S @ chi_s @ S + 0.5 * C @ chi_c @ C - 0.25 * (S + C) @ chi_bar @ (S + C)
+                np.testing.assert_allclose(store.get_freq_batch("W", 0, nmat), W_ref, rtol=1e-12, atol=1e-13)
+                np.testing.assert_allclose(res.collapse0, chi_bar[:, :, :nd, :nd], atol=1e-14)
+                np.testing.assert_allclose(res.collapse_s, chi_s[:, :, :nd, :nd], atol=1e-12)
+                np.testing.assert_allclose(res.collapse_c, chi_c[:, :, :nd, :nd], atol=1e-12)
+                np.testing.assert_allclose(res.static_s, chi_s[nmat // 2], atol=1e-12)
+                np.testing.assert_allclose(res.static_c, chi_c[nmat // 2], atol=1e-12)
+                self.assertTrue(res.static_s.flags.owndata)
+                self.assertGreater(res.cond_min_s, 0.0)
+                if output_full:
+                    np.testing.assert_allclose(store.get_freq_batch("chi_s_w", 0, nmat), chi_s, atol=1e-12)
+                    np.testing.assert_allclose(store.get_freq_batch("chi_s_w", nmat // 2, nmat // 2 + 1)[0],
+                                               res.static_s, atol=0)
+                else:
+                    with self.assertRaises(KeyError):
+                        store.get_freq_batch("chi_s_w", 0, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_bond_dressing.py
+++ b/tests/test_flex_bond_dressing.py
@@ -72,7 +72,7 @@ class TestDressAndBuildW(unittest.TestCase):
                 W2[:, :, nd:, :nd] = 0.25 * (A + Bc)[:, :, nd:, :nd]
                 W_ref = W_ref + W2
                 np.testing.assert_allclose(store.get_freq_batch("W", 0, nmat), W_ref, rtol=1e-12, atol=1e-13)
-                np.testing.assert_allclose(res.collapse0, chi_bar[:, :, :nd, :nd], atol=1e-14)
+                np.testing.assert_allclose(res.collapse0, chi_bar[:, :, :nd, :nd], rtol=0, atol=1e-14)
                 np.testing.assert_allclose(res.collapse_s, chi_s[:, :, :nd, :nd], atol=1e-12)
                 np.testing.assert_allclose(res.collapse_c, chi_c[:, :, :nd, :nd], atol=1e-12)
                 np.testing.assert_allclose(res.static_s, chi_s[nmat // 2], atol=1e-12)

--- a/tests/test_flex_bond_gate.py
+++ b/tests/test_flex_bond_gate.py
@@ -340,5 +340,64 @@ class TestOutputs(unittest.TestCase):
             self.assertEqual(v, getattr(s._bond_last, "cond_min_" + ch))
 
 
+class TestFailureClearing(unittest.TestCase):
+
+    def test_caches_and_seed_are_dropped_on_every_failure(self):
+        from hwave.solver import flex_bond
+        attrs = ("_phase_b_seed", "_hf_tables", "_bond_topo", "_bond_split", "_bond_view",
+                 "_bond_S", "_bond_C", "_bond_S_on", "_bond_C_on", "_bond_est", "_bond_last")
+        with tempfile.TemporaryDirectory() as out:
+            # preflight failure (no declared shell)
+            s, r = _flex(inter={"CoulombIntra": "coulombintra.dat"})
+            with self.assertRaises(ValueError):
+                s.solve(r.get_param("green"), out)
+            for a in attrs:
+                self.assertFalse(hasattr(s, a), a)
+            # mid-loop failure in the transport
+            s, r = _flex({"IterationMax": 2})
+            gi = r.get_param("green")
+            with mock.patch.object(flex_bond, "calc_self_energy_bond",
+                                   side_effect=RuntimeError("injected")):
+                with self.assertRaises(RuntimeError):
+                    s.solve(gi, out)
+            for a in attrs:
+                self.assertFalse(hasattr(s, a), a)
+            self.assertFalse(any(str(k).startswith("longitudinal_bond_") for k in gi))
+            # the seed is gone once the loop runs (a successful run)
+            s, r = _flex({"IterationMax": 1})
+            s.solve(r.get_param("green"), out)
+            self.assertFalse(hasattr(s, "_phase_b_seed"))
+
+
+class TestStandaloneHFAdmissibility(unittest.TestCase):
+
+    def test_complex_offsite_coefficient_and_offsite_exchange_refused_at_preflight(self):
+        with tempfile.TemporaryDirectory() as inp:
+            for f in ("geom.dat", "transfer.dat"):
+                shutil.copy(os.path.join(_IN2, f), inp)
+            lines = open(os.path.join(_IN2, "coulombinter.dat")).read().splitlines()
+            out = lines[:4]
+            for ln in lines[4:]:
+                p = ln.split()
+                if p[:3] == ["0", "1", "0"] and p[3:5] == ["1", "1"]:
+                    p[6] = "0.2"
+                if p[:3] == ["0", "-1", "0"] and p[3:5] == ["1", "1"]:
+                    p[6] = "-0.2"
+                out.append("  ".join(p))
+            open(os.path.join(inp, "pairlift.dat"), "w").write("\n".join(out).replace("CoulombInter", "PairLift") + "\n")
+            open(os.path.join(inp, "coulombinter.dat"), "w").write("\n".join(out) + "\n")
+            shutil.copy(os.path.join(_IN2, "coulombinter.dat"), os.path.join(inp, "coulombinter_real.dat"))
+            boom = mock.Mock(side_effect=RuntimeError("expensive step reached"))
+            for inter in ({"CoulombInter": "coulombinter.dat"},
+                          {"CoulombInter": "coulombinter_real.dat", "PairLift": "pairlift.dat"},
+                          {"Exchange": "coulombinter_real.dat"}):
+                s, r = _flex(path=inp, inter=inter, gate=False)
+                with mock.patch.object(type(s), "_calc_epsilon_k", boom), \
+                        tempfile.TemporaryDirectory() as o:
+                    with self.assertRaises(ValueError) as cm:
+                        s.solve(r.get_param("green"), o)
+                self.assertIn("flex_hartree_fock", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_flex_bond_gate.py
+++ b/tests/test_flex_bond_gate.py
@@ -1,0 +1,344 @@
+"""The bond-resolved longitudinal channel inside the FLEX loop (spec
+2026-09-06, gates G0, G3, G4): the declared-zero reduction to standalone
+HF FLEX, the first-map static slice against the Phase A RPA gate, the
+refusal precedence tripwires, the output-path validation, the dedicated
+archive, IterationMax = 0, reuse/failure atomicity and the cond_min
+provenance."""
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN2 = "tests/rpa/input_2orb"
+_NMAT = 8
+_PAR = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+        "Nmat": _NMAT, "IterationMax": 3, "Mix": 0.5, "EPS": 1e-12}
+
+
+def _reader(path, inter):
+    idict = {"path_to_input": path, "Geometry": "geom.dat", "Transfer": "transfer.dat"}
+    idict.update(inter)
+    return read_input_k.QLMSkInput({"path_to_input": path, "interaction": idict})
+
+
+def _flex(param_extra=None, path=_IN2, inter=None, gate=True, hf=True, mixing="linear"):
+    import hwave.solver.flex as flex_mod
+    r = _reader(path, {"CoulombInter": "coulombinter.dat"} if inter is None else inter)
+    par = dict(_PAR, flex_hartree_fock=hf, longitudinal_bond_channels=gate, mixing_scheme=mixing)
+    par.update(param_extra or {})
+    par = {k: v for k, v in par.items() if v is not None}
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+def _rpa(param_extra=None, path=_IN2, inter=None):
+    import hwave.solver.rpa as rpa_mod
+    r = _reader(path, {"CoulombInter": "coulombinter.dat"} if inter is None else inter)
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": _NMAT, "longitudinal_bond_channels": True}
+    par.update(param_extra or {})
+    par = {k: v for k, v in par.items() if v is not None}
+    info = {"mode": "RPA", "param": par, "enable_spin_orbital": False,
+            "calc_scheme": "general", "calc_type": "ring"}
+    return rpa_mod.RPA(r.get_param("ham"), {}, info), r
+
+
+def _zeroed_offsite_copy(dst):
+    """input_2orb with every off-site CoulombInter coefficient set to zero
+    (the shells stay declared)."""
+    for f in ("geom.dat", "transfer.dat"):
+        shutil.copy(os.path.join(_IN2, f), dst)
+    lines = open(os.path.join(_IN2, "coulombinter.dat")).read().splitlines()
+    out = lines[:4]
+    for ln in lines[4:]:
+        parts = ln.split()
+        if len(parts) >= 7 and any(int(x) != 0 for x in parts[:3]):
+            parts[5], parts[6] = "0.0", "0.0"
+        out.append("  ".join(parts))
+    with open(os.path.join(dst, "coulombinter.dat"), "w") as fw:
+        fw.write("\n".join(out) + "\n")
+
+
+def _collect(s, gi, out):
+    rec = []
+    s._iteration_hook = lambda d: rec.append(d)
+    s.solve(gi, out)
+    return rec
+
+
+class TestG0DeclaredZero(unittest.TestCase):
+
+    def test_g0_declared_zero_equals_standalone_hf(self):
+        with tempfile.TemporaryDirectory() as inp, tempfile.TemporaryDirectory() as out:
+            _zeroed_offsite_copy(inp)
+            recs = {}
+            gis = {}
+            for gate in (True, False):
+                s, r = _flex(path=inp, gate=gate)
+                gi = r.get_param("green")
+                recs[gate] = _collect(s, gi, out)
+                gis[gate] = (s, gi)
+            self.assertEqual(len(recs[True]), len(recs[False]))
+            self.assertGreaterEqual(len(recs[True]), 2)
+            for a, b in zip(recs[True], recs[False]):
+                self.assertEqual(a["iteration"], b["iteration"])
+                self.assertAlmostEqual(a["mu"], b["mu"], delta=1e-12)
+                for k in ("static_new", "fluct_new", "chi0q", "chiq_s", "chiq_c"):
+                    np.testing.assert_allclose(a[k], b[k], rtol=0, atol=1e-12, err_msg=k)
+            sg, gg = gis[True]
+            sh, gh = gis[False]
+            for k in ("sigma", "sigma_static", "sigma_fluct", "green"):
+                np.testing.assert_allclose(gg[k], gh[k], rtol=0, atol=1e-12, err_msg=k)
+            self.assertAlmostEqual(gg["physics"]["mu"], gh["physics"]["mu"], delta=1e-12)
+            # gate-owned additions present only with the gate
+            self.assertIn("longitudinal_bond_chi_s", gg)
+            self.assertEqual(str(gg["longitudinal_bond_source"]), "last_map")
+            self.assertFalse(any(str(k).startswith("longitudinal_bond_") for k in gh))
+
+
+class TestG3StaticSlice(unittest.TestCase):
+
+    def test_g3_static_slice_equals_phase_a(self):
+        with tempfile.TemporaryDirectory() as out:
+            rs, rr = _rpa({"mu": 0.3, "filling": None})
+            rgi = rr.get_param("green")
+            rs.solve(rgi, out)
+            fs, fr = _flex({"mu": 0.3, "filling": None, "IterationMax": 1})
+            fgi = fr.get_param("green")
+            rec = _collect(fs, fgi, out)
+        self.assertEqual(len(rec), 1)
+        d = rec[0]
+        np.testing.assert_allclose(d["bond_static_s"], rgi["longitudinal_bond_chi_s"], rtol=0, atol=1e-12)
+        np.testing.assert_allclose(d["bond_static_c"], rgi["longitudinal_bond_chi_c"], rtol=0, atol=1e-12)
+        np.testing.assert_allclose(d["chiq_s"][_NMAT // 2], rgi["longitudinal_bond_chiq_s_static"],
+                                   rtol=0, atol=1e-12)
+        np.testing.assert_allclose(d["chiq_c"][_NMAT // 2], rgi["longitudinal_bond_chiq_c_static"],
+                                   rtol=0, atol=1e-12)
+
+
+class TestRefusals(unittest.TestCase):
+
+    def _tripwired(self, s):
+        import hwave.solver.backend as bk
+        boom = mock.Mock(side_effect=RuntimeError("expensive step reached"))
+        patches = [mock.patch.object(type(s), n, boom) for n in
+                   ("_calc_epsilon_k", "_find_mu_dressed", "_calc_green", "_calc_chi0q")]
+        patches.append(mock.patch.object(bk, "get_backend", boom))
+        return patches
+
+    def _assert_refused(self, s, gi, needle):
+        patches = self._tripwired(s)
+        for p in patches:
+            p.start()
+        try:
+            with tempfile.TemporaryDirectory() as out:
+                with self.assertRaises(ValueError) as cm:
+                    s.solve(gi, out)
+        finally:
+            for p in patches:
+                p.stop()
+        self.assertIn(needle, str(cm.exception))
+        self.assertFalse(any(str(k).startswith("longitudinal_bond_") for k in gi))
+
+    def test_refusal_precedence_tripwires(self):
+        # (6) off-site Exchange
+        s, r = _flex(inter={"CoulombInter": "coulombinter.dat", "Exchange": "coulombinter.dat"})
+        self._assert_refused(s, r.get_param("green"), "Exchange")
+        # (6) no declared off-site shell
+        s, r = _flex(inter={"CoulombIntra": "coulombintra.dat"})
+        self._assert_refused(s, r.get_param("green"), "shell")
+        # (7) memory cap
+        s, r = _flex({"longitudinal_bond_memory_cap_gb": 1e-9})
+        self._assert_refused(s, r.get_param("green"), "GiB")
+        # (4) spin-mixing mean field
+        s, r = _flex()
+        gi = r.get_param("green")
+        nvol, norb = s.lattice.nvol, s.norb
+        tm = np.zeros((nvol, 2, norb, 2, norb), complex)
+        tm[:, 0, :, 1, :] = 0.1
+        gi["trans_mod"] = tm
+        self._assert_refused(s, gi, "spin")
+        # (5) split seed with a mean field (D15)
+        with tempfile.TemporaryDirectory() as out:
+            s0, r0 = _flex({"IterationMax": 1})
+            gi0 = r0.get_param("green")
+            s0.solve(gi0, out)
+            s0.save_results({"path_to_output": out, "sigma": "sigma.npz"}, gi0)
+            s, r = _flex()
+            gi = r.get_param("green")
+            gi.update(s.read_init({"path_to_input": out, "sigma_init": "sigma.npz"}))
+            gi["trans_mod"] = np.zeros((nvol, 2, norb, 2, norb), complex)
+            self._assert_refused(s, gi, "split")
+
+    def test_complex_offsite_coefficient_refused(self):
+        with tempfile.TemporaryDirectory() as inp:
+            for f in ("geom.dat", "transfer.dat"):
+                shutil.copy(os.path.join(_IN2, f), inp)
+            lines = open(os.path.join(_IN2, "coulombinter.dat")).read().splitlines()
+            out = lines[:4]
+            for ln in lines[4:]:
+                p = ln.split()
+                if p[:3] == ["0", "1", "0"] and p[3:5] == ["1", "1"]:
+                    p[6] = "0.2"
+                if p[:3] == ["0", "-1", "0"] and p[3:5] == ["1", "1"]:
+                    p[6] = "-0.2"
+                out.append("  ".join(p))
+            open(os.path.join(inp, "coulombinter.dat"), "w").write("\n".join(out) + "\n")
+            s, r = _flex(path=inp)
+            self._assert_refused(s, r.get_param("green"), "real")
+
+
+class TestOutputs(unittest.TestCase):
+
+    def test_output_paths_collision_refused_at_solve_entry_and_qlms(self):
+        from hwave.solver import flex_bond
+        with tempfile.TemporaryDirectory() as out:
+            paths = flex_bond.resolve_output_paths(
+                {"path_to_output": out, "chiq_s": "a", "sigma": "b.npz"}, out,
+                ("chiq_s", "chiq_c", "sigma"))
+            self.assertEqual(paths["chiq_s"], os.path.abspath(os.path.join(out, "a.npz")))
+            self.assertEqual(paths["chiq_c"], os.path.abspath(os.path.join(out, "chiq_c.npz")))
+            with self.assertRaises(ValueError) as cm:
+                flex_bond.resolve_output_paths({"chiq_s": "x", "sigma": "x.npz"}, out,
+                                               ("chiq_s", "sigma"))
+            self.assertIn("chiq_s", str(cm.exception))
+            self.assertIn("sigma", str(cm.exception))
+            s, r = _flex()
+            with self.assertRaises(ValueError):
+                s.validate_output_paths()          # no mapping stored, no argument
+            s.validate_output_paths({"path_to_output": out, "chiq_s": "x", "sigma": "y"})
+            with self.assertRaises(ValueError):
+                s.validate_output_paths({"path_to_output": out, "chiq_s": "x", "sigma": "x"})
+            # stored mapping -> solve entry refuses before any work
+            with mock.patch.object(type(s), "_calc_epsilon_k",
+                                   mock.Mock(side_effect=RuntimeError("reached"))):
+                with self.assertRaises(ValueError):
+                    s.solve(r.get_param("green"), out)
+            # the dedicated archive counts only when it will be written
+            s2, _ = _flex({"longitudinal_bond_output_full": True})
+            with self.assertRaises(ValueError):
+                s2.validate_output_paths({"path_to_output": out, "chiq_s": "longitudinal_bond"})
+            s3, _ = _flex()
+            s3.validate_output_paths({"path_to_output": out, "chiq_s": "longitudinal_bond"})
+            # qlms.run
+            import hwave.qlms as qlms
+            d = {"log": {"print_level": 1},
+                 "mode": {"mode": "FLEX", "calc_scheme": "general", "enable_spin_orbital": False,
+                          "param": dict(_PAR, flex_hartree_fock=True, longitudinal_bond_channels=True)},
+                 "file": {"input": {"path_to_input": _IN2,
+                                    "interaction": {"path_to_input": _IN2, "Geometry": "geom.dat",
+                                                    "Transfer": "transfer.dat",
+                                                    "CoulombInter": "coulombinter.dat"}},
+                          "output": {"path_to_output": out, "green": "same.npz", "sigma": "same"}}}
+            with mock.patch("hwave.solver.flex.FLEX.solve", side_effect=RuntimeError("reached")):
+                with self.assertRaises(ValueError):
+                    qlms.run(input_dict=d)
+
+    def test_dedicated_archive_schema_and_cross_output_consistency(self):
+        with tempfile.TemporaryDirectory() as out:
+            s, r = _flex({"longitudinal_bond_output_full": True, "IterationMax": 2})
+            gi = r.get_param("green")
+            s.solve(gi, out)
+            s.save_results({"path_to_output": out, "sigma": "sigma.npz", "green": "green.npz",
+                            "chi0q": "chi0q.npz"}, gi)
+            for f in ("longitudinal_bond.npz", "chiq_s.npz", "chiq_c.npz", "sigma.npz",
+                      "green.npz", "chi0q.npz"):
+                self.assertTrue(os.path.exists(os.path.join(out, f)), f)
+            b = np.load(os.path.join(out, "longitudinal_bond.npz"))
+            self.assertEqual(int(b["bond_archive_schema"]), 1)
+            self.assertEqual(str(b["freq_axis"]), "bosonic l -> 2l - nmat")
+            nvol, nd = s.lattice.nvol, s.norb ** 2
+            B = b["delta_r"].shape[0]
+            self.assertEqual(b["chi_s_w"].shape, (_NMAT, nvol, B * nd, B * nd))
+            self.assertEqual(b["chi_c_w"].shape, (_NMAT, nvol, B * nd, B * nd))
+            for k in ("beta", "T", "nmat", "cell_shape", "momentum_convention", "index_order",
+                      "reverse", "types", "longitudinal_bond_schema", "scf_converged",
+                      "payload_kind", "hf_density_error", "density_target_enforced",
+                      "longitudinal_bond_cond_min_s"):
+                self.assertIn(k, b.files, k)
+            self.assertEqual(str(b["payload_kind"]), "last_map")
+            np.testing.assert_array_equal(b["chi_s_w"][_NMAT // 2], b["longitudinal_bond_chi_s"])
+            np.testing.assert_array_equal(b["chi_c_w"][_NMAT // 2], b["longitudinal_bond_chi_c"])
+            cs = np.load(os.path.join(out, "chiq_s.npz"))
+            self.assertIn("longitudinal_bond_chi_s", cs.files)
+            self.assertIn("longitudinal_bond_chi_c", cs.files)
+            self.assertEqual(str(cs["longitudinal_bond_source"]), "last_map")
+            self.assertNotIn("chi_s_w", cs.files)
+            np.testing.assert_array_equal(cs["longitudinal_bond_chi_s"], b["longitudinal_bond_chi_s"])
+            np.testing.assert_array_equal(cs["chiq_s"][_NMAT // 2].reshape(nvol, nd, nd),
+                                          b["longitudinal_bond_chi_s"][:, :nd, :nd])
+            sg = np.load(os.path.join(out, "sigma.npz"))
+            self.assertEqual(str(sg["sigma_convention"]), "split")
+            np.testing.assert_array_equal(sg["sigma"], sg["sigma_static"] + sg["sigma_fluct"])
+            self.assertEqual(str(sg["payload_kind"]), "final_state")
+            c0 = np.load(os.path.join(out, "chi0q.npz"))
+            self.assertEqual(str(c0["payload_kind"]), "last_map")
+            # combined chiq routing: static keys go to chiq, not chiq_s
+            s.save_results({"path_to_output": out, "chiq": "chiq.npz"}, gi)
+            cq = np.load(os.path.join(out, "chiq.npz"))
+            self.assertIn("longitudinal_bond_chi_s", cq.files)
+            cs2 = np.load(os.path.join(out, "chiq_s.npz"))
+            self.assertNotIn("longitudinal_bond_chi_s", cs2.files)
+
+    def test_iteration_max_zero_omits_last_map_archives(self):
+        with tempfile.TemporaryDirectory() as out:
+            s, r = _flex({"IterationMax": 0, "longitudinal_bond_output_full": True})
+            gi = r.get_param("green")
+            s.solve(gi, out)
+            self.assertFalse(any(str(k).startswith("longitudinal_bond_") for k in gi))
+            s.validate_output_paths({"path_to_output": out, "chiq_s": "longitudinal_bond"})
+            s.save_results({"path_to_output": out, "sigma": "sigma.npz", "green": "green.npz",
+                            "chi0q": "chi0q.npz", "chiq": "chiq.npz"}, gi)
+            for f in ("chi0q.npz", "chiq.npz", "chiq_s.npz", "chiq_c.npz", "longitudinal_bond.npz"):
+                self.assertFalse(os.path.exists(os.path.join(out, f)), f)
+            sg = np.load(os.path.join(out, "sigma.npz"))
+            self.assertEqual(int(sg["scf_iterations"]), 0)
+            self.assertTrue(np.isnan(float(sg["scf_sigma_residual"])))
+
+    def test_reused_green_info_and_failure_atomicity(self):
+        from hwave.solver import flex_bond
+        with tempfile.TemporaryDirectory() as out:
+            s, r = _flex({"IterationMax": 1})
+            gi = r.get_param("green")
+            s.solve(gi, out)
+            self.assertIn("longitudinal_bond_chi_s", gi)
+            stores = []
+            real = flex_bond.BondBlockStore
+
+            def _spy(*a, **k):
+                st = real(*a, **k)
+                stores.append(st)
+                return st
+            with mock.patch.object(flex_bond, "BondBlockStore", _spy), \
+                    mock.patch.object(flex_bond, "calc_self_energy_bond",
+                                      side_effect=RuntimeError("injected")):
+                with self.assertRaises(RuntimeError):
+                    s.solve(gi, out)
+            self.assertEqual(len(stores), 1)
+            self.assertTrue(stores[0].released)
+            self.assertFalse(any(str(k).startswith("longitudinal_bond_") for k in gi))
+            for k in ("sigma", "green", "chiq_s", "physics"):
+                self.assertNotIn(k, gi)
+            self.assertFalse(hasattr(s, "_bond_last"))
+            s.solve(gi, out)
+            self.assertIn("longitudinal_bond_chi_s", gi)
+            self.assertIn("sigma", gi)
+
+    def test_cond_min_provenance(self):
+        with tempfile.TemporaryDirectory() as out:
+            s, r = _flex({"IterationMax": 2})
+            gi = r.get_param("green")
+            s.solve(gi, out)
+        for ch in ("s", "c"):
+            v = float(gi["longitudinal_bond_cond_min_" + ch])
+            self.assertTrue(np.isfinite(v) and v > 0.0)
+            self.assertEqual(v, getattr(s._bond_last, "cond_min_" + ch))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_bond_gate.py
+++ b/tests/test_flex_bond_gate.py
@@ -374,9 +374,12 @@ class TestFailureClearing(unittest.TestCase):
             s._info_outputfile = {"path_to_output": out, "chiq_s": "same", "sigma": "same"}
             with self.assertRaises(ValueError):
                 s.solve(gi, out)
-            for k in ("sigma", "green", "chiq_s", "physics"):
+            for k in ("sigma", "sigma_static", "sigma_fluct", "green", "physics", "chi0q",
+                      "chiq_s", "chiq_c"):
                 self.assertNotIn(k, gi)
-            for a in attrs + ("sigma", "green_kw", "chi_s", "physics"):
+            self.assertFalse(any(str(k).startswith(("longitudinal_bond_", "scf_")) for k in gi))
+            for a in attrs + ("sigma", "sigma_static", "sigma_fluct", "green_kw", "chi_s",
+                              "chi_c", "physics"):
                 self.assertFalse(hasattr(s, a), a)
 
 

--- a/tests/test_flex_bond_gate.py
+++ b/tests/test_flex_bond_gate.py
@@ -365,8 +365,19 @@ class TestFailureClearing(unittest.TestCase):
             self.assertFalse(any(str(k).startswith("longitudinal_bond_") for k in gi))
             # the seed is gone once the loop runs (a successful run)
             s, r = _flex({"IterationMax": 1})
-            s.solve(r.get_param("green"), out)
+            gi = r.get_param("green")
+            s.solve(gi, out)
             self.assertFalse(hasattr(s, "_phase_b_seed"))
+            # a reused solver whose stored output mapping now collides: the
+            # solve-entry refusal clears the previous results too
+            s.validate_output_paths({"path_to_output": out, "sigma": "s"})
+            s._info_outputfile = {"path_to_output": out, "chiq_s": "same", "sigma": "same"}
+            with self.assertRaises(ValueError):
+                s.solve(gi, out)
+            for k in ("sigma", "green", "chiq_s", "physics"):
+                self.assertNotIn(k, gi)
+            for a in attrs + ("sigma", "green_kw", "chi_s", "physics"):
+                self.assertFalse(hasattr(s, a), a)
 
 
 class TestStandaloneHFAdmissibility(unittest.TestCase):

--- a/tests/test_flex_bond_memory.py
+++ b/tests/test_flex_bond_memory.py
@@ -1,0 +1,252 @@
+"""Memory preflight of the bond-resolved FLEX gate (spec 2026-09-06
+section 3.6): the named-buffer table, the batch selection, the refusal
+naming every row, the operation warnings, the tracer invariant and the
+subprocess RSS validation."""
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import tracemalloc
+import unittest
+
+import numpy as np
+
+from tests.heavy_tests import heavy
+
+_IN2 = "tests/rpa/input_2orb"
+
+
+def _kw(**over):
+    kw = dict(nmat=8, nvol=16, norb=2, B=3, depth=0, output_full=False, split_seed=False,
+              n_types=1, freq_batch=None, cap_gb=8.0, mixing="linear")
+    kw.update(over)
+    return kw
+
+
+class TestEstimate(unittest.TestCase):
+
+    def test_rows_follow_the_table(self):
+        from hwave.solver.flex_bond import estimate_bond_memory
+        est = estimate_bond_memory(**_kw(depth=4, mixing="anderson", output_full=True, split_seed=True,
+                                         n_types=2))
+        nmat, nvol, norb, B = 8, 16, 2, 3
+        P = norb ** 2; ND = B * P
+        U = nmat * nvol * ND * ND * 16; G = nmat * nvol * P * 16; C = nmat * nvol * P * P * 16
+        S = nvol * ND * ND * 16; H = nvol * P * 16
+        pr = est["persistent_rows"]
+        self.assertEqual(pr["chibar_W"], 2 * U)
+        self.assertEqual(pr["chi_sc_w"], 2 * U)
+        self.assertEqual(pr["vertices_static"], 5 * S)
+        self.assertEqual(pr["state"], G + H)
+        self.assertEqual(pr["seed_envelope"], 2 * G + H)
+        self.assertEqual(pr["anderson_history"], 2 * 4 * 2 * G)
+        self.assertEqual(pr["collapses"], 3 * C)
+        self.assertEqual(pr["eigenpairs_hf"], 5 * H)
+        self.assertEqual(pr["flex_arrays"], 5 * G)
+        self.assertEqual(pr["hf_tables"], 2 * H)
+        self.assertEqual(est["persistent"], sum(pr.values()))
+        ph = est["phase_rows"]
+        self.assertEqual(ph["green_mu"], 6 * G + H)
+        self.assertEqual(ph["density_hf"], 31 * H)
+        prep = 16 * nvol * (ND ** 2 + 4 * P * (nmat + 2))
+        pair = 16 * nvol * (2 * ND ** 2 + 3 * nmat * P ** 2 + 2 * nmat * P + 8 * P)
+        self.assertEqual(ph["bubble"], max(prep, pair))
+        self.assertEqual(ph["dressing"], 6 * est["nb"] * nvol * ND * ND * 16)
+        self.assertEqual(ph["transport"], 4 * G + 4 * C)
+        self.assertEqual(ph["convergence"], 6 * G + H)
+        self.assertEqual(ph["mixing"], 2 * 4 * 2 * G + 4 * G)
+        self.assertEqual(ph["post_scf"], G + U)
+        self.assertEqual(est["nb"], nmat)
+        self.assertAlmostEqual(est["peak"], 1.25 * (est["persistent"] + max(ph.values())))
+
+    def test_nb_selection_and_refusal(self):
+        from hwave.solver.flex_bond import estimate_bond_memory
+        big = estimate_bond_memory(**_kw())
+        nvol, ND = 16, 12
+        per_batch = 6 * nvol * ND * ND * 16
+        others = max(v for k, v in big["phase_rows"].items() if k != "dressing")
+        # a cap that admits exactly three batches worth of dressing
+        cap = 1.25 * (big["persistent"] + max(others, 3 * per_batch)) / 1024 ** 3
+        est = estimate_bond_memory(**_kw(cap_gb=cap * (1 + 1e-9)))
+        self.assertEqual(est["nb"], 3 if 3 * per_batch >= others else 8)
+        est = estimate_bond_memory(**_kw(cap_gb=cap * (1 + 1e-9), freq_batch=2))
+        self.assertEqual(est["nb"], 2)
+        with self.assertRaises(ValueError) as cm:
+            estimate_bond_memory(**_kw(cap_gb=cap * (1 + 1e-9), freq_batch=8))
+        self.assertIn("longitudinal_bond_freq_batch", str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            estimate_bond_memory(**_kw(cap_gb=1e-6))
+        msg = str(cm.exception)
+        for row in ("chibar_W", "green_mu", "dressing", "transport", "post_scf", "GiB"):
+            self.assertIn(row, msg)
+
+    def test_operation_formulas(self):
+        from hwave.solver.flex_bond import dressing_ops, transport_ops
+        self.assertEqual(dressing_ops(8, 16, 12), 2 * 8 * 16 * 12 ** 3)
+        P = 4
+        self.assertAlmostEqual(transport_ops(3, 8, 16, 2),
+                               9 * 8 * 16 * (P ** 2 * np.log2(8 * 16) + P ** 3))
+
+
+def _solver(param_extra=None, inter=None):
+    import hwave.qlmsio.read_input_k as read_input_k
+    import hwave.solver.flex as flex_mod
+    idict = {"path_to_input": _IN2, "Geometry": "geom.dat", "Transfer": "transfer.dat"}
+    idict.update({"CoulombInter": "coulombinter.dat"} if inter is None else inter)
+    r = read_input_k.QLMSkInput({"path_to_input": _IN2, "interaction": idict})
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": 8, "IterationMax": 2, "Mix": 0.5, "EPS": 1e-12,
+           "flex_hartree_fock": True, "longitudinal_bond_channels": True}
+    par.update(param_extra or {})
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+class _Tracer:
+    """``solver._phase_tracer``: per-phase tracemalloc peak increments."""
+
+    def __init__(self):
+        self.peaks = {}
+
+    def __call__(self, name):
+        tracer = self
+
+        class _Ctx:
+            def __enter__(self_):
+                tracemalloc.reset_peak()
+                self_.start = tracemalloc.get_traced_memory()[0]
+                return self_
+
+            def __exit__(self_, *exc):
+                peak = tracemalloc.get_traced_memory()[1]
+                tracer.peaks[name] = max(tracer.peaks.get(name, 0), peak - self_.start)
+                return False
+        return _Ctx()
+
+
+class TestSolverPreflight(unittest.TestCase):
+
+    def test_operation_warnings_are_logged(self):
+        import hwave.solver.flex_bond as fb
+        s, r = _solver()
+        old = fb._DRESSING_OPS_WARN, fb._TRANSPORT_OPS_WARN
+        fb._DRESSING_OPS_WARN, fb._TRANSPORT_OPS_WARN = 1.0, 1.0
+        try:
+            with self.assertLogs("hwave.solver.flex", level="WARNING") as cm:
+                s._phase_b_reset({})
+                s._phase_b_preflight(r.get_param("green"))
+        finally:
+            fb._DRESSING_OPS_WARN, fb._TRANSPORT_OPS_WARN = old
+        text = "\n".join(cm.output)
+        self.assertIn("dense", text)
+        self.assertIn("transport", text)
+
+    def _run_traced(self, param_extra, green_extra=None):
+        s, r = _solver(param_extra)
+        gi = r.get_param("green")
+        gi.update(green_extra or {})
+        tracer = _Tracer()
+        s._phase_tracer = tracer
+        tracemalloc.start()
+        try:
+            with tempfile.TemporaryDirectory() as out:
+                s.solve(gi, out)
+        finally:
+            tracemalloc.stop()
+        return s, tracer
+
+    def test_preflight_rows_match_tracemalloc_per_phase(self):
+        for mixing in ("linear", "anderson"):
+            with self.subTest(mixing=mixing):
+                s, tracer = self._run_traced({"mixing_scheme": mixing, "anderson_depth": 3,
+                                              "longitudinal_bond_output_full": True})
+                est = s._bond_est
+                self.assertTrue(tracer.peaks, "no phase was traced")
+                for name, measured in tracer.peaks.items():
+                    self.assertIn(name, est["phase_rows"])
+                    bound = est["phase_rows"][name] + est["persistent"]
+                    self.assertLessEqual(measured, bound,
+                                         "phase {} measured {} > row {} + persistent {}".format(
+                                             name, measured, est["phase_rows"][name], est["persistent"]))
+                self.assertGreaterEqual(len(tracer.peaks), 7)
+
+    def test_tracer_invariant_split_warm_start(self):
+        import hwave.solver.flex as flex_mod
+        s, r = _solver({"IterationMax": 1})
+        gi = r.get_param("green")
+        with tempfile.TemporaryDirectory() as out:
+            s.solve(gi, out)
+            s.save_results({"path_to_output": out, "sigma": "sigma.npz"}, gi)
+            s2, r2 = _solver({"IterationMax": 1})
+            gi2 = r2.get_param("green")
+            gi2.update(s2.read_init({"path_to_input": out, "sigma_init": "sigma.npz"}))
+            tracer = _Tracer()
+            s2._phase_tracer = tracer
+            tracemalloc.start()
+            try:
+                s2.solve(gi2, out)
+            finally:
+                tracemalloc.stop()
+        est = s2._bond_est
+        self.assertEqual(est["persistent_rows"]["seed_envelope"] > 0, True)
+        for name, measured in tracer.peaks.items():
+            self.assertLessEqual(measured, est["phase_rows"][name] + est["persistent"], name)
+
+
+_RSS_SCRIPT = r"""
+import json, resource, sys, tempfile
+import hwave.qlmsio.read_input_k as read_input_k
+import hwave.solver.flex as flex_mod
+solve = sys.argv[1] == "solve"
+idict = {"path_to_input": "tests/rpa/input_2orb", "Geometry": "geom.dat", "Transfer": "transfer.dat",
+         "CoulombInter": "coulombinter.dat"}
+r = read_input_k.QLMSkInput({"path_to_input": "tests/rpa/input_2orb", "interaction": idict})
+par = {"T": 2.0, "filling": 0.5, "CellShape": [6, 6, 1], "SubShape": [1, 1, 1], "Nmat": 64,
+       "IterationMax": 3, "Mix": 0.5, "EPS": 1e-12, "flex_hartree_fock": True,
+       "longitudinal_bond_channels": True, "longitudinal_bond_output_full": True,
+       "mixing_scheme": "anderson", "anderson_depth": 8}
+info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+s = flex_mod.FLEX(r.get_param("ham"), {}, info)
+gi = r.get_param("green")
+peak = None
+if solve:
+    with tempfile.TemporaryDirectory() as out:
+        s.solve(gi, out)
+        s.save_results({"path_to_output": out, "sigma": "sigma.npz", "green": "green.npz"}, gi)
+    peak = s._bond_est["peak"]
+rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+if sys.platform != "darwin":
+    rss *= 1024
+print(json.dumps({"rss": rss, "peak": peak}))
+"""
+
+
+class TestSubprocessRSS(unittest.TestCase):
+    #: incremental regression bound (gated peak RSS minus the calibrated
+    #: baseline), calibrated 2026-09-06 on the 6x6, Nmat=64, depth-8,
+    #: output_full case (measured: baseline 80 MiB, gated 238 MiB, estimate
+    #: 186 MiB, increment 158 MiB); 20 % slack is applied in the assertion.
+    INCREMENT_BOUND_BYTES = 165 * 1024 ** 2
+
+    @heavy
+    def test_subprocess_rss_below_estimate_plus_allowance(self):
+        env = dict(os.environ, PYTHONPATH="src:.")
+
+        def _run(kind):
+            out = subprocess.run([sys.executable, "-B", "-c", _RSS_SCRIPT, kind], env=env,
+                                 capture_output=True, text=True, check=True)
+            line = [ln for ln in out.stdout.splitlines() if ln.startswith("{")][-1]
+            return json.loads(line)
+        base = _run("baseline")
+        gated = _run("solve")
+        logging.getLogger("qlms").info("RSS baseline %.1f MiB, gated %.1f MiB, estimate %.1f MiB",
+                                       base["rss"] / 2 ** 20, gated["rss"] / 2 ** 20,
+                                       gated["peak"] / 2 ** 20)
+        self.assertLess(gated["rss"], gated["peak"] + base["rss"])
+        self.assertLess(gated["rss"] - base["rss"], 1.2 * self.INCREMENT_BOUND_BYTES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_bond_memory.py
+++ b/tests/test_flex_bond_memory.py
@@ -42,6 +42,7 @@ class TestEstimate(unittest.TestCase):
         self.assertEqual(pr["state"], G + H)
         self.assertEqual(pr["seed_envelope"], 2 * G + H)
         self.assertEqual(pr["anderson_history"], 2 * 4 * 2 * G)
+        self.assertEqual(pr["anderson_work"], 2 * 3 * 2 * G)
         self.assertEqual(pr["collapses"], 3 * C)
         self.assertEqual(pr["eigenpairs_hf"], 5 * H)
         self.assertEqual(pr["flex_arrays"], 5 * G)
@@ -49,14 +50,14 @@ class TestEstimate(unittest.TestCase):
         self.assertEqual(est["persistent"], sum(pr.values()))
         ph = est["phase_rows"]
         self.assertEqual(ph["green_mu"], 6 * G + H)
-        self.assertEqual(ph["density_hf"], 31 * H)
+        self.assertEqual(ph["density_hf"], 2 * G + 35 * H)
         prep = 16 * nvol * (ND ** 2 + 4 * P * (nmat + 2))
         pair = 16 * nvol * (2 * ND ** 2 + 3 * nmat * P ** 2 + 2 * nmat * P + 8 * P)
         self.assertEqual(ph["bubble"], max(prep, pair))
         self.assertEqual(ph["dressing"], 6 * est["nb"] * nvol * ND * ND * 16)
         self.assertEqual(ph["transport"], 4 * G + 4 * C)
-        self.assertEqual(ph["convergence"], 6 * G + H)
-        self.assertEqual(ph["mixing"], 2 * 4 * 2 * G + 4 * G)
+        self.assertEqual(ph["convergence"], 7 * G + H)
+        self.assertEqual(ph["mixing"], 4 * G)
         self.assertEqual(ph["post_scf"], G + U)
         self.assertEqual(est["nb"], nmat)
         self.assertAlmostEqual(est["peak"], 1.25 * (est["persistent"] + max(ph.values())))
@@ -104,11 +105,27 @@ def _solver(param_extra=None, inter=None):
     return flex_mod.FLEX(r.get_param("ham"), {}, info), r
 
 
-class _Tracer:
-    """``solver._phase_tracer``: per-phase tracemalloc peak increments."""
+def _preimport():
+    """Import everything the solve imports lazily, so that module objects do
+    not count as solve memory."""
+    import scipy.fft, scipy.linalg  # noqa: F401
+    from hwave.solver import (flex_bond, flex_hf, flex_mixing, hartree_fock, bubble,  # noqa: F401
+                              bond_channels, offsite, matsubara, backend, vertex_table)
+    from hwave.solver import _sc_matrices_myo  # noqa: F401
+    import hwave.sc  # noqa: F401
 
-    def __init__(self):
+
+class _Tracer:
+    """``solver._phase_tracer``: per-phase tracemalloc peaks measured from
+    the traced memory at SOLVE entry (``base``), so every buffer the solve
+    allocates -- persistent ones included, also those a phase allocates
+    for the first time such as the Anderson stacks -- counts, while the
+    process's pre-solve state does not. The invariant compares each phase
+    with persistent + its row."""
+
+    def __init__(self, base=0):
         self.peaks = {}
+        self.base = base
 
     def __call__(self, name):
         tracer = self
@@ -121,7 +138,7 @@ class _Tracer:
 
             def __exit__(self_, *exc):
                 peak = tracemalloc.get_traced_memory()[1]
-                tracer.peaks[name] = max(tracer.peaks.get(name, 0), peak - self_.start)
+                tracer.peaks[name] = max(tracer.peaks.get(name, 0), peak - tracer.base)
                 return False
         return _Ctx()
 
@@ -147,11 +164,13 @@ class TestSolverPreflight(unittest.TestCase):
         s, r = _solver(param_extra)
         gi = r.get_param("green")
         gi.update(green_extra or {})
+        _preimport()
         tracer = _Tracer()
         s._phase_tracer = tracer
         tracemalloc.start()
         try:
             with tempfile.TemporaryDirectory() as out:
+                tracer.base = tracemalloc.get_traced_memory()[0]
                 s.solve(gi, out)
         finally:
             tracemalloc.stop()
@@ -166,10 +185,10 @@ class TestSolverPreflight(unittest.TestCase):
                 self.assertTrue(tracer.peaks, "no phase was traced")
                 for name, measured in tracer.peaks.items():
                     self.assertIn(name, est["phase_rows"])
-                    bound = est["phase_rows"][name] + est["persistent"]
+                    bound = est["persistent"] + est["phase_rows"][name]
                     self.assertLessEqual(measured, bound,
-                                         "phase {} measured {} > row {} + persistent {}".format(
-                                             name, measured, est["phase_rows"][name], est["persistent"]))
+                                         "phase {} peak since solve entry {} > persistent {} + row {}".format(
+                                             name, measured, est["persistent"], est["phase_rows"][name]))
                 self.assertGreaterEqual(len(tracer.peaks), 7)
 
     def test_tracer_invariant_split_warm_start(self):
@@ -182,17 +201,19 @@ class TestSolverPreflight(unittest.TestCase):
             s2, r2 = _solver({"IterationMax": 1})
             gi2 = r2.get_param("green")
             gi2.update(s2.read_init({"path_to_input": out, "sigma_init": "sigma.npz"}))
+            _preimport()
             tracer = _Tracer()
             s2._phase_tracer = tracer
             tracemalloc.start()
             try:
+                tracer.base = tracemalloc.get_traced_memory()[0]
                 s2.solve(gi2, out)
             finally:
                 tracemalloc.stop()
         est = s2._bond_est
         self.assertEqual(est["persistent_rows"]["seed_envelope"] > 0, True)
         for name, measured in tracer.peaks.items():
-            self.assertLessEqual(measured, est["phase_rows"][name] + est["persistent"], name)
+            self.assertLessEqual(measured, est["persistent"] + est["phase_rows"][name], name)
 
 
 _RSS_SCRIPT = r"""

--- a/tests/test_flex_bond_onari_trend.py
+++ b/tests/test_flex_bond_onari_trend.py
@@ -1,0 +1,134 @@
+"""Onari-type trend milestone of the bond-resolved Hartree-Fock FLEX (#181
+Phase B, spec 2026-09-06 section 5): the f-like triplet eigenvalue
+``lambda_t`` of the EXISTING static bond Eliashberg chain, fed with the
+Phase B ``green.npz`` of each V, rises monotonically with the inter-site
+V on the single-band Onari case; every SCF converged by the three-residual
+rule with the density closure ``hf_density_error < 1e-6``; a cold start
+and a warm start from the adjacent V agree at the two points nearest the
+d-to-f crossing (no metastable SCF branch).
+
+Setting and generator: ``tests/sc/onari_bond/generate_flex_bond_fixtures.py``
+(``U = 4``, ``n = 0.7``, ``T = 0.02``, ``L = 16``, ``Nmat = 2048``, Anderson
+depth 8, ``Mix = 0.2``, ``EPS = 8``, ``IterationMax = 1500``).  The Green
+functions are NOT committed; the compact observables file
+``tests/sc/onari_bond/flex_bond_observables.json`` is.  By default this
+module verifies that file against the pinned tables below; with
+``HWAVE_RUN_SLOW_FIXTURES=1`` it regenerates every Green function (hours)
+and re-derives the observables.
+"""
+import json
+import os
+import unittest
+
+import numpy as np
+
+import hwave.sc as sc
+from hwave.solver import bond_channels as bc
+from tests.heavy_tests import heavy
+from tests.test_bond_onari_milestone import (_odd_spectrum, _kgrid, _interactions, DEG_TOL,
+                                             BETA, LAMBDA_RTOL, ATOL_MONO)
+
+_SLOW_ENV = "HWAVE_RUN_SLOW_FIXTURES"
+FIXTURE_DIR = os.path.join("tests", "sc", "onari_bond")
+OBSERVABLES = os.path.join(FIXTURE_DIR, "flex_bond_observables.json")
+
+#: tracked f-like triplet lambda_t of the Phase B greens (cold starts),
+#: recorded from the generator run of 2026-09-06 (see the observables file;
+#: every point converged in 10-25 iterations from the legacy seed, the warm
+#: starts at V = 1.0 and 1.2 agree with the cold ones to 1e-9 relative).
+LAMBDA_FLEX_BOND_16 = {
+    "0.00": 0.07975703202716758,
+    "0.40": 0.08178290472738786,
+    "0.80": 0.09940861974554759,
+    "1.00": 0.13084753641943114,
+    "1.20": 0.20422236554811116,
+}
+HF_DENSITY_TOL = 1.0e-6
+
+
+def _point_from_green(green_path, V):
+    """One bond-path point from a Phase B green (sc layout), built by the
+    production ``sc._build_bond_operator`` exactly as the milestone does."""
+    raw = np.load(green_path)["green"]
+    nmat = raw.shape[1]
+    Lg = int(round(np.sqrt(raw.shape[2])))
+    green = raw[0].reshape(nmat, Lg, Lg, 1, 1, 1).transpose(4, 5, 1, 2, 3, 0).copy()
+    kx, ky, kz = _kgrid(Lg)
+    it = _interactions(V, True)
+    inter_k = sc._build_interaction_k(kx, ky, kz, it, 1)
+    bond_set = bc.resolve_interactions(it.get("CoulombInter", {}), np.eye(3), 1)
+    carrier = sc._BondGreen(full_sc=green, deflated_kw=sc._green_sc_to_canonical(green),
+                            green0_tail=None, coeff_tail_requested=0.0, coeff_tail_applied=0.0,
+                            source="external_npz")
+    (A, vec_size), provenance, attribution = sc._build_bond_operator(
+        bond_set, carrier, it, inter_k, {"norb": 1, "rvec": np.eye(3)}, 1, kx, ky, kz, BETA,
+        "triplet", bond_max_shells=None, bond_memory_cap_gb=0.0, g2_tail=False)
+    evals, vecs = _odd_spectrum(A, vec_size, attribution["weight"], Lg)
+    return {"evals": evals, "vecs": vecs, "weight": attribution["weight"], "L": Lg}
+
+
+def lambda_sweep(green_paths, v_grid):
+    """Invariant-subspace-tracked lambda_t along ``v_grid`` (milestone
+    tracking: f_x seed, odd harmonic basis)."""
+    points = [_point_from_green(p, V) for p, V in zip(green_paths, v_grid)]
+    Lg = points[0]["L"]
+    kx, ky, kz = _kgrid(Lg)
+    seed = sc._initialize_gap("f_x", 1, kx, ky, kz).ravel()
+    basis = sc._odd_harmonic_basis(1, kx, ky, kz)
+    records = bc.track_subspace([(p["evals"], p["vecs"]) for p in points], seed=seed,
+                                weight=points[0]["weight"], basis=basis, deg_tol=DEG_TOL,
+                                capture_tol=0.2)
+    return {"lambda": [float(r["lambda"]) for r in records],
+            "tracking": [{"V": float(V), "dim": int(r["dim"]), "overlap": float(r.get("overlap", 1.0))}
+                         for V, r in zip(v_grid, records)]}
+
+
+def _accept(obs, testcase):
+    """The acceptance rules on an observables dict (committed or fresh)."""
+    from tests.sc.onari_bond import generate_flex_bond_fixtures as gen
+    testcase.assertEqual(obs["settings"], json.loads(json.dumps(gen.SETTINGS)))
+    v_grid = [float(v) for v in obs["settings"]["V_grid"]]
+    eps = 10.0 ** (-obs["settings"]["EPS"])
+    for rec in obs["records"]:
+        testcase.assertTrue(rec["scf_converged"], rec)
+        for k in ("scf_sigma_residual", "scf_green_residual", "scf_component_residual"):
+            testcase.assertLess(rec[k], eps, (rec["V"], rec["seed"], k))
+        testcase.assertLess(rec["hf_density_error"], HF_DENSITY_TOL, (rec["V"], rec["seed"]))
+        testcase.assertGreater(min(rec["cond_min_s"], rec["cond_min_c"]), 0.0)
+    lam = [obs["lambda_t"]["cold"]["{:.2f}".format(V)] for V in v_grid]
+    for i in range(1, len(lam)):
+        testcase.assertGreaterEqual(lam[i], lam[i - 1] - ATOL_MONO,
+                                    "lambda_t not monotone at V={}".format(v_grid[i]))
+    testcase.assertGreater(lam[-1], lam[0])
+    for tr in obs["tracking"]:
+        testcase.assertEqual(tr["dim"], 2)
+    for key, lw in obs["lambda_t"]["warm"].items():
+        lc = obs["lambda_t"]["cold"][key]
+        testcase.assertLess(abs(lw - lc), LAMBDA_RTOL * abs(lc), "two-seed check at V={}".format(key))
+    return lam, v_grid
+
+
+class TestFlexBondOnariTrend(unittest.TestCase):
+
+    def test_committed_observables_pass_the_acceptance(self):
+        with open(OBSERVABLES) as f:
+            obs = json.load(f)
+        lam, v_grid = _accept(obs, self)
+        for V, value in zip(v_grid, lam):
+            ref = LAMBDA_FLEX_BOND_16["{:.2f}".format(V)]
+            self.assertLess(abs(value - ref), LAMBDA_RTOL * abs(ref), "V={}".format(V))
+
+    @heavy
+    def test_regenerated_greens_reproduce_the_pinned_lambda(self):
+        if os.environ.get(_SLOW_ENV, "").strip().lower() in ("", "0", "false", "no", "off"):
+            self.skipTest("set {}=1 to regenerate the Phase B Onari greens (hours)".format(_SLOW_ENV))
+        from tests.sc.onari_bond import generate_flex_bond_fixtures as gen
+        obs = gen.generate(gen.DEFAULT_DIR)
+        lam, v_grid = _accept(obs, self)
+        for V, value in zip(v_grid, lam):
+            ref = LAMBDA_FLEX_BOND_16["{:.2f}".format(V)]
+            self.assertLess(abs(value - ref), LAMBDA_RTOL * abs(ref), "V={}".format(V))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_bond_onari_trend.py
+++ b/tests/test_flex_bond_onari_trend.py
@@ -11,7 +11,9 @@ Setting and generator: ``tests/sc/onari_bond/generate_flex_bond_fixtures.py``
 (``U = 4``, ``n = 0.7``, ``T = 0.02``, ``L = 16``, ``Nmat = 2048``, Anderson
 depth 8, ``Mix = 0.2``, ``EPS = 8``, ``IterationMax = 1500``).  The Green
 functions are NOT committed; the compact observables file
-``tests/sc/onari_bond/flex_bond_observables.json`` is.  By default this
+``tests/sc/onari_bond/flex_bond_observables.json`` is (its per-file SHA-256
+values are informational: neither FLEX nor ``np.savez_compressed`` is
+bit-reproducible, so the physics is pinned by the lambda table, not by hashes).  By default this
 module verifies that file against the pinned tables below; with
 ``HWAVE_RUN_SLOW_FIXTURES=1`` it regenerates every Green function (hours)
 and re-derives the observables.

--- a/tests/test_flex_bond_sigma_transport.py
+++ b/tests/test_flex_bond_sigma_transport.py
@@ -1,6 +1,6 @@
 """The bond-aware self-energy transport (spec 2026-09-06 section 3.4) and
 gate G1: the B = 1 reduction to the general path and the direct-sum
-oracle in (k, q, tau) space with explicit external-leg phases."""
+oracle in (k, q, tau) space with the explicit internal-leg bond phase."""
 import unittest
 
 import numpy as np

--- a/tests/test_flex_bond_sigma_transport.py
+++ b/tests/test_flex_bond_sigma_transport.py
@@ -1,0 +1,147 @@
+"""The bond-aware self-energy transport (spec 2026-09-06 section 3.4) and
+gate G1: the B = 1 reduction to the general path and the direct-sum
+oracle in (k, q, tau) space with explicit external-leg phases."""
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN2 = "tests/rpa/input_2orb"
+
+
+def _flex():
+    import hwave.solver.flex as flex_mod
+    idict = {"path_to_input": _IN2, "Geometry": "geom.dat", "Transfer": "transfer.dat",
+             "CoulombInter": "coulombinter.dat"}
+    r = read_input_k.QLMSkInput({"path_to_input": _IN2, "interaction": idict})
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": 8, "IterationMax": 1, "Mix": 1.0, "EPS": 1}
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+def _green(s, beta):
+    nmat, nvol, norb = s.nmat, s.lattice.nvol, s.norb
+    return s._calc_dressed_green(beta, 0.1, np.zeros((1, nmat, nvol, norb, norb), complex))
+
+
+class TestTransport(unittest.TestCase):
+
+    def test_b1_reduces_to_calc_self_energy_general(self):
+        from hwave.solver import bond_channels as bc
+        from hwave.solver.flex_bond import BondBlockStore, calc_self_energy_bond
+        s, _ = _flex()
+        import os; os.makedirs("tests/flex/output", exist_ok=True)
+        nmat, nvol, norb, nd = s.nmat, s.lattice.nvol, s.norb, s.norb ** 2
+        beta = 0.5
+        rng = np.random.default_rng(0)
+        W = rng.normal(size=(nmat, nvol, nd, nd)) + 1j * rng.normal(size=(nmat, nvol, nd, nd))
+        topo = bc.resolve_bond_topology({}, np.eye(3), norb, active_types=bc._LONGITUDINAL_ACTIVE_TYPES)
+        view = bc.BondSetView(topo)
+        s._calc_epsilon_k({})
+        G = _green(s, beta)
+        with BondBlockStore(nmat, nvol, nd, nd, ("W",)) as store:
+            store.put_freq_batch("W", 0, nmat, W)
+            sig = calc_self_energy_bond(store, G, beta, view, (4, 4, 1), norb, 1)
+        ref = s._calc_self_energy_general(G, W, beta)
+        np.testing.assert_array_equal(sig, ref)
+
+    def test_g1_direct_sum_oracle(self):
+        """4x4, norb = 2, nmat = 8, B = 5 (declared +-x, +-y), complex hopping,
+        a random non-symmetric W: the (k, q, tau) oracle with explicit
+        phases e^{+ik.R_alpha} e^{-i(k-q).R_beta} and k - q reduced modulo
+        the mesh equals the production transport."""
+        from hwave.solver import bond_channels as bc
+        from hwave.solver.flex_bond import BondBlockStore, calc_self_energy_bond
+        from hwave.solver import matsubara as _ms
+        s, _ = _flex()
+        s._calc_epsilon_k({})
+        nmat, nvol, norb, nd = s.nmat, s.lattice.nvol, s.norb, s.norb ** 2
+        nx, ny, nz = 4, 4, 1
+        beta = 0.5
+        decl = {"CoulombInter": {((1, 0, 0), (0, 1)): 0.3, ((-1, 0, 0), (1, 0)): 0.3,
+                                 ((0, 1, 0), (0, 0)): 0.2, ((0, -1, 0), (0, 0)): 0.2}}
+        topo = bc.resolve_bond_topology(decl, np.eye(3), norb, active_types=bc._LONGITUDINAL_ACTIVE_TYPES)
+        view = bc.BondSetView(topo)
+        B = view.n_channels; ND = B * nd
+        rng = np.random.default_rng(1)
+        W = rng.normal(size=(nmat, nvol, ND, ND)) + 1j * rng.normal(size=(nmat, nvol, ND, ND))
+        G = _green(s, beta)                                    # (1, nmat, nvol, norb, norb)
+        with BondBlockStore(nmat, nvol, ND, nd, ("W",)) as store:
+            store.put_freq_batch("W", 0, nmat, W)
+            sig = calc_self_energy_bond(store, G, beta, view, (nx, ny, nz), norb, 1)
+        # ---- oracle: tau-space product, explicit k, q sums and phases ----
+        kx = 2 * np.pi * np.arange(nx) / nx; ky = 2 * np.pi * np.arange(ny) / ny
+        kvec = np.array([(kx[i], ky[j], 0.0) for i in range(nx) for j in range(ny) for _ in range(nz)])
+        G_t = _ms.fermion_to_tau(G[0].reshape(nmat, nvol * norb * norb), axis=0).reshape(nmat, nvol, norb, norb)
+        W_t = _ms.boson_to_tau(W.reshape(nmat, nvol * ND * ND), axis=0).reshape(nmat, nvol, B, nd, B, nd)
+        idx = np.arange(nvol).reshape(nx, ny, nz)
+        sig_t = np.zeros((nmat, nvol, norb, norb), complex)
+        R = np.array(view.delta_r)                             # (B, 3)
+        for k in range(nvol):
+            ik = np.unravel_index(k, (nx, ny, nz))
+            for q in range(nvol):
+                iq = np.unravel_index(q, (nx, ny, nz))
+                kmq = idx[(ik[0] - iq[0]) % nx, (ik[1] - iq[1]) % ny, (ik[2] - iq[2]) % nz]
+                kk = kvec[k]; kq = kvec[kmq]
+                for a_ in range(B):
+                    for b_ in range(B):
+                        ph = np.exp(1j * kk @ R[a_]) * np.exp(-1j * kq @ R[b_])
+                        Wblk = W_t[:, q, a_, :, b_, :].reshape(nmat, norb, norb, norb, norb)   # (t, c, a, d, b)
+                        sig_t[:, k] += ph * np.einsum('tcadb,tcd->tab', Wblk, G_t[:, kmq])
+        sig_t /= nvol
+        ref = _ms.tau_to_fermion(sig_t.reshape(nmat, nvol * norb * norb), axis=0).reshape(1, nmat, nvol, norb, norb) / beta
+        np.testing.assert_allclose(sig, ref, rtol=1e-10, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestFrequencyOracleSanity(unittest.TestCase):
+
+    def test_large_nmat_frequency_oracle_sanity(self):
+        """Pure-frequency oracle with the naive index difference n - l at
+        nmat = 256 (wrap terms negligible; loose tolerance), B = 2, 2x2 mesh."""
+        from hwave.solver import bond_channels as bc
+        from hwave.solver.flex_bond import BondBlockStore, calc_self_energy_bond
+        nmat, nx, ny, nz, norb = 256, 2, 2, 1, 1
+        nvol, nd = nx * ny * nz, 1
+        beta = 4.0
+        decl = {"CoulombInter": {((1, 0, 0), (0, 0)): 0.3, ((-1, 0, 0), (0, 0)): 0.3}}
+        topo = bc.resolve_bond_topology(decl, np.eye(3), norb, active_types=bc._LONGITUDINAL_ACTIVE_TYPES)
+        view = bc.BondSetView(topo)
+        B = view.n_channels; ND = B * nd
+        wn = (2 * np.arange(nmat) + 1 - nmat) * np.pi / beta
+        nu = (2 * np.arange(nmat) - nmat) * np.pi / beta
+        ek = np.array([-0.5, 0.2, 0.2, 0.9])
+        G = 1.0 / (1j * wn[:, None] - ek[None, :])                       # (nmat, nvol)
+        G5 = G.reshape(1, nmat, nvol, 1, 1)
+        rng = np.random.default_rng(3)
+        amp = rng.normal(size=(nvol, ND, ND)) + 1j * rng.normal(size=(nvol, ND, ND))
+        W = amp[None] / (1.0 + nu[:, None, None, None] ** 2)             # decays ~ 1/nu^2
+        with BondBlockStore(nmat, nvol, ND, nd, ("W",)) as store:
+            store.put_freq_batch("W", 0, nmat, W)
+            sig = calc_self_energy_bond(store, G5, beta, view, (nx, ny, nz), norb, 1)[0, :, :, 0, 0]
+        kx = 2 * np.pi * np.arange(nx) / nx; ky = 2 * np.pi * np.arange(ny) / ny
+        kvec = np.array([(kx[i], ky[j], 0.0) for i in range(nx) for j in range(ny)])
+        idx = np.arange(nvol).reshape(nx, ny)
+        R = np.array(view.delta_r)
+        ref = np.zeros((nmat, nvol), complex)
+        for k in range(nvol):
+            ik = np.unravel_index(k, (nx, ny))
+            for q in range(nvol):
+                iq = np.unravel_index(q, (nx, ny))
+                kmq = idx[(ik[0] - iq[0]) % nx, (ik[1] - iq[1]) % ny]
+                for a_ in range(B):
+                    for b_ in range(B):
+                        ph = np.exp(1j * kvec[k] @ R[a_]) * np.exp(-1j * kvec[kmq] @ R[b_])
+                        for n in range(nmat):
+                            for l in range(nmat):
+                                m = n - l + nmat // 2          # w_n - nu_l -> index n - l + nmat/2
+                                if 0 <= m < nmat:
+                                    ref[n, k] += ph * W[l, q, a_, b_] * G[m, kmq]
+        ref /= beta * nvol
+        mid = slice(nmat // 2 - 8, nmat // 2 + 8)
+        np.testing.assert_allclose(sig[mid], ref[mid], rtol=1e-3, atol=1e-6)

--- a/tests/test_flex_bond_sigma_transport.py
+++ b/tests/test_flex_bond_sigma_transport.py
@@ -78,7 +78,7 @@ class TestTransport(unittest.TestCase):
     def test_g1_direct_sum_oracle(self):
         """4x4, norb = 2, nmat = 8, B = 5 (declared +-x, +-y), complex hopping,
         a random non-symmetric W: the (k, q, tau) oracle with the explicit
-        bond form factor e^{+i(k-q).(R_alpha - R_beta)} on the internal leg
+        bond form factor e^{+i(k-q).(R_beta - R_alpha)} on the internal leg
         and k - q reduced modulo the mesh equals the production transport."""
         from hwave.solver import bond_channels as bc
         from hwave.solver.flex_bond import BondBlockStore, calc_self_energy_bond
@@ -115,7 +115,7 @@ class TestTransport(unittest.TestCase):
                 kk = kvec[k]; kq = kvec[kmq]
                 for a_ in range(B):
                     for b_ in range(B):
-                        ph = np.exp(1j * kq @ (R[a_] - R[b_]))
+                        ph = np.exp(1j * kq @ (R[b_] - R[a_]))
                         Wblk = W_t[:, q, a_, :, b_, :].reshape(nmat, norb, norb, norb, norb)   # (t, c, a, d, b)
                         sig_t[:, k] += ph * np.einsum('tcadb,tcd->tab', Wblk, G_t[:, kmq])
         sig_t /= nvol
@@ -164,7 +164,7 @@ class TestFrequencyOracleSanity(unittest.TestCase):
                 kmq = idx[(ik[0] - iq[0]) % nx, (ik[1] - iq[1]) % ny]
                 for a_ in range(B):
                     for b_ in range(B):
-                        ph = np.exp(1j * kvec[kmq] @ (R[a_] - R[b_]))
+                        ph = np.exp(1j * kvec[kmq] @ (R[b_] - R[a_]))
                         for n in range(nmat):
                             for l in range(nmat):
                                 m = n - l + nmat // 2          # w_n - nu_l -> index n - l + nmat/2

--- a/tests/test_flex_bond_sigma_transport.py
+++ b/tests/test_flex_bond_sigma_transport.py
@@ -47,11 +47,39 @@ class TestTransport(unittest.TestCase):
         ref = s._calc_self_energy_general(G, W, beta)
         np.testing.assert_array_equal(sig, ref)
 
+    def test_hermitian_consistency_of_the_transport(self):
+        """Sigma(k, iw)^dagger == Sigma(k, -iw) to round-off for a W with the
+        bubble's conjugation symmetry W(q, i nu)^dagger = W(q, -i nu); the
+        mixed-leg phase assignment breaks this at O(1e-3)."""
+        from hwave.solver import bond_channels as bc
+        from hwave.solver.flex_bond import BondBlockStore, calc_self_energy_bond
+        s, _ = _flex()
+        s._calc_epsilon_k({})
+        nmat, nvol, norb, nd = s.nmat, s.lattice.nvol, s.norb, s.norb ** 2
+        decl = {"CoulombInter": {((1, 0, 0), (0, 1)): 0.3, ((-1, 0, 0), (1, 0)): 0.3,
+                                 ((0, 1, 0), (0, 0)): 0.2, ((0, -1, 0), (0, 0)): 0.2}}
+        topo = bc.resolve_bond_topology(decl, np.eye(3), norb, active_types=bc._LONGITUDINAL_ACTIVE_TYPES)
+        view = bc.BondSetView(topo)
+        ND = view.n_channels * nd
+        rng = np.random.default_rng(7)
+        X = rng.normal(size=(nmat, nvol, ND, ND)) + 1j * rng.normal(size=(nmat, nvol, ND, ND))
+        # impose W(q, l)^dagger = W(q, nmat - l) (l -> -l on the centred grid)
+        W = np.empty_like(X)
+        for l in range(nmat):
+            lm = (nmat - l) % nmat
+            W[l] = 0.5 * (X[l] + X[lm].conj().swapaxes(-1, -2))
+        G = _green(s, 0.5)
+        with BondBlockStore(nmat, nvol, ND, nd, ("W",)) as store:
+            store.put_freq_batch("W", 0, nmat, W)
+            sig = calc_self_energy_bond(store, G, 0.5, view, (4, 4, 1), norb, 1)[0]
+        dev = np.max(np.abs(sig.conj().swapaxes(-1, -2) - sig[::-1])) / np.max(np.abs(sig))
+        self.assertLess(dev, 1e-12)
+
     def test_g1_direct_sum_oracle(self):
         """4x4, norb = 2, nmat = 8, B = 5 (declared +-x, +-y), complex hopping,
-        a random non-symmetric W: the (k, q, tau) oracle with explicit
-        phases e^{+ik.R_alpha} e^{-i(k-q).R_beta} and k - q reduced modulo
-        the mesh equals the production transport."""
+        a random non-symmetric W: the (k, q, tau) oracle with the explicit
+        bond form factor e^{+i(k-q).(R_alpha - R_beta)} on the internal leg
+        and k - q reduced modulo the mesh equals the production transport."""
         from hwave.solver import bond_channels as bc
         from hwave.solver.flex_bond import BondBlockStore, calc_self_energy_bond
         from hwave.solver import matsubara as _ms
@@ -87,7 +115,7 @@ class TestTransport(unittest.TestCase):
                 kk = kvec[k]; kq = kvec[kmq]
                 for a_ in range(B):
                     for b_ in range(B):
-                        ph = np.exp(1j * kk @ R[a_]) * np.exp(-1j * kq @ R[b_])
+                        ph = np.exp(1j * kq @ (R[a_] - R[b_]))
                         Wblk = W_t[:, q, a_, :, b_, :].reshape(nmat, norb, norb, norb, norb)   # (t, c, a, d, b)
                         sig_t[:, k] += ph * np.einsum('tcadb,tcd->tab', Wblk, G_t[:, kmq])
         sig_t /= nvol
@@ -136,7 +164,7 @@ class TestFrequencyOracleSanity(unittest.TestCase):
                 kmq = idx[(ik[0] - iq[0]) % nx, (ik[1] - iq[1]) % ny]
                 for a_ in range(B):
                     for b_ in range(B):
-                        ph = np.exp(1j * kvec[k] @ R[a_]) * np.exp(-1j * kvec[kmq] @ R[b_])
+                        ph = np.exp(1j * kvec[kmq] @ (R[a_] - R[b_]))
                         for n in range(nmat):
                             for l in range(nmat):
                                 m = n - l + nmat // 2          # w_n - nu_l -> index n - l + nmat/2

--- a/tests/test_flex_bond_sopt.py
+++ b/tests/test_flex_bond_sopt.py
@@ -1,0 +1,357 @@
+"""Gate G2 (spec 2026-09-06 section 5): perturbative ownership of the
+bond-resolved FLEX vertex. With a FROZEN bare Green function (fixed mu, no
+SCF) the fluctuation self-energy of one map is fitted to a quadratic in
+(U, V) on the 3 x 3 grid {0, u0/2, u0} x {0, v0/2, v0}; (a) its constant
+and linear parts vanish and the fit residual scales as the cube of the
+grid; (b) the Hartree-Fock map is linear in every coefficient and the
+PairLift map is identically zero on the paramagnetic density; (c) the
+quadratic coefficients equal an INDEPENDENT hand-enumerated second-order
+evaluation (the two skeleton diagrams, direct and exchange, enumerated in
+real space on the torus with explicit spin bookkeeping -- no production
+vertex code); (d) with every off-site coefficient zero the gate reproduces
+the general path's coefficients."""
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN1 = "tests/rpa/input"
+_IN2 = "tests/rpa/input_2orb"
+_NMAT = 8
+_SHAPE = (4, 4, 1)
+_T = 1.0
+_MU = 0.1
+
+
+def _write_wan(path, name, norb, rows):
+    rvecs = sorted({tuple(r[:3]) for r in rows})
+    with open(path, "w") as fw:
+        fw.write("{} in wannier90-like format for uhfk\n{}\n{}\n".format(name, norb, len(rvecs)))
+        fw.write(" ".join("1" for _ in rvecs) + "\n")
+        for r in rows:
+            fw.write("{:4d} {:4d} {:4d} {:4d} {:4d} {: .15e} {: .15e}\n".format(*r))
+
+
+def _make_inputs(d, norb, U, V, uprime=0.0, pairlift=None):
+    src = _IN1 if norb == 1 else _IN2
+    for f in ("geom.dat", "transfer.dat"):
+        shutil.copy(os.path.join(src, f), d)
+    _write_wan(os.path.join(d, "intra.dat"), "CoulombIntra", norb,
+               [(0, 0, 0, a, a, U, 0.0) for a in range(1, norb + 1)])
+    rows = []
+    if norb == 2:
+        rows += [(0, 0, 0, 1, 2, uprime, 0.0), (0, 0, 0, 2, 1, uprime, 0.0)]
+        rows += [(1, 0, 0, 1, 1, V, 0.0), (-1, 0, 0, 1, 1, V, 0.0),
+                 (0, 1, 0, 2, 2, V, 0.0), (0, -1, 0, 2, 2, V, 0.0),
+                 (1, 0, 0, 1, 2, 0.6 * V, 0.0), (-1, 0, 0, 2, 1, 0.6 * V, 0.0)]
+    else:
+        rows += [(1, 0, 0, 1, 1, V, 0.0), (-1, 0, 0, 1, 1, V, 0.0),
+                 (0, 1, 0, 1, 1, 0.5 * V, 0.0), (0, -1, 0, 1, 1, 0.5 * V, 0.0)]
+    _write_wan(os.path.join(d, "inter.dat"), "CoulombInter", norb, rows)
+    inter = {"CoulombIntra": "intra.dat", "CoulombInter": "inter.dat"}
+    if pairlift is not None:
+        _write_wan(os.path.join(d, "pairlift.dat"), "PairLift", norb, pairlift)
+        inter["PairLift"] = "pairlift.dat"
+    return inter
+
+
+def _solver(d, inter, gate):
+    import hwave.solver.flex as flex_mod
+    idict = {"path_to_input": d, "Geometry": "geom.dat", "Transfer": "transfer.dat"}
+    idict.update(inter)
+    r = read_input_k.QLMSkInput({"path_to_input": d, "interaction": idict})
+    par = {"T": _T, "mu": _MU, "CellShape": list(_SHAPE), "SubShape": [1, 1, 1], "Nmat": _NMAT,
+           "IterationMax": 1, "Mix": 1.0, "EPS": 1e-12, "flex_hartree_fock": True,
+           "longitudinal_bond_channels": gate}
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r.get_param("green")
+
+
+def _one_map(s, gi, gate):
+    """(Sigma_HF (nvol,norb,norb), Sigma_fluct (nmat,nvol,norb,norb), G) of ONE
+    map from the frozen bare G at the fixed mu."""
+    from hwave.solver import flex_bond
+    s._phase_b_reset(gi)
+    s._phase_b_preflight(gi)
+    s._calc_epsilon_k({})
+    beta = 1.0 / s.T
+    mu = s.mu_value
+    green0, green0_tail = s._calc_green(beta, mu)
+    nmat, nvol, norb = s.nmat, s.lattice.nvol, s.norb
+    nd = norb * norb
+    G = s._calc_dressed_green(beta, mu, np.zeros((1, nmat, nvol, norb, norb), complex))
+    static0 = np.zeros((1, 1, nvol, norb, norb), complex)
+    _, sigma_hf, _ = s._phase_b_density_and_hf(G, static0, mu, beta, None)
+    if gate:
+        B = s._bond_view.n_channels
+        with flex_bond.BondBlockStore(nmat, nvol, B * nd, nd, ("chibar", "W")) as store:
+            s._phase_b_prepare_vertices()
+            flex_bond.assemble_bubble(store, G, green0_tail, beta, s._bond_view, _SHAPE, 1)
+            flex_bond.dress_and_build_w(store, s._bond_S, s._bond_C, S_on=s._bond_S_on,
+                                        C_on=s._bond_C_on, nb=nmat, output_full=False,
+                                        nmat=nmat, nvol=nvol, nd=nd, spatial_shape=_SHAPE)
+            sig = flex_bond.calc_self_energy_bond(store, G, beta, s._bond_view, _SHAPE, norb, 1)
+    else:
+        chi0q_raw = s._calc_chi0q(G, green0_tail, beta)[0]
+        _, v_eff, _, _ = s._flex_compute_veff_general(chi0q_raw, s.ham_info.ham_inter_q)
+        sig = s._calc_self_energy_general(G, v_eff, beta)
+    return sigma_hf[0, 0], sig[0], G
+
+
+# ---------------------------------------------------------------------------
+# the independent second-order oracle (real-space enumeration on the torus)
+# ---------------------------------------------------------------------------
+
+def _site(x, y):
+    nx, ny, _ = _SHAPE
+    return (x % nx) * ny + (y % ny)
+
+
+def _coords(site):
+    nx, ny, _ = _SHAPE
+    return site // ny, site % ny
+
+
+def _interaction_matrices(norb, U, V, uprime, V_rows):
+    """W^{up up} and W^{up down} on the site-orbital torus (M x M), from the
+    same declarations the solver reads: H = sum over DECLARED rows of
+    v n_i n_j (each ordered pair once); the symmetric matrix W_ij with
+    W_ij = W_ji = v then enters 1/2 sum_ij W_ij n_i n_j with W = 2 v for a
+    pair declared in both orders (the reader's Hermitian closure)."""
+    nvol = _SHAPE[0] * _SHAPE[1]
+    M = nvol * norb
+    Wuu = np.zeros((M, M))
+    Wud = np.zeros((M, M))
+    for s in range(nvol):
+        x, y = _coords(s)
+        for a in range(norb):
+            i = s * norb + a
+            Wud[i, i] += U                      # Hubbard: opposite spins only
+            for (rx, ry, rz, a1, b1, v, _im) in V_rows:
+                if a1 - 1 != a:
+                    continue
+                j = _site(x + rx, y + ry) * norb + (b1 - 1)
+                Wuu[i, j] += v
+                Wud[i, j] += v
+    return Wuu, Wud
+
+
+def _sopt_oracle(G, beta, norb, Wuu, Wud):
+    """Direct and exchange second-order skeletons with the frozen G, in the
+    same discrete (r, tau) representation the solver's transforms realise
+    (fermionic tau grid, FFT-grid reversal for G(-r, -tau) with the
+    antiperiodic sign, spatial FFTs); returns (Sigma_direct,
+    Sigma_exchange) as (nmat, nvol, norb, norb) on (k, i w_n)."""
+    from hwave.solver import matsubara as _ms, backend as _bk
+    nx, ny, nz = _SHAPE
+    nvol = nx * ny * nz
+    nmat = G.shape[1]
+    M = nvol * norb
+    g_rt = _bk.spatial_ifftn(
+        _ms.fermion_to_tau(G[0].reshape(nmat, nvol * norb * norb), axis=0).reshape(nmat, nx, ny, nz, norb * norb),
+        axes=(1, 2, 3), workers=1).reshape(nmat, nx, ny, nz, norb, norb)
+    rev = np.zeros_like(g_rt)
+    for t in range(nmat):
+        for ix in range(nx):
+            for iy in range(ny):
+                rev[t, ix, iy, 0] = g_rt[(-t) % nmat, (-ix) % nx, (-iy) % ny, 0]
+    g_rt = g_rt.reshape(nmat, nvol, norb, norb)
+    rev = rev.reshape(nmat, nvol, norb, norb)
+    sgn = -np.ones(nmat)
+    sgn[0] = 1.0
+    # site-orbital matrices
+    Gf = np.zeros((nmat, M, M), complex)
+    Gr = np.zeros((nmat, M, M), complex)
+    for si in range(nvol):
+        xi, yi = _coords(si)
+        for sj in range(nvol):
+            xj, yj = _coords(sj)
+            d = _site(xi - xj, yi - yj)
+            for a in range(norb):
+                for b in range(norb):
+                    Gf[:, si * norb + a, sj * norb + b] = g_rt[:, d, a, b]
+                    Gr[:, si * norb + a, sj * norb + b] = rev[:, d, a, b]
+    L = Gf * Gr.transpose(0, 2, 1)                          # L_kl = G_kl(tau) G_lk(-tau)
+    K = Wuu @ L @ Wuu + Wud @ L @ Wud.T
+    sig_d = -(1.0 / beta) * sgn[:, None, None] * Gf * K
+    sig_x = (1.0 / beta) * sgn[:, None, None] * np.einsum('ik,tkj,til,lj,tlk->tij', Wuu, Gf, Gf, Wuu, Gr,
+                                                          optimize=True)
+
+    def _to_kw(sig):
+        out = np.zeros((nmat, nvol, norb, norb), complex)
+        for s in range(nvol):
+            for a in range(norb):
+                for b in range(norb):
+                    out[:, s, a, b] = sig[:, s * norb + a, b]      # j = (site 0, b)
+        kt = _bk.spatial_fftn(out.reshape(nmat, nx, ny, nz, norb * norb), axes=(1, 2, 3), workers=1)
+        return _ms.tau_to_fermion(kt.reshape(nmat, nvol * norb * norb), axis=0).reshape(
+            nmat, nvol, norb, norb) / beta
+    return _to_kw(sig_d), _to_kw(sig_x)
+
+
+def _fit(points, values):
+    """Unweighted least squares of c20 U^2 + c11 U V + c02 V^2 + c10 U + c01 V + c00
+    per element; returns (coeffs dict, residual (rss over the points))."""
+    A = np.array([[u * u, u * v, v * v, u, v, 1.0] for (u, v) in points])
+    Y = np.array([np.asarray(val).ravel() for val in values])
+    C, _, _, _ = np.linalg.lstsq(A, Y, rcond=None)
+    fit = A @ C
+    rss = np.sqrt(np.sum(np.abs(Y - fit) ** 2))
+    shape = np.asarray(values[0]).shape
+    names = ("c20", "c11", "c02", "c10", "c01", "c00")
+    return {n: C[i].reshape(shape) for i, n in enumerate(names)}, rss
+
+
+def _rel(a, b):
+    return np.linalg.norm(np.asarray(a).ravel() - np.asarray(b).ravel()) / max(
+        np.linalg.norm(np.asarray(b).ravel()), 1e-300)
+
+
+class _Grid:
+    """One map per grid point on a temporary input directory."""
+
+    def __init__(self, norb, gate, u0=0.5, v0=0.5, scale=1.0, uprime=0.0):
+        self.norb, self.gate = norb, gate
+        self.points = [(u * scale, v * scale) for u in (0.0, u0 / 2, u0) for v in (0.0, v0 / 2, v0)]
+        self.hf, self.fluct = [], []
+        with tempfile.TemporaryDirectory() as d:
+            for (U, V) in self.points:
+                inter = _make_inputs(d, norb, U, V, uprime=uprime * (U / u0 if u0 else 0.0))
+                s, gi = _solver(d, inter, gate)
+                hf, fl, G = _one_map(s, gi, gate)
+                self.hf.append(hf)
+                self.fluct.append(fl)
+                self.G = G
+                self.rows = _read_rows(os.path.join(d, "inter.dat"))
+        self.coeffs, self.rss = _fit(self.points, self.fluct)
+
+
+def _read_rows(path):
+    rows = []
+    for ln in open(path).read().splitlines()[4:]:
+        p = ln.split()
+        rows.append((int(p[0]), int(p[1]), int(p[2]), int(p[3]), int(p[4]), float(p[5]), float(p[6])))
+    return rows
+
+
+_H = 2.0e-3          # coupling scale of the coefficient-extraction grids
+_U0 = _V0 = 0.5      # the spec's grid; used for the residual-scaling test
+
+
+def _richardson(cs):
+    """Three-level extrapolation of a fitted coefficient c(h) = a + b1 h +
+    b2 h^2 + O(h^3) from the grids at h, h/2, h/4 (the 3 x 3 quadratic fit
+    interpolates, so the cubic and quartic terms of Sigma alias into the
+    fitted coefficients at O(h) and O(h^2))."""
+    return (8.0 * cs[2] - 6.0 * cs[1] + cs[0]) / 3.0
+
+
+def _coefficients(norb, gate, uprime=0.0):
+    grids = [_Grid(norb, gate=gate, scale=_H / _U0 * f, uprime=uprime) for f in (1.0, 0.5, 0.25)]
+    out = {k: _richardson([g.coeffs[k] for g in grids]) for k in ("c20", "c11", "c02")}
+    return out, grids[0]
+
+
+class TestG2(unittest.TestCase):
+    """Coefficient extraction at h = 2e-3 with three-level Richardson
+    extrapolation (a3/a2 is 0.1-1 on this fixture, so the spec's u0 = v0 =
+    0.5 grid aliases the cubic terms at 1e-2 into every fitted coefficient;
+    the residual-scaling test keeps the spec's grid)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.on, cls.g_on = _coefficients(1, gate=True)
+        cls.off, cls.g_off = _coefficients(1, gate=False)
+        beta = 1.0 / _T
+        G = cls.g_on.G
+        rows = cls.g_on.rows
+        vscale = _V0 * _H / _U0            # the V of the largest grid point
+        Wuu_v, Wud_v = _interaction_matrices(1, 0.0, 0.0, 0.0,
+                                             [r[:5] + (r[5] / vscale, r[6]) for r in rows])
+        Wuu_u, Wud_u = _interaction_matrices(1, 1.0, 0.0, 0.0, [])
+        d_u, x_u = _sopt_oracle(G, beta, 1, Wuu_u, Wud_u)
+        d_v, x_v = _sopt_oracle(G, beta, 1, Wuu_v, Wud_v)
+        d_uv, x_uv = _sopt_oracle(G, beta, 1, Wuu_u + Wuu_v, Wud_u + Wud_v)
+        cls.oracle = dict(c20=d_u + x_u, c02=d_v + x_v, c11=(d_uv + x_uv) - (d_u + x_u) - (d_v + x_v),
+                          d_v=d_v, x_v=x_v, x_u=x_u, x_uv=x_uv, x_v_only=x_v)
+
+    def test_a_constant_and_linear_parts_vanish(self):
+        c = self.g_on.coeffs
+        quad = max(np.abs(c[k]).max() for k in ("c20", "c11", "c02"))
+        low = max(np.abs(c[k]).max() for k in ("c10", "c01", "c00"))
+        self.assertLess(low, 1e-6 * quad)
+
+    def test_a_residual_scales_as_the_cube_of_the_grid(self):
+        grids = [_Grid(1, gate=True, scale=sc) for sc in (1.0, 0.5, 0.25)]
+        ref = np.linalg.norm(np.asarray(grids[0].fluct).ravel())
+        floor = 1e3 * np.finfo(float).eps * ref
+        pts = [(sc, g.rss) for sc, g in zip((1.0, 0.5, 0.25), grids) if g.rss >= floor]
+        if len(pts) < 2:
+            self.skipTest("fit residual at the round-off floor; exponent passes vacuously")
+        sv = np.array([x[0] for x in pts]); rv = np.array([x[1] for x in pts])
+        slope = np.polyfit(np.log(sv), np.log(rv), 1)[0]
+        self.assertTrue(2.5 <= slope <= 3.5, "slope {}".format(slope))
+
+    def test_b_hartree_fock_map_is_linear(self):
+        g = self.g_on
+        hf = {p: h for p, h in zip(g.points, g.hf)}
+        u0, v0 = max(p[0] for p in g.points), max(p[1] for p in g.points)
+        h00 = hf[(0.0, 0.0)]
+        du = (hf[(u0, 0.0)] - h00) / u0
+        dv = (hf[(0.0, v0)] - h00) / v0
+        ref = max(np.linalg.norm(du.ravel()), np.linalg.norm(dv.ravel()))
+        for (U, V), h in hf.items():
+            pred = h00 + U * du + V * dv
+            self.assertLess(np.linalg.norm((h - pred).ravel()), 1e-12 * ref)
+        self.assertGreater(np.linalg.norm(dv.ravel()), 1e-3)     # V has a nonzero (Fock) map
+
+    def test_b_pairlift_map_is_zero_on_the_paramagnetic_density(self):
+        from hwave.solver import flex_hf
+        with tempfile.TemporaryDirectory() as d:
+            rows = [(1, 0, 0, 1, 2, 0.3, 0.0), (-1, 0, 0, 2, 1, 0.3, 0.0),
+                    (0, 0, 0, 1, 2, 0.2, 0.0), (0, 0, 0, 2, 1, 0.2, 0.0)]
+            inter = _make_inputs(d, 2, 0.4, 0.3, uprime=0.2, pairlift=rows)
+            s, gi = _solver(d, inter, gate=True)
+            hf, _, G = _one_map(s, gi, gate=True)
+            self.assertGreater(np.abs(hf).max(), 1e-3)
+            from hwave.solver import hartree_fock as _hf
+            s._calc_epsilon_k({})
+            heff = _hf.heff_eigenpairs(np.asarray(s.H0_k)[0], np.zeros((s.lattice.nvol, 2, 2), complex))
+            dens = _hf.equal_time_density(G, heff, s.mu_value, 1.0 / s.T, _SHAPE)
+            self.assertGreater(np.abs(dens.rho_r[:, 0, 1]).max(), 1e-6)   # orbital coherences present
+            tabs = flex_hf.build_flex_hf_tables({"PairLift": s.ham_info.param_ham["PairLift"]}, 2, _SHAPE)
+            self.assertLess(np.abs(flex_hf.hf_map(dens.rho_r, tabs, _SHAPE, 2)).max(), 1e-14)
+
+    def test_c_quadratic_coefficients_equal_the_hand_enumerated_sopt(self):
+        for k in ("c20", "c11", "c02"):
+            self.assertLess(_rel(self.on[k], self.oracle[k]), 1e-8, k)
+        # the exchange skeleton is load-bearing (nonzero) and the Hubbard-only
+        # coefficients carry none
+        self.assertGreater(np.linalg.norm(self.oracle["x_v"].ravel()), 1e-2 * np.linalg.norm(self.oracle["d_v"].ravel()))
+        self.assertLess(np.abs(self.oracle["x_u"]).max(), 1e-14)
+        self.assertLess(np.abs(self.oracle["x_uv"] - self.oracle["x_v_only"]).max(), 1e-14)
+
+    def test_c_general_path_second_order_recorded(self):
+        """Recorded finding (not a Phase B defect): the general path's
+        Takimoto-Hotta-Ueda subtraction -1/4 (S+C) chi (S+C) with the
+        density-slot placement (S, C) = (0, 2 V(q)) of a spin-independent
+        off-site V removes half of the direct V^2 skeleton and the whole
+        U V cross term at second order, and carries no exchange skeleton."""
+        self.assertLess(_rel(self.off["c02"], 0.5 * self.oracle["d_v"]), 1e-8)
+        self.assertLess(np.abs(self.off["c11"]).max(), 1e-8 * np.abs(self.oracle["c11"]).max())
+        self.assertLess(_rel(self.off["c20"], self.oracle["c20"]), 1e-8)
+
+    def test_d_declared_zero_reproduces_the_general_path(self):
+        g_on, g_off = self.g_on, self.g_off
+        for (p, a), (q, b) in zip(zip(g_on.points, g_on.fluct), zip(g_off.points, g_off.fluct)):
+            if p[1] == 0.0:            # V = 0 points: the two paths coincide exactly
+                self.assertEqual(p, q)
+                np.testing.assert_allclose(a, b, rtol=0, atol=1e-12 * np.abs(b).max())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_bond_store.py
+++ b/tests/test_flex_bond_store.py
@@ -1,0 +1,112 @@
+"""BondBlockStore and the dynamic bubble assembly (spec 2026-09-06
+sections 3.1 and 3.5): pair/frequency-batch views, detach/release,
+rollback, the static-slice pin against bond_bubble_static, and the
+every-frequency channel-0 identity with the general bubble under a
+nonzero coeff_tail."""
+import os
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN2 = "tests/rpa/input_2orb"
+
+
+def _flex(param_extra):
+    import hwave.solver.flex as flex_mod
+    idict = {"path_to_input": _IN2, "Geometry": "geom.dat", "Transfer": "transfer.dat",
+             "CoulombInter": "coulombinter.dat"}
+    r = read_input_k.QLMSkInput({"path_to_input": _IN2, "interaction": idict})
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": 32, "IterationMax": 1, "Mix": 1.0, "EPS": 1}
+    par.update(param_extra)
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+class TestBondBlockStore(unittest.TestCase):
+
+    def test_views_detach_release(self):
+        from hwave.solver.flex_bond import BondBlockStore
+        nmat, nvol, nd, B = 4, 3, 4, 2
+        with BondBlockStore(nmat, nvol, B * nd, nd, ("chibar", "W")) as store:
+            blk = np.arange(nmat * nvol * nd * nd, dtype=float).reshape(nmat, nvol, nd, nd) + 0j
+            store.put_pair("chibar", 1, 0, blk)
+            np.testing.assert_array_equal(store.get_pair("chibar", 1, 0), blk)
+            full = store.get_freq_batch("chibar", 1, 3)
+            self.assertEqual(full.shape, (2, nvol, B * nd, B * nd))
+            self.assertTrue(full.flags.c_contiguous)
+            np.testing.assert_array_equal(full[:, :, nd:, :nd], blk[1:3])
+            store.put_freq_batch("W", 0, 4, np.ones((4, nvol, B * nd, B * nd), complex))
+            w = store.detach("W")
+            self.assertTrue(w.flags.owndata)
+            with self.assertRaises(KeyError):
+                store.get_pair("W", 0, 0)
+        with self.assertRaises(RuntimeError):
+            store.get_pair("chibar", 0, 0)                       # released
+        self.assertEqual(np.abs(w).max(), 1.0)                  # detached array survives
+
+    def test_release_on_exception_and_rollback(self):
+        from hwave.solver.flex_bond import BondBlockStore
+        try:
+            with BondBlockStore(2, 2, 2, 1, ("chibar",)) as store:
+                raise ValueError("boom")
+        except ValueError:
+            pass
+        with self.assertRaises(RuntimeError):
+            store.get_freq_batch("chibar", 0, 1)
+        with self.assertRaises(ValueError):
+            BondBlockStore(2, 2, 2, 1, ("chibar", "chibar"))    # duplicate name refused
+
+
+class TestBubbleAssembly(unittest.TestCase):
+
+    def _prepared(self, coeff_tail):
+        s, r = _flex({"coeff_tail": coeff_tail})
+        gi = r.get_param("green")
+        os.makedirs("tests/flex/output", exist_ok=True)
+        s.solve(gi, "tests/flex/output")           # gate off: builds green0 / tails
+        return s, gi
+
+    def test_static_slice_equals_bond_bubble_static(self):
+        from hwave.solver import bond_channels as bc, bubble
+        from hwave.solver.flex_bond import BondBlockStore, assemble_bubble
+        s, gi = self._prepared(0.0)
+        topo = bc.resolve_bond_topology(s.ham_info.param_ham, np.eye(3), s.norb,
+                                        active_types=bc._LONGITUDINAL_ACTIVE_TYPES)
+        view = bc.BondSetView(topo)
+        nd, nvol, nmat = s.norb ** 2, s.lattice.nvol, s.nmat
+        ND = view.n_channels * nd
+        with BondBlockStore(nmat, nvol, ND, nd, ("chibar",)) as store:
+            assemble_bubble(store, s.green0, s.green0_tail, 0.5, view, (4, 4, 1), 1)
+            stat = bubble.bond_bubble_static(s.green0, s.green0_tail, 0.5, view, spatial_shape=(4, 4, 1))
+            np.testing.assert_allclose(store.get_freq_batch("chibar", nmat // 2, nmat // 2 + 1)[0],
+                                       np.asarray(stat), rtol=0, atol=1e-13)
+
+    def test_channel_zero_equals_general_bubble_at_every_frequency_with_tail(self):
+        from hwave.solver import bond_channels as bc
+        from hwave.solver.flex_bond import BondBlockStore, assemble_bubble
+        s, gi = self._prepared(1.0)
+        topo = bc.resolve_bond_topology(s.ham_info.param_ham, np.eye(3), s.norb,
+                                        active_types=bc._LONGITUDINAL_ACTIVE_TYPES)
+        view = bc.BondSetView(topo)
+        nd, nvol, nmat, norb = s.norb ** 2, s.lattice.nvol, s.nmat, s.norb
+        ND = view.n_channels * nd
+        # the loop's own green_scf / green0_tail: bare G minus the tail (first iteration)
+        beta = 0.5
+        green_kw = s._calc_dressed_green(beta, s.mu, np.zeros((1, nmat, nvol, norb, norb), complex))
+        iomega = (np.arange(nmat) * 2 + 1 - nmat) * np.pi / beta
+        ev = s.H0_eigenvector
+        VVt = ev @ np.conj(ev).swapaxes(-2, -1)
+        tail_w = ((1.0 / (1j * iomega))[None, :, None, None, None] * VVt[:, None])
+        green_scf = green_kw - tail_w
+        ref = s._calc_chi0q(green_scf, s.green0_tail, beta)[0]       # (nmat, nvol, norb, norb, norb, norb)
+        with BondBlockStore(nmat, nvol, ND, nd, ("chibar",)) as store:
+            assemble_bubble(store, green_scf, s.green0_tail, beta, view, (4, 4, 1), 1)
+            ch0 = store.get_freq_batch("chibar", 0, nmat)[:, :, :nd, :nd]
+        np.testing.assert_allclose(ch0.reshape(nmat, nvol, norb, norb, norb, norb), ref, rtol=0, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_hf_adapter.py
+++ b/tests/test_flex_hf_adapter.py
@@ -1,0 +1,102 @@
+"""The FLEX-side Hartree-Fock adapter (spec 2026-09-06 section 2.2): the
+paramagnetic embedding of the spin-free density into the shared kernel,
+the spin-block checks, the owning copy, the admissibility filter on the
+table builder, and PairLift's symmetry-zero map (D12)."""
+import unittest
+
+import numpy as np
+
+
+def _rho(nvol, norb, seed=0):
+    rng = np.random.default_rng(seed)
+    g = rng.normal(size=(nvol, norb, norb)) + 1j * rng.normal(size=(nvol, norb, norb))
+    # Hermitian closure rho(r) = conj(rho(-r))^T on a (nvol,1,1) ring
+    rev = np.conj(np.swapaxes(g, -1, -2))
+    rev = np.roll(rev[::-1], 1, axis=0)
+    return 0.5 * (g + rev)
+
+
+_KANAMORI = {
+    "CoulombIntra": {((0, 0, 0), (0, 0)): 2.0, ((0, 0, 0), (1, 1)): 1.5},
+    "CoulombInter": {((0, 0, 0), (0, 1)): 0.7, ((0, 0, 0), (1, 0)): 0.7,
+                     ((1, 0, 0), (0, 1)): 0.4, ((-1, 0, 0), (1, 0)): 0.4},
+    "Hund": {((0, 0, 0), (0, 1)): 0.3, ((0, 0, 0), (1, 0)): 0.3,
+             ((1, 0, 0), (0, 0)): 0.1, ((-1, 0, 0), (0, 0)): 0.1},
+    "Ising": {((1, 0, 0), (0, 1)): 0.15, ((-1, 0, 0), (1, 0)): 0.15},
+    "Exchange": {((0, 0, 0), (0, 1)): 0.3, ((0, 0, 0), (1, 0)): 0.3},
+    "PairHop": {((0, 0, 0), (0, 1)): 0.3, ((0, 0, 0), (1, 0)): 0.3},
+    "PairLift": {((1, 0, 0), (0, 1)): 0.05, ((-1, 0, 0), (1, 0)): 0.05},
+}
+
+
+class TestHfAdapter(unittest.TestCase):
+
+    def setUp(self):
+        self.shape, self.norb = (4, 1, 1), 2
+        self.nvol = 4
+        self.rho = _rho(self.nvol, self.norb)
+
+    def test_map_is_the_up_block_of_the_spin_major_kernel(self):
+        from hwave.solver import flex_hf, hartree_fock as hf
+        tabs = flex_hf.build_flex_hf_tables(_KANAMORI, self.norb, self.shape)
+        sig = flex_hf.hf_map(self.rho, tabs, self.shape, self.norb)
+        rho_so = np.zeros((self.nvol, 2, self.norb, 2, self.norb), complex)
+        rho_so[:, 0, :, 0, :] = self.rho
+        rho_so[:, 1, :, 1, :] = self.rho
+        out = np.zeros((self.nvol, 2 * self.norb, 2 * self.norb), complex)
+        hf.accumulate_hf(out, rho_so, tabs.inter_table, tabs.spin_table, self.shape, include_fock=True)
+        o = out.reshape(self.nvol, 2, self.norb, 2, self.norb)
+        np.testing.assert_array_equal(sig, o[:, 0, :, 0, :])
+        self.assertTrue(sig.flags.owndata)                     # owning copy, not a view
+        self.assertEqual(np.abs(o[:, 0, :, 1, :]).max(), 0.0)  # paramagnetic: no spin off-diagonal
+        np.testing.assert_array_equal(o[:, 0, :, 0, :], o[:, 1, :, 1, :])
+        self.assertGreater(np.abs(sig).max(), 0.0)
+
+    def test_hermiticity_in_k_space_is_checked(self):
+        from hwave.solver import flex_hf
+        tabs = flex_hf.build_flex_hf_tables(_KANAMORI, self.norb, self.shape)
+        sig = flex_hf.hf_map(self.rho, tabs, self.shape, self.norb)
+        np.testing.assert_allclose(sig, np.conj(np.swapaxes(sig, -1, -2)), atol=1e-12)
+        bad = self.rho.copy(); bad[:, 0, 1] += 0.3                # breaks rho(r) = conj(rho(-r))^T
+        with self.assertRaises(ValueError):
+            flex_hf.hf_map(bad, tabs, self.shape, self.norb)
+
+    def test_pairlift_map_is_zero_on_the_paramagnetic_embedding(self):
+        from hwave.solver import flex_hf, hartree_fock as hf
+        tabs = flex_hf.build_flex_hf_tables({"PairLift": _KANAMORI["PairLift"]}, self.norb, self.shape)
+        sig = flex_hf.hf_map(self.rho, tabs, self.shape, self.norb)    # coherences and R != 0 present
+        self.assertLessEqual(np.abs(sig).max(), 1e-14)
+        # kernel-level: a spin-off-diagonal density DOES produce a PairLift map
+        rho_so = np.zeros((self.nvol, 2, self.norb, 2, self.norb), complex)
+        rho_so[:, 0, :, 1, :] = self.rho
+        rho_so[:, 1, :, 0, :] = np.conj(np.swapaxes(self.rho, -1, -2))
+        out = np.zeros((self.nvol, 4, 4), complex)
+        hf.accumulate_hf(out, rho_so, tabs.inter_table, tabs.spin_table, self.shape, include_fock=True)
+        self.assertGreater(np.abs(out).max(), 1e-6)
+
+    def test_discarded_coulombintra_is_refused_naming_the_declaration(self):
+        from hwave.solver import flex_hf
+        ph = {"CoulombIntra": {((0, 0, 0), (0, 0)): 2.0, ((1, 0, 0), (0, 0)): 0.5}}
+        with self.assertRaises(ValueError) as cm:
+            flex_hf.build_flex_hf_tables(ph, self.norb, self.shape)
+        self.assertIn("CoulombIntra", str(cm.exception))
+        self.assertIn("(1, 0, 0)", str(cm.exception))
+        ph = {"CoulombIntra": {((0, 0, 0), (0, 1)): 0.5}}
+        with self.assertRaises(ValueError):
+            flex_hf.build_flex_hf_tables(ph, self.norb, self.shape)
+
+    def test_linear_in_each_coefficient(self):
+        from hwave.solver import flex_hf
+        for t in ("CoulombIntra", "CoulombInter", "Hund", "Ising", "Exchange", "PairHop"):
+            with self.subTest(t=t):
+                def sig_at(scale):
+                    tbl = {k: (v * scale) for k, v in _KANAMORI[t].items()}
+                    tabs = flex_hf.build_flex_hf_tables({t: tbl}, self.norb, self.shape)
+                    return flex_hf.hf_map(self.rho, tabs, self.shape, self.norb)
+                s1, s2 = sig_at(1.0), sig_at(2.0)
+                self.assertGreater(np.abs(s1).max(), 1e-8, t)
+                np.testing.assert_allclose(s2, 2.0 * s1, rtol=1e-12, atol=1e-14)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_hf_adapter.py
+++ b/tests/test_flex_hf_adapter.py
@@ -56,7 +56,7 @@ class TestHfAdapter(unittest.TestCase):
         from hwave.solver import flex_hf
         tabs = flex_hf.build_flex_hf_tables(_KANAMORI, self.norb, self.shape)
         sig = flex_hf.hf_map(self.rho, tabs, self.shape, self.norb)
-        np.testing.assert_allclose(sig, np.conj(np.swapaxes(sig, -1, -2)), atol=1e-12)
+        np.testing.assert_allclose(sig, np.conj(np.swapaxes(sig, -1, -2)), rtol=0, atol=1e-12)
         bad = self.rho.copy(); bad[:, 0, 1] += 0.3                # breaks rho(r) = conj(rho(-r))^T
         with self.assertRaises(ValueError):
             flex_hf.hf_map(bad, tabs, self.shape, self.norb)

--- a/tests/test_flex_hf_density.py
+++ b/tests/test_flex_hf_density.py
@@ -1,0 +1,115 @@
+"""The Heff-referenced equal-time density evaluator of the Phase B design
+(spec 2026-09-06 section 2.1): UHFk's density convention, exactness for a
+frequency-independent self-energy at any Nmat, the O(nmat^-3) truncation
+for a dynamic one, and the refusals."""
+import unittest
+
+import numpy as np
+
+
+def _ring(L, norb, seed=0):
+    """A complex-hopping ring: H0(k) = t e^{ik} + t^dag e^{-ik} + diag(eps)."""
+    rng = np.random.default_rng(seed)
+    t = rng.normal(size=(norb, norb)) + 1j * rng.normal(size=(norb, norb))
+    eps = np.diag(rng.normal(size=norb))
+    k = 2.0 * np.pi * np.arange(L) / L
+    H0 = (t[None] * np.exp(1j * k)[:, None, None]
+          + t.conj().T[None] * np.exp(-1j * k)[:, None, None] + eps[None])
+    return H0                                       # (L, norb, norb)
+
+
+def _green(H0, sigma_w, mu, beta, nmat):
+    """G(k, iw_n) = [(iw_n + mu) - H0 - sigma(iw_n)]^-1, shape (nmat, L, norb, norb)."""
+    L, norb = H0.shape[0], H0.shape[1]
+    iw = 1j * (2 * np.arange(nmat) + 1 - nmat) * np.pi / beta
+    eye = np.eye(norb)
+    ginv = (iw[:, None, None, None] + mu) * eye - H0[None] - sigma_w
+    return np.linalg.inv(ginv)
+
+
+def _fermi(e, mu, beta):
+    return 1.0 / (np.exp(beta * (e - mu)) + 1.0)
+
+
+class TestEqualTimeDensity(unittest.TestCase):
+
+    def setUp(self):
+        self.L, self.norb, self.beta, self.mu, self.nmat = 6, 2, 4.0, 0.2, 64
+        self.H0 = _ring(self.L, self.norb)
+        self.shape = (self.L, 1, 1)
+
+    def test_bare_matches_uhfk_green_convention(self):
+        from hwave.solver import hartree_fock as hf
+        e, V = np.linalg.eigh(self.H0)
+        f = _fermi(e, self.mu, self.beta)
+        # UHFk _green: rho_ab(k) = sum_j conj(V_aj) f_j V_bj ; rho(r) = fftn(rho_k, norm="forward")
+        rho_k_ref = np.einsum('kaj,kj,kbj->kab', V.conj(), f, V)
+        rho_r_ref = np.fft.fftn(rho_k_ref.reshape(self.L, 1, 1, self.norb, self.norb),
+                                axes=(0, 1, 2), norm="forward").reshape(self.L, self.norb, self.norb)
+        G = _green(self.H0, 0.0, self.mu, self.beta, self.nmat)[None]      # (1, nmat, L, norb, norb)
+        heff = hf.heff_eigenpairs(self.H0, np.zeros_like(self.H0))
+        res = hf.equal_time_density(G, heff, self.mu, self.beta, self.shape)
+        np.testing.assert_allclose(res.rho_r, rho_r_ref, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(res.rho_k, rho_k_ref, rtol=0, atol=1e-12)
+        self.assertFalse(res.rho_r.flags.writeable)
+        self.assertFalse(res.rho_k.flags.writeable)
+        self.assertIsInstance(res.n_per_spin, float)
+        self.assertAlmostEqual(res.n_per_spin, float(f.sum()), places=12)
+
+    def test_static_seed_exact_at_finite_nmat(self):
+        from hwave.solver import hartree_fock as hf
+        rng = np.random.default_rng(1)
+        S = rng.normal(size=(self.L, self.norb, self.norb)) + 1j * rng.normal(size=(self.L, self.norb, self.norb))
+        S = 0.5 * (S + S.conj().swapaxes(-1, -2))
+        heff = hf.heff_eigenpairs(self.H0, S)
+        for nmat in (16, 64):
+            G = _green(self.H0, S[None], self.mu, self.beta, nmat)[None]
+            res = hf.equal_time_density(G, heff, self.mu, self.beta, self.shape)
+            e, _ = np.linalg.eigh(self.H0 + S)
+            self.assertAlmostEqual(res.n_per_spin, float(_fermi(e, self.mu, self.beta).sum()), places=12)
+
+    def test_dynamic_tail_exponent(self):
+        """Single orbital, two-pole self-energy A/(iw - E): the exact density
+        is the Fermi-weighted residue sum of the two poles of G."""
+        from hwave.solver import hartree_fock as hf
+        L, beta, mu = 8, 3.0, 0.1
+        H0 = _ring(L, 1, seed=2)
+        h = H0[:, 0, 0].real
+        A, E = 0.3, -0.4
+        disc = np.sqrt((h - mu - E) ** 2 + 4 * A)
+        wp = 0.5 * ((h - mu + E) + disc)
+        wm = 0.5 * ((h - mu + E) - disc)
+        rp = (wp - E) / (wp - wm)
+        rm = (wm - E) / (wm - wp)
+        # poles of G measured from mu: G = (iw - E) / ((iw + mu - h)(iw - E) - A); poles at iw = w_pm
+        n_exact = float(np.sum(rp * _fermi(wp, 0.0, beta) + rm * _fermi(wm, 0.0, beta)))
+        heff = hf.heff_eigenpairs(H0, np.zeros_like(H0))
+        errs = []
+        for nmat in (64, 128, 256):
+            iw = 1j * (2 * np.arange(nmat) + 1 - nmat) * np.pi / beta
+            sig = (A / (iw - E))[:, None, None, None] * np.ones((1, L, 1, 1))
+            G = _green(H0, sig, mu, beta, nmat)[None]
+            res = hf.equal_time_density(G, heff, mu, beta, (L, 1, 1))
+            errs.append(abs(res.n_per_spin - n_exact))
+        slope = -np.polyfit(np.log([64, 128, 256]), np.log(errs), 1)[0]
+        print("tail exponent", slope, errs)
+        self.assertGreaterEqual(slope, 2.5)
+        self.assertLessEqual(slope, 3.5)
+
+    def test_refusals(self):
+        from hwave.solver import hartree_fock as hf
+        G = _green(self.H0, 0.0, self.mu, self.beta, self.nmat)[None]
+        heff = hf.heff_eigenpairs(self.H0, np.zeros_like(self.H0))
+        with self.assertRaises(ValueError):                    # non-Hermitian Heff
+            bad = np.zeros_like(self.H0); bad[:, 0, 1] = 1.0
+            hf.heff_eigenpairs(self.H0, bad)
+        with self.assertRaises(hf.NonFiniteError):
+            Gn = G.copy(); Gn[0, 0, 0, 0, 0] = np.nan
+            hf.equal_time_density(Gn, heff, self.mu, self.beta, self.shape)
+        with self.assertRaises(ValueError):                    # symmetry violation
+            Gb = G.copy(); Gb[:, :, 0, 0, 1] += 0.5
+            hf.equal_time_density(Gb, heff, self.mu, self.beta, self.shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_hf_scf.py
+++ b/tests/test_flex_hf_scf.py
@@ -206,12 +206,12 @@ class TestG5UHFkFixedPoint(unittest.TestCase):
         from hwave.solver import hartree_fock as hf
         heff = hf.heff_eigenpairs(np.asarray(s.H0_k)[0], gi["sigma_static"][0, 0])
         dens = hf.equal_time_density(gi["green"], heff, s.mu, 1.0 / 2.0, (4, 4, 1))
-        np.testing.assert_allclose(G[:, 0, :, 0, :], dens.rho_r, atol=1e-8)
-        np.testing.assert_allclose(G[:, 1, :, 1, :], dens.rho_r, atol=1e-8)
+        np.testing.assert_allclose(G[:, 0, :, 0, :], dens.rho_r, rtol=0, atol=1e-8)
+        np.testing.assert_allclose(G[:, 1, :, 1, :], dens.rho_r, rtol=0, atol=1e-8)
         self.assertLess(np.abs(G[:, 0, :, 1, :]).max(), 1e-10)
         h_uhf = np.asarray(u.ham).reshape(nvol, 2, norb, 2, norb)[:, 0, :, 0, :]
         h_flex = np.asarray(s.H0_k)[0] + gi["sigma_static"][0, 0]
-        np.testing.assert_allclose(h_flex, h_uhf, atol=1e-8)
+        np.testing.assert_allclose(h_flex, h_uhf, rtol=0, atol=1e-8)
 
 
 if __name__ == "__main__":

--- a/tests/test_flex_hf_scf.py
+++ b/tests/test_flex_hf_scf.py
@@ -112,7 +112,7 @@ class TestStandaloneHF(unittest.TestCase):
         self.assertEqual(len(seen), 2)
         self.assertEqual(np.abs(seen[0]["static_new"]).max(), 0.0)              # the map is zero
         np.testing.assert_allclose(np.asarray(gi["sigma_static"])[0, 0],
-                                   0.75 ** 2 * np.broadcast_to(shift, (nvol, norb, norb)), atol=1e-12)
+                                   0.75 ** 2 * np.broadcast_to(shift, (nvol, norb, norb)), rtol=0, atol=1e-12)
         self.assertIn("trans_mod", gi)                                          # input preserved
 
     def test_reset_set_iteration_max_zero_and_provenance(self):

--- a/tests/test_flex_hf_scf.py
+++ b/tests/test_flex_hf_scf.py
@@ -1,0 +1,218 @@
+"""The standalone Hartree-Fock-renormalised FLEX loop (spec 2026-09-06
+sections 1, 2, 4.2-4.3, 5.6; gates G0-off, G5, D7): gate-off inputs are
+byte-identical to develop, the single-band Hubbard HF term is a chemical-
+potential shift, the mean-field seed follows the initial-value
+trajectory, the W-disabled fixed point equals paramagnetic UHFk, the
+reset set, IterationMax = 0 and the provenance block."""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN2 = "tests/rpa/input_2orb"
+_IN1 = "tests/rpa/input"
+
+
+def _build(param_extra=None, path=_IN2, interactions=None, mixing="linear"):
+    import hwave.solver.flex as flex_mod
+    idict = {"path_to_input": path, "Geometry": "geom.dat", "Transfer": "transfer.dat"}
+    idict.update({"CoulombInter": "coulombinter.dat"} if interactions is None else interactions)
+    r = read_input_k.QLMSkInput({"path_to_input": path, "interaction": idict})
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": 32, "IterationMax": 4, "Mix": 0.5, "EPS": 8, "mixing_scheme": mixing}
+    par.update(param_extra or {})
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+_G0_SCRIPT = r'''
+import os, sys, json, logging, numpy as np
+sys.path.insert(0, sys.argv[1] + "/src"); sys.path.insert(0, sys.argv[1])
+import hwave.qlmsio.read_input_k as read_input_k
+import hwave.solver.flex as flex_mod
+out = sys.argv[2]
+logging.basicConfig(level=logging.DEBUG, filename=os.path.join(out, "log.txt"), filemode="w",
+                    format="%(name)s %(levelname)s %(message)s")
+p = "tests/rpa/input_2orb"
+idict = {"path_to_input": p, "Geometry": "geom.dat", "Transfer": "transfer.dat", "CoulombInter": "coulombinter.dat"}
+r = read_input_k.QLMSkInput({"path_to_input": p, "interaction": idict})
+par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1], "Nmat": 32,
+       "IterationMax": 3, "Mix": 0.5, "EPS": 8, "mixing_scheme": "anderson"}
+s = flex_mod.FLEX(r.get_param("ham"), {}, {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"})
+gi = r.get_param("green")
+s.solve(gi, out)
+s.save_results({"path_to_output": out, "sigma": "sigma.npz", "green": "green.npz", "chi0q": "chi0q.npz", "chiq": "chiq.npz"}, gi)
+'''
+
+
+class TestG0Off(unittest.TestCase):
+    """Gate-off inputs: every archive member and the complete log stream
+    equal those of develop (the main checkout)."""
+
+    def test_byte_identity_against_develop(self):
+        here = os.getcwd()
+        develop = os.environ.get("HWAVE_DEVELOP_CHECKOUT",
+                                 os.path.abspath(os.path.join(here, "..", "..", "..")))
+        if not os.path.isdir(os.path.join(develop, "src", "hwave")):
+            self.skipTest("develop checkout not found at {}".format(develop))
+        with tempfile.TemporaryDirectory() as a, tempfile.TemporaryDirectory() as b:
+            for root, out in ((here, a), (develop, b)):
+                subprocess.run([sys.executable, "-B", "-c", _G0_SCRIPT, root, out], check=True, cwd=here)
+            for name in ("sigma.npz", "green.npz", "chi0q.npz", "chiq.npz"):
+                da, db = np.load(os.path.join(a, name), allow_pickle=True), np.load(os.path.join(b, name), allow_pickle=True)
+                self.assertEqual(da.files, db.files, name)
+                for k in da.files:
+                    self.assertEqual(da[k].dtype, db[k].dtype, (name, k))
+                    self.assertTrue(np.array_equal(da[k], db[k]), (name, k))
+            la = open(os.path.join(a, "log.txt")).read().replace(here, "<root>").replace(a, "<out>")
+            lb = open(os.path.join(b, "log.txt")).read().replace(develop, "<root>").replace(b, "<out>")
+            self.assertEqual(la, lb)
+
+
+class TestStandaloneHF(unittest.TestCase):
+
+    def test_single_band_hubbard_hf_is_a_mu_shift(self):
+        """norb=1, on-site U only: Sigma_HF is a constant absorbed by mu, so
+        the dressed Green function equals the HF-off one."""
+        s_on, r1 = _build({"flex_hartree_fock": True}, path=_IN1, interactions={"CoulombIntra": "coulombintra.dat"})
+        s_off, r2 = _build({}, path=_IN1, interactions={"CoulombIntra": "coulombintra.dat"})
+        g_on, g_off = r1.get_param("green"), r2.get_param("green")
+        os.makedirs("tests/flex/output", exist_ok=True)
+        s_on.solve(g_on, "tests/flex/output"); s_off.solve(g_off, "tests/flex/output")
+        st = np.asarray(g_on["sigma_static"])
+        self.assertLess(np.abs(st - st[0, 0, 0, 0, 0]).max(), 1e-12)     # k-independent constant
+        np.testing.assert_allclose(np.asarray(g_on["green"]), np.asarray(g_off["green"]), rtol=0, atol=1e-10)
+        self.assertAlmostEqual(g_on["physics"]["mu"] - g_off["physics"]["mu"], st[0, 0, 0, 0, 0].real, places=9)
+        self.assertAlmostEqual(g_on["physics"]["NCond"], g_off["physics"]["NCond"], places=8)
+
+    def test_d7_trajectory_delta_h_is_never_readded(self):
+        """A trans_mod seed Delta H with the HF map forced to zero and
+        linear mixing m: the static state is (1-m)^k Delta H after k maps."""
+        import hwave.solver.flex_hf as flex_hf
+        s, r = _build({"flex_hartree_fock": True, "IterationMax": 2, "Mix": 0.25})
+        nvol, norb = s.lattice.nvol, s.norb
+        shift = np.diag([0.3, -0.2])
+        H = np.zeros((nvol, 2, norb, 2, norb), complex)
+        base = np.asarray(s.ham_info.ham_trans_q).reshape(nvol, norb, norb)
+        H[:, 0, :, 0, :] = base + shift; H[:, 1, :, 1, :] = base + shift
+        gi = r.get_param("green"); gi["trans_mod"] = H.reshape(nvol, 2 * norb, 2 * norb)
+        real = flex_hf.hf_map
+        flex_hf.hf_map = lambda rho_r, tables, shape, norb_: np.zeros((rho_r.shape[0], norb_, norb_), complex)
+        seen = []
+        s._iteration_hook = lambda d: seen.append(d)
+        try:
+            s.solve(gi, "tests/flex/output")
+        finally:
+            flex_hf.hf_map = real
+        self.assertEqual(len(seen), 2)
+        self.assertEqual(np.abs(seen[0]["static_new"]).max(), 0.0)              # the map is zero
+        np.testing.assert_allclose(np.asarray(gi["sigma_static"])[0, 0],
+                                   0.75 ** 2 * np.broadcast_to(shift, (nvol, norb, norb)), atol=1e-12)
+        self.assertIn("trans_mod", gi)                                          # input preserved
+
+    def test_reset_set_iteration_max_zero_and_provenance(self):
+        s, r = _build({"flex_hartree_fock": True})
+        gi = r.get_param("green")
+        os.makedirs("tests/flex/output", exist_ok=True)
+        s.solve(gi, "tests/flex/output")
+        self.assertEqual(s.scf_iterations, 4)
+        for k in ("sigma", "sigma_static", "sigma_fluct", "green", "physics", "chi0q", "chiq_s", "chiq_c"):
+            self.assertIn(k, gi)
+        np.testing.assert_allclose(gi["sigma"], gi["sigma_static"] + gi["sigma_fluct"], atol=1e-14)
+        # reuse: a second solver on the same container with IterationMax = 0
+        s0, _ = _build({"flex_hartree_fock": True, "IterationMax": 0})
+        gi["chiq_s"] = np.zeros(3)                                             # stale, must vanish
+        s0.solve(gi, "tests/flex/output")
+        for k in ("chi0q", "chiq_s", "chiq_c"):
+            self.assertNotIn(k, gi)
+        for k in ("sigma", "green", "physics"):
+            self.assertIn(k, gi)
+        self.assertEqual((s0.scf_iterations, s0.map_iteration, s0.state_iteration), (0, 0, 0))
+        self.assertTrue(np.isnan(s0.scf_green_residual))
+        with tempfile.TemporaryDirectory() as tmp:
+            s0.save_results({"path_to_output": tmp, "sigma": "s.npz", "green": "g.npz", "chiq": "c.npz"}, gi)
+            d = np.load(os.path.join(tmp, "s.npz"))
+            for k in ("sigma_convention", "sigma_static", "sigma_fluct", "scf_converged", "scf_iterations",
+                      "map_iteration", "state_iteration", "scf_sigma_residual", "scf_green_residual",
+                      "scf_component_residual", "payload_kind", "hf_density_error", "hf_density_source",
+                      "density_target_enforced"):
+                self.assertIn(k, d.files, k)
+            self.assertEqual(str(d["payload_kind"]), "final_state")
+            self.assertEqual(str(d["sigma_convention"]), "split")
+            self.assertFalse(os.path.exists(os.path.join(tmp, "c.npz")) and "chiq_s" in np.load(os.path.join(tmp, "c.npz")).files)
+        # failure atomicity: a refused re-solve leaves nothing produced behind
+        s_bad, _ = _build({"flex_hartree_fock": True})
+        gi["trans_mod"] = np.zeros((s.lattice.nvol, 2 * s.norb, 2 * s.norb), complex)
+        gi["sigma_init_envelope"] = s._read_sigma.__self__ and None
+        gi.pop("sigma_init_envelope")
+        import hwave.solver.flex_hf as flex_hf
+        env = flex_hf.SigmaSeedEnvelope(sigma=np.zeros(1), sigma_static=None, sigma_fluct=None,
+                                        marker="split", ir_meta=None, file_name="x")
+        gi["sigma_init_envelope"] = env
+        with self.assertRaises(ValueError):
+            s_bad.solve(gi, "tests/flex/output")
+        for k in ("sigma", "green", "physics", "chi0q"):
+            self.assertNotIn(k, gi)
+        self.assertFalse(hasattr(s_bad, "physics"))
+
+    def test_hf_off_does_not_write_new_members(self):
+        s, r = _build({})
+        gi = r.get_param("green")
+        os.makedirs("tests/flex/output", exist_ok=True)
+        s.solve(gi, "tests/flex/output")
+        with tempfile.TemporaryDirectory() as tmp:
+            s.save_results({"path_to_output": tmp, "sigma": "s.npz", "chi0q": "c.npz"}, gi)
+            self.assertNotIn("sigma_convention", np.load(os.path.join(tmp, "s.npz")).files)
+            self.assertNotIn("payload_kind", np.load(os.path.join(tmp, "c.npz")).files)
+
+
+class TestG5UHFkFixedPoint(unittest.TestCase):
+
+    def test_w_disabled_fixed_point_equals_paramagnetic_uhfk(self):
+        """Fluctuations disabled: the converged FLEX Hartree-Fock state equals
+        a paramagnetic UHFk run (flag_fock=true, 2Sz=0, same T, per-cell
+        normalisation) at the fixed point."""
+        import hwave.solver.flex as flex_mod
+        from hwave.solver.uhfk import UHFk
+        # FLEX: seed sigma_static = HF map of the bare paramagnetic density (through trans_mod)
+        s, r = _build({"flex_hartree_fock": True, "IterationMax": 400, "Mix": 0.5, "EPS": 10},
+                      path=_IN2, interactions={"CoulombInter": "onsite_inter.dat", "CoulombIntra": "coulombintra.dat"})
+        real = flex_mod.FLEX._calc_self_energy_general
+        flex_mod.FLEX._calc_self_energy_general = lambda self_, g, v, b: np.zeros_like(g)
+        gi = r.get_param("green")
+        try:
+            s.solve(gi, "tests/flex/output")
+        finally:
+            flex_mod.FLEX._calc_self_energy_general = real
+        self.assertTrue(s.scf_converged)
+        # UHFk on the same input, paramagnetic (2Sz = 0), T = 2.0, Ncond = filling * 2 * norb * nvol
+        nvol, norb = s.lattice.nvol, s.norb
+        idict = {"path_to_input": _IN2, "Geometry": "geom.dat", "Transfer": "transfer.dat",
+                 "CoulombInter": "onsite_inter.dat", "CoulombIntra": "coulombintra.dat"}
+        r2 = read_input_k.QLMSkInput({"path_to_input": _IN2, "interaction": idict})
+        par = {"T": 2.0, "Ncond": int(round(0.5 * 2 * norb * nvol)), "2Sz": 0, "flag_fock": True,
+               "CellShape": [4, 4, 1], "SubShape": [1, 1, 1], "IterationMax": 2000, "EPS": 12, "Mix": 0.5,
+               "RndSeed": 1}
+        u = UHFk(r2.get_param("ham"), {"print_level": 1, "print_step": 1}, {"mode": "UHFk", "param": par})
+        with tempfile.TemporaryDirectory() as tmp:
+            u.solve(r2.get_param("green"), tmp)
+        G = u.Green                                                   # (nvol, 2, norb, 2, norb)
+        # the FLEX final-state density
+        from hwave.solver import hartree_fock as hf
+        heff = hf.heff_eigenpairs(np.asarray(s.H0_k)[0], gi["sigma_static"][0, 0])
+        dens = hf.equal_time_density(gi["green"], heff, s.mu, 1.0 / 2.0, (4, 4, 1))
+        np.testing.assert_allclose(G[:, 0, :, 0, :], dens.rho_r, atol=1e-8)
+        np.testing.assert_allclose(G[:, 1, :, 1, :], dens.rho_r, atol=1e-8)
+        self.assertLess(np.abs(G[:, 0, :, 1, :]).max(), 1e-10)
+        h_uhf = np.asarray(u.ham).reshape(nvol, 2, norb, 2, norb)[:, 0, :, 0, :]
+        h_flex = np.asarray(s.H0_k)[0] + gi["sigma_static"][0, 0]
+        np.testing.assert_allclose(h_flex, h_uhf, atol=1e-8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_mixing_split.py
+++ b/tests/test_flex_mixing_split.py
@@ -1,0 +1,105 @@
+"""The provenance-split self-energy state and its mixing (spec 2026-09-06
+sections 2.4 and 5.6): linear pair mixing equals the legacy total update,
+the stacked Anderson mixer with REAL coefficients equals an independent
+reference and applies one coefficient vector to both components, the
+static block stays Hermitian, the cancellation regression, and the
+three-residual pass counter."""
+import unittest
+
+import numpy as np
+
+
+def _herm(rng, shape):
+    a = rng.normal(size=shape) + 1j * rng.normal(size=shape)
+    return 0.5 * (a + np.conj(np.swapaxes(a, -1, -2)))
+
+
+def _state(rng, nmat=6, nvol=4, norb=2):
+    from hwave.solver.flex_mixing import SplitState
+    st = _herm(rng, (1, 1, nvol, norb, norb))
+    fl = _herm(rng, (1, nmat, nvol, norb, norb))
+    return SplitState(static=st, fluct=fl)
+
+
+def _reference_anderson(xs, rs, mix):
+    """Independent stacked-vector Anderson step with a REAL Gram system
+    (spec 2.4): x_{k+1} = x + mix r - (dX + mix dR)^T gamma,
+    gamma = solve(Re(dR dR^H) + lam I, Re(dR conj r))."""
+    m = len(xs)
+    x, r = xs[-1], rs[-1]
+    if m == 1:
+        return x + mix * r
+    dR = np.stack([rs[i + 1] - rs[i] for i in range(m - 1)])
+    dX = np.stack([xs[i + 1] - xs[i] for i in range(m - 1)])
+    G = (dR.conj() @ dR.T).real
+    b = (dR.conj() @ r).real
+    lam = 1.0e-10 * max(float(np.trace(G)) / (m - 1), 1.0e-300)
+    gamma = np.linalg.solve(G + lam * np.eye(m - 1), b)
+    return x + mix * r - (dX + mix * dR).T @ gamma
+
+
+class TestSplitMixing(unittest.TestCase):
+
+    def test_linear_pair_equals_legacy_total(self):
+        from hwave.solver.flex_mixing import linear_mix_pair
+        rng = np.random.default_rng(0)
+        s, n = _state(rng), _state(rng)
+        out = linear_mix_pair(s, n, 0.3)
+        legacy = (1.0 - 0.3) * s.total() + 0.3 * n.total()
+        np.testing.assert_allclose(out.total(), legacy, rtol=0, atol=1e-14)
+        self.assertEqual(out.static.shape, s.static.shape)
+
+    def test_anderson_matches_reference_and_shares_coefficients(self):
+        from hwave.solver.flex_mixing import StackedAndersonMixer, SplitState
+        rng = np.random.default_rng(1)
+        mix, depth = 0.3, 4
+        mixer = StackedAndersonMixer(mix, depth)
+        s = _state(rng)
+        xs, rs = [], []
+        for it in range(6):
+            n = SplitState(static=s.static + 0.1 * _herm(rng, s.static.shape),
+                           fluct=s.fluct + 0.1 * _herm(rng, s.fluct.shape))
+            x = mixer.stack(s); r = mixer.stack(n) - x
+            xs.append(x); rs.append(r)
+            if len(xs) > depth:
+                xs.pop(0); rs.pop(0)
+            ref = _reference_anderson(xs, rs, mix)
+            out = mixer.step(s, n)
+            np.testing.assert_allclose(mixer.stack(out), ref, rtol=0, atol=1e-12)
+            # one real coefficient vector for both components: the sum of the
+            # component outputs equals the same affine combination of the summed histories
+            gamma = mixer.last_gamma
+            if gamma is not None:
+                nb = s.static.size * s.fluct.shape[1]      # the static block is stacked BROADCAST
+                tot_x = [xx[:nb].reshape(s.fluct.shape) + xx[nb:].reshape(s.fluct.shape) for xx in xs]
+                tot_r = [rr[:nb].reshape(s.fluct.shape) + rr[nb:].reshape(s.fluct.shape) for rr in rs]
+                dR = np.stack([tot_r[i + 1] - tot_r[i] for i in range(len(tot_r) - 1)])
+                dX = np.stack([tot_x[i + 1] - tot_x[i] for i in range(len(tot_x) - 1)])
+                exp_total = tot_x[-1] + mix * tot_r[-1] - np.tensordot(gamma, dX + mix * dR, axes=(0, 0))
+                np.testing.assert_allclose(out.total(), exp_total, rtol=0, atol=1e-12)
+            self.assertTrue(np.allclose(out.static, np.conj(np.swapaxes(out.static, -1, -2)), atol=1e-13))
+            s = out
+
+    def test_cancellation_is_not_convergence(self):
+        from hwave.solver.flex_mixing import SplitState, residuals
+        rng = np.random.default_rng(2)
+        s = _state(rng)
+        X = _herm(rng, s.static.shape)
+        n = SplitState(static=s.static + X, fluct=s.fluct - np.repeat(X, s.fluct.shape[1], axis=1))
+        G = rng.normal(size=s.fluct.shape) + 0j
+        res_sigma, res_g, res_comp = residuals(s, n, G, G)
+        self.assertLess(res_sigma, 1e-14)
+        self.assertLess(res_g, 1e-300 + 1e-14)
+        self.assertGreater(res_comp, 1e-2)
+
+    def test_pass_counter_three_consecutive(self):
+        from hwave.solver.flex_mixing import PassCounter
+        pc = PassCounter(eps=1e-6, needed=3)
+        self.assertEqual(pc.update(1e-7, 1e-7, 1e-7), (False, 1))
+        self.assertEqual(pc.update(1e-7, 1e-3, 1e-7), (False, 0))     # any residual above eps resets
+        for expect in ((False, 1), (False, 2), (True, 3)):
+            self.assertEqual(pc.update(1e-8, 1e-8, 1e-8), expect)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_mixing_split.py
+++ b/tests/test_flex_mixing_split.py
@@ -101,5 +101,31 @@ class TestSplitMixing(unittest.TestCase):
             self.assertEqual(pc.update(1e-8, 1e-8, 1e-8), expect)
 
 
+class TestResidualDefinitions(unittest.TestCase):
+
+    def test_res_sigma_equals_the_legacy_convergence_rule(self):
+        """res_sigma is FLEX._calc_convergence's diff / ||sigma_new|| with its
+        1e-30 rule: a cold 0 -> nonzero map gives 1, a near-zero new total
+        the bare difference."""
+        from hwave.solver.flex_mixing import SplitState, residuals
+        rng = np.random.default_rng(0)
+        nmat, nvol, norb = 4, 2, 2
+        z = np.zeros((1, nmat, nvol, norb, norb), complex)
+        zs = np.zeros((1, 1, nvol, norb, norb), complex)
+        x = rng.normal(size=z.shape) + 1j * rng.normal(size=z.shape)
+        s0 = SplitState(static=zs, fluct=z)
+        n1 = SplitState(static=zs, fluct=x)
+        G = np.ones_like(z)
+        self.assertAlmostEqual(residuals(s0, n1, G, G)[0], 1.0, places=14)
+        s1 = SplitState(static=zs, fluct=x)
+        n2 = SplitState(static=zs, fluct=1e-40 * x)
+        diff = float(np.linalg.norm((n2.total() - s1.total()).ravel()))
+        self.assertAlmostEqual(residuals(s1, n2, G, G)[0], diff, places=14)
+        n3 = SplitState(static=zs, fluct=1.5 * x)
+        self.assertAlmostEqual(residuals(s1, n3, G, G)[0],
+                               float(np.linalg.norm((0.5 * x).ravel())) / float(np.linalg.norm((1.5 * x).ravel())),
+                               places=14)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_flex_phase_b_config.py
+++ b/tests/test_flex_phase_b_config.py
@@ -22,6 +22,7 @@ def _build(param_extra=None, mode="FLEX", calc_scheme="general", interactions=No
     par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
            "Nmat": 32, "IterationMax": 1, "Mix": 1.0, "EPS": 1}
     par.update(param_extra or {})
+    par = {k: v for k, v in par.items() if v is not None}
     info = {"mode": mode, "param": par, "enable_spin_orbital": False, "calc_scheme": calc_scheme}
     info.update(info_extra or {})
     if mode == "FLEX":
@@ -125,6 +126,32 @@ class TestPhaseBConfig(unittest.TestCase):
         finally:
             logger.removeHandler(h)
         self.assertFalse([m for m in records if "longitudinal_bond" in m or "flex_hartree_fock" in m])
+
+
+class TestPhaseBDomainRefusals(unittest.TestCase):
+
+    def test_auto_scheme_resolving_to_reduced_is_refused(self):
+        with self.assertRaises(ValueError) as cm:
+            _build({"flex_hartree_fock": True}, calc_scheme="auto",
+                   interactions={"CoulombIntra": "coulombintra.dat"})
+        self.assertIn("general", str(cm.exception))
+        s, _ = _build({"flex_hartree_fock": True}, calc_scheme="auto",
+                      interactions={"CoulombInter": "coulombinter.dat"})   # off-site -> general
+        self.assertEqual(s.calc_scheme, "general")
+
+    def test_nmat_default_and_bounds(self):
+        s, _ = _build({"flex_hartree_fock": True, "Nmat": None})
+        self.assertEqual(s.nmat, 1024)
+        for bad in (0, -2, 7, True, 3.0):
+            with self.subTest(nmat=bad):
+                with self.assertRaises(ValueError):
+                    _build({"flex_hartree_fock": True, "Nmat": bad})
+
+    def test_iteration_max_must_be_non_negative(self):
+        with self.assertRaises(ValueError):
+            _build({"flex_hartree_fock": True, "IterationMax": -1})
+        s, _ = _build({"flex_hartree_fock": True, "IterationMax": 0})
+        self.assertEqual(s.max_iter, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_flex_phase_b_config.py
+++ b/tests/test_flex_phase_b_config.py
@@ -1,0 +1,131 @@
+"""Phase B configuration surface of the FLEX solver (spec 2026-09-06
+sections 4.1 and D6/D9): the keys, their defaults, the refusal precedence
+steps 1-3 (raw key types, domain keys, gate-HF coupling), the stale-key
+warning, and the mode/key matrix (FLEX-only keys are warned-and-ignored
+outside FLEX)."""
+import logging
+import os
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN = "tests/rpa/input_2orb"
+
+
+def _build(param_extra=None, mode="FLEX", calc_scheme="general", interactions=None,
+           info_extra=None):
+    idict = {"path_to_input": _IN, "Geometry": "geom.dat", "Transfer": "transfer.dat"}
+    idict.update({"CoulombInter": "coulombinter.dat"} if interactions is None else interactions)
+    r = read_input_k.QLMSkInput({"path_to_input": _IN, "interaction": idict})
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": 32, "IterationMax": 1, "Mix": 1.0, "EPS": 1}
+    par.update(param_extra or {})
+    info = {"mode": mode, "param": par, "enable_spin_orbital": False, "calc_scheme": calc_scheme}
+    info.update(info_extra or {})
+    if mode == "FLEX":
+        import hwave.solver.flex as flex_mod
+        return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+    import hwave.solver.rpa as rpa_mod
+    info["calc_type"] = "ring"
+    return rpa_mod.RPA(r.get_param("ham"), {}, info), r
+
+
+class TestPhaseBConfig(unittest.TestCase):
+
+    def test_defaults(self):
+        s, _ = _build()
+        self.assertFalse(s.flex_hartree_fock)
+        self.assertFalse(s.longitudinal_bond_channels)
+        self.assertFalse(s.longitudinal_bond_output_full)
+        self.assertIsNone(s.longitudinal_bond_freq_batch)
+        self.assertIsNone(s.longitudinal_bond_max_shells)
+        self.assertEqual(s.longitudinal_bond_memory_cap_gb, 8.0)
+        self.assertFalse(s._phase_b_active)
+
+    def test_keys_case_insensitive_and_active(self):
+        s, _ = _build({"Flex_Hartree_Fock": True, "LONGITUDINAL_bond_channels": True,
+                       "longitudinal_bond_output_full": True, "longitudinal_bond_freq_batch": 4,
+                       "longitudinal_bond_max_shells": 2, "longitudinal_bond_memory_cap_gb": 3.5})
+        self.assertTrue(s.flex_hartree_fock and s.longitudinal_bond_channels)
+        self.assertTrue(s.longitudinal_bond_output_full)
+        self.assertEqual(s.longitudinal_bond_freq_batch, 4)
+        self.assertEqual(s.longitudinal_bond_max_shells, 2)
+        self.assertEqual(s.longitudinal_bond_memory_cap_gb, 3.5)
+        self.assertTrue(s._phase_b_active)
+        s, _ = _build({"flex_hartree_fock": True})
+        self.assertTrue(s._phase_b_active)
+
+    def test_refusals(self):
+        hf = {"flex_hartree_fock": True}
+        gate = {"flex_hartree_fock": True, "longitudinal_bond_channels": True}
+        cases = [
+            ({"flex_hartree_fock": "yes"}, {}, "boolean"),
+            ({"longitudinal_bond_channels": 1}, {}, "boolean"),
+            (dict(hf, Nmat=31), {}, "even"),
+            (dict(hf, matsubara_basis="ir"), {}, "matsubara_basis"),
+            (dict(hf, gpu=True), {}, "gpu"),
+            (dict(hf, SubShape=[2, 1, 1]), {}, "sublattice"),
+            ({"longitudinal_bond_channels": True}, {}, "flex_hartree_fock"),
+            (dict(gate, longitudinal_bond_freq_batch=0), {}, "longitudinal_bond_freq_batch"),
+            (dict(gate, longitudinal_bond_freq_batch=33), {}, "longitudinal_bond_freq_batch"),
+            (dict(gate, longitudinal_bond_max_shells=0), {}, "longitudinal_bond_max_shells"),
+            (dict(gate, longitudinal_bond_memory_cap_gb=0.0), {}, "longitudinal_bond_memory_cap_gb"),
+        ]
+        for extra, info_extra, fragment in cases:
+            with self.subTest(extra=extra):
+                with self.assertRaises(ValueError) as cm:
+                    _build(extra, info_extra=info_extra)
+                self.assertIn(fragment, str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            _build(hf, calc_scheme="reduced")
+        self.assertIn("general", str(cm.exception))
+
+    def test_refusals_precede_the_base_constructor(self):
+        """Odd Nmat is a ValueError from the FLEX parser (before the base
+        constructor's legacy exit) whenever HF or the gate is on; a legacy
+        input keeps the legacy exit."""
+        with self.assertRaises(ValueError):
+            _build({"flex_hartree_fock": True, "Nmat": 31})
+        with self.assertRaises(SystemExit):
+            _build({"Nmat": 31})
+
+    def test_stale_bond_keys_warn_once_and_are_not_parsed(self):
+        with self.assertLogs("hwave.solver.flex", level="WARNING") as cm:
+            s, _ = _build({"longitudinal_bond_output_full": "junk", "longitudinal_bond_freq_batch": -7,
+                           "longitudinal_bond_max_shells": "x", "longitudinal_bond_memory_cap_gb": "y"})
+        msgs = [m for m in cm.output if "longitudinal_bond_output_full" in m]
+        self.assertEqual(len(msgs), 1)
+        for k in ("longitudinal_bond_freq_batch", "longitudinal_bond_max_shells", "longitudinal_bond_memory_cap_gb"):
+            self.assertIn(k, msgs[0])
+        self.assertFalse(s.longitudinal_bond_output_full)
+        self.assertIsNone(s.longitudinal_bond_freq_batch)
+        with self.assertLogs("hwave.solver.flex", level="WARNING") as cm:
+            _build({"flex_hartree_fock": True, "longitudinal_bond_freq_batch": 3})
+        self.assertTrue(any("longitudinal_bond_freq_batch" in m for m in cm.output))
+
+    def test_flex_only_keys_are_ignored_with_a_warning_in_rpa(self):
+        with self.assertLogs("hwave.solver.rpa", level="WARNING") as cm:
+            s, _ = _build({"flex_hartree_fock": True, "longitudinal_bond_output_full": True,
+                           "longitudinal_bond_freq_batch": 2}, mode="RPA")
+        msgs = [m for m in cm.output if "FLEX-only" in m]
+        self.assertEqual(len(msgs), 1)
+        for k in ("flex_hartree_fock", "longitudinal_bond_output_full", "longitudinal_bond_freq_batch"):
+            self.assertIn(k, msgs[0])
+        self.assertFalse(hasattr(s, "flex_hartree_fock"))
+
+    def test_no_new_warning_for_legacy_inputs(self):
+        logger = logging.getLogger("hwave.solver.flex")
+        records = []
+        h = logging.Handler(); h.emit = lambda rec: records.append(rec.getMessage())
+        logger.addHandler(h)
+        try:
+            _build({})
+        finally:
+            logger.removeHandler(h)
+        self.assertFalse([m for m in records if "longitudinal_bond" in m or "flex_hartree_fock" in m])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_sigma_seeds.py
+++ b/tests/test_flex_sigma_seeds.py
@@ -1,0 +1,189 @@
+"""Self-energy seeds of the Phase B design (spec 2026-09-06 section 2.3,
+D7, D10, D15): the seed envelope, the split-file validation, the copied
+mean-field assembly, and the seed matrix under HF off / HF on."""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN = "tests/rpa/input_2orb"
+
+
+def _build(param_extra=None, calc_scheme="general"):
+    import hwave.solver.flex as flex_mod
+    idict = {"path_to_input": _IN, "Geometry": "geom.dat", "Transfer": "transfer.dat",
+             "CoulombInter": "coulombinter.dat"}
+    r = read_input_k.QLMSkInput({"path_to_input": _IN, "interaction": idict})
+    par = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1],
+           "Nmat": 32, "IterationMax": 1, "Mix": 1.0, "EPS": 1}
+    par.update(param_extra or {})
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": calc_scheme}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+class _SeedFiles:
+    """A legacy sigma.npz written by a one-iteration FLEX run, plus split /
+    total / unmarked variants derived from it."""
+
+    def __init__(self, tmp):
+        self.tmp = tmp
+        s, r = _build({})
+        gi = r.get_param("green")
+        s.solve(gi, tmp)
+        s.save_results({"path_to_output": tmp, "sigma": "legacy.npz"}, gi)
+        self.legacy = os.path.join(tmp, "legacy.npz")
+        d = dict(np.load(self.legacy, allow_pickle=True))
+        self.sigma = d["sigma"]
+        self.meta = {k: v for k, v in d.items() if k != "sigma"}
+        rng = np.random.default_rng(0)
+        st = rng.normal(size=self.sigma.shape[2:]) + 1j * rng.normal(size=self.sigma.shape[2:])
+        st = 0.5 * (st + np.conj(np.swapaxes(st, -1, -2)))
+        self.sigma_static = st[None, None]                          # (1, 1, nvol, norb, norb)
+        self.sigma_fluct = self.sigma - self.sigma_static
+        self.split = os.path.join(tmp, "split.npz")
+        np.savez(self.split, sigma=self.sigma, sigma_static=self.sigma_static,
+                 sigma_fluct=self.sigma_fluct, sigma_convention="split", **self.meta)
+        self.total = os.path.join(tmp, "total.npz")
+        np.savez(self.total, sigma=self.sigma, sigma_convention="total", **self.meta)
+
+    def variant(self, name, **changes):
+        d = dict(np.load(self.split, allow_pickle=True))
+        d.update(changes)
+        path = os.path.join(self.tmp, name)
+        np.savez(path, **d)
+        return path
+
+
+class TestSeedEnvelope(unittest.TestCase):
+
+    def test_read_sigma_returns_an_unvalidated_read_only_envelope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _SeedFiles(tmp)
+            s, _ = _build({})
+            env = s._read_sigma(f.split)
+            self.assertEqual(env.marker, "split")
+            self.assertEqual(env.file_name, f.split)
+            self.assertFalse(env.sigma.flags.writeable)
+            self.assertFalse(env.sigma_static.flags.writeable)
+            self.assertEqual(env.sigma_static.shape, (1, 1, 16, 2, 2))
+            env = s._read_sigma(f.legacy)
+            self.assertIsNone(env.marker)
+            self.assertIsNone(env.sigma_static)
+            env = s._read_sigma(f.total)
+            self.assertEqual(env.marker, "total")
+
+    def test_read_init_keeps_the_legacy_array_and_adds_the_envelope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _SeedFiles(tmp)
+            s, _ = _build({})
+            info = s.read_init({"path_to_input": tmp, "sigma_init": "split.npz"})
+            np.testing.assert_array_equal(info["sigma_init"], f.sigma)
+            self.assertEqual(info["sigma_init_envelope"].marker, "split")
+
+    def test_validate_split_seed_rules(self):
+        from hwave.solver import flex_hf
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _SeedFiles(tmp)
+            s, _ = _build({})
+            ok = s._read_sigma(f.split)
+            st, fl = flex_hf.validate_split_seed(ok, f.sigma.shape)
+            np.testing.assert_array_equal(st, f.sigma_static)
+            np.testing.assert_array_equal(fl, f.sigma_fluct)
+            bad_sum = f.variant("bad_sum.npz", sigma_fluct=f.sigma_fluct + 1e-6)
+            bad_shape = f.variant("bad_shape.npz", sigma_static=f.sigma_static[:, :, :8])
+            nonherm = f.sigma_static.copy(); nonherm[0, 0, :, 0, 1] += 0.1
+            bad_herm = f.variant("bad_herm.npz", sigma_static=nonherm, sigma_fluct=f.sigma - nonherm)
+            bad_freq = f.variant("bad_freq.npz", sigma_static=np.repeat(f.sigma_static, 2, axis=1))
+            nan = f.sigma_fluct.copy(); nan[0, 0, 0, 0, 0] = np.nan
+            bad_nan = f.variant("bad_nan.npz", sigma_fluct=nan)
+            unknown = f.variant("unknown.npz", sigma_convention="weird")
+            for path in (bad_sum, bad_shape, bad_herm, bad_freq, bad_nan, unknown):
+                with self.subTest(path=os.path.basename(path)):
+                    with self.assertRaises(ValueError):
+                        flex_hf.validate_split_seed(s._read_sigma(path), f.sigma.shape)
+
+
+class TestMeanFieldSeed(unittest.TestCase):
+
+    def test_calc_trans_mod_copy_matches_and_does_not_mutate(self):
+        s, r = _build({})
+        nd = 2 * s.norb
+        rng = np.random.default_rng(2)
+        g0 = rng.normal(size=(1, nd, nd)) + 1j * rng.normal(size=(1, nd, nd))
+        g0 = 0.5 * (g0 + np.conj(np.swapaxes(g0, -1, -2)))
+        before_r = s.ham_info.ham_trans_r.copy()
+        before_q = s.ham_info.ham_trans_q.copy()
+        ref = s._calc_trans_mod(g0.copy())            # the legacy helper mutates ham_trans_r
+        s.ham_info.ham_trans_r[...] = before_r
+        got = s._calc_trans_mod_copy(g0)
+        np.testing.assert_array_equal(got, ref)
+        np.testing.assert_array_equal(s.ham_info.ham_trans_r, before_r)
+        np.testing.assert_array_equal(s.ham_info.ham_trans_q, before_q)
+
+    def _paramagnetic_trans_mod(self, s, shift):
+        nvol, norb = s.lattice.nvol, s.norb
+        H = np.zeros((nvol, 2, norb, 2, norb), complex)
+        base = np.asarray(s.ham_info.ham_trans_q).reshape(nvol, norb, norb)
+        H[:, 0, :, 0, :] = base + shift
+        H[:, 1, :, 1, :] = base + shift
+        return H.reshape(nvol, 2 * norb, 2 * norb)
+
+    def test_seed_matrix_hf_on(self):
+        from hwave.solver import flex_hf
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _SeedFiles(tmp)
+            s, r = _build({"flex_hartree_fock": True})
+            nvol, norb, nmat = s.lattice.nvol, s.norb, s.nmat
+            shift = np.diag([0.3, -0.2])
+            expected = (1, nmat, nvol, norb, norb)
+            # none: zero
+            st, fl = s._assemble_static_seed({}, expected)
+            self.assertEqual(st.shape, (1, 1, nvol, norb, norb)); self.assertEqual(np.abs(st).max(), 0.0)
+            self.assertEqual(np.abs(fl).max(), 0.0)
+            # trans_mod -> Delta H (bare band stays bare)
+            gi = {"trans_mod": self._paramagnetic_trans_mod(s, shift)}
+            st, fl = s._assemble_static_seed(gi, expected)
+            np.testing.assert_allclose(st[0, 0], np.broadcast_to(shift, (nvol, norb, norb)), atol=1e-12)
+            self.assertIn("trans_mod", gi)                       # inputs preserved
+            # split seed: components as stored
+            env = s._read_sigma(f.split)
+            st, fl = s._assemble_static_seed({"sigma_init_envelope": env}, expected)
+            np.testing.assert_array_equal(st, f.sigma_static); np.testing.assert_array_equal(fl, f.sigma_fluct)
+            # split + mean field: refused (D15)
+            with self.assertRaises(ValueError) as cm:
+                s._assemble_static_seed({"sigma_init_envelope": env, "trans_mod": gi["trans_mod"]}, expected)
+            self.assertIn("trans_mod", str(cm.exception))
+            # total / unmarked: refused naming the converter
+            for path in (f.total, f.legacy):
+                with self.assertRaises(ValueError) as cm:
+                    s._assemble_static_seed({"sigma_init_envelope": s._read_sigma(path)}, expected)
+                self.assertIn("hwave_sigma_split", str(cm.exception))
+            # spin-diag trans_mod: refused at step 4 (spin classification)
+            H = gi["trans_mod"].reshape(nvol, 2, norb, 2, norb).copy(); H[:, 1, :, 1, :] += 0.5
+            with self.assertRaises(ValueError) as cm:
+                s._assemble_static_seed({"trans_mod": H.reshape(nvol, 2 * norb, 2 * norb)}, expected)
+            self.assertIn("spin", str(cm.exception))
+            # trans_mod and green_init: trans_mod wins (INFO)
+            g0 = np.zeros((1, 2 * norb, 2 * norb), complex)
+            with self.assertLogs("hwave.solver.flex", level="INFO") as lg:
+                st2, _ = s._assemble_static_seed({"trans_mod": gi["trans_mod"], "green_init": g0}, expected)
+            np.testing.assert_array_equal(st2, st if False else s._assemble_static_seed(gi, expected)[0])
+            self.assertTrue(any("trans_mod" in m and "green_init" in m for m in lg.output))
+
+    def test_hf_off_paths_unchanged(self):
+        """With HF off the legacy array contract is what the loop consumes:
+        a total seed is one array, a split seed's total is used."""
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _SeedFiles(tmp)
+            s, _ = _build({})
+            info = s.read_init({"path_to_input": tmp, "sigma_init": "total.npz"})
+            np.testing.assert_array_equal(info["sigma_init"], f.sigma)
+            info = s.read_init({"path_to_input": tmp, "sigma_init": "split.npz"})
+            np.testing.assert_array_equal(info["sigma_init"], f.sigma)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flex_sigma_seeds.py
+++ b/tests/test_flex_sigma_seeds.py
@@ -202,5 +202,27 @@ class TestSplitTailDiagnostic(unittest.TestCase):
         self.assertLess(emax, 1e-8)
 
 
+class TestMarkerAdmissibilityAtRead(unittest.TestCase):
+
+    def test_unknown_marker_refused_and_split_used_as_total_without_hf(self):
+        import hwave.solver.flex as flex_mod
+        with tempfile.TemporaryDirectory() as out:
+            files = _SeedFiles(out)
+            unknown = files.variant("unknown.npz", sigma_convention=np.str_("weird"))
+            # unknown marker: refused at read time, HF on or off
+            for hf in (False, True):
+                s, r = _build({"flex_hartree_fock": hf})
+                with self.assertRaises(ValueError) as cm:
+                    s.read_init({"path_to_input": out, "sigma_init": os.path.basename(unknown)})
+                self.assertIn("sigma_convention", str(cm.exception))
+            # split archive without HF: one INFO line, the total is the seed
+            s, r = _build({"flex_hartree_fock": False})
+            with self.assertLogs("hwave.solver.flex", level="INFO") as cm:
+                info = s.read_init({"path_to_input": out, "sigma_init": os.path.basename(files.split)})
+            self.assertTrue(any("used as the one seed" in m for m in cm.output))
+            np.testing.assert_array_equal(info["sigma"] if "sigma" in info else info["sigma_init"],
+                                          np.load(files.split)["sigma"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_flex_sigma_seeds.py
+++ b/tests/test_flex_sigma_seeds.py
@@ -185,5 +185,22 @@ class TestMeanFieldSeed(unittest.TestCase):
             np.testing.assert_array_equal(info["sigma_init"], f.sigma)
 
 
+class TestSplitTailDiagnostic(unittest.TestCase):
+
+    def test_ratio_and_window_rule(self):
+        from hwave.solver.flex_hf import split_tail_diagnostic
+        nmat, nvol = 64, 3
+        wn = (2 * np.arange(nmat) + 1 - nmat) * np.pi
+        odd = (1.0 / (1j * wn))[None, :, None, None, None] * np.ones((1, 1, nvol, 1, 1))
+        self.assertIsNone(split_tail_diagnostic(odd[:, :31], 31))
+        r, emax = split_tail_diagnostic(odd, nmat)
+        self.assertLess(emax, 1e-14)
+        r, emax = split_tail_diagnostic(odd + 0.3, nmat)
+        self.assertGreater(r, 0.1)
+        self.assertAlmostEqual(emax, 0.3, places=12)
+        r, emax = split_tail_diagnostic(odd + 1e-9, nmat)
+        self.assertLess(emax, 1e-8)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hartree_fock_kernel.py
+++ b/tests/test_hartree_fock_kernel.py
@@ -1,0 +1,568 @@
+"""Bit-identity oracle for the Hartree-Fock kernel extracted from UHFk
+(#181 Phase B, spec 2026-09-06 section 2.2).
+
+``_LegacyUHFk`` carries the PRE-refactor bodies of ``UHFk._make_ham_inter`` and
+``UHFk._make_ham`` VERBATIM (extracted mechanically from develop 703ca32c before
+the refactor; do not edit them). The new ``hwave.solver.hartree_fock`` kernel
+must reproduce their arithmetic bit for bit on every interaction type, with
+and without the Fock term, on complex, non-symmetric paramagnetic and
+non-paramagnetic densities.
+"""
+import logging
+import unittest
+
+import numpy as np
+
+from hwave.qlmsio import wan90
+from hwave.solver.kgrid import reverse_fft_axes
+
+logger = logging.getLogger(__name__)
+
+
+def exit(code):  # the legacy body calls exit(1) on the ambiguous Coulomb case
+    raise SystemExit(code)
+
+
+class _LegacyUHFk:
+    """Just enough state for the two legacy methods (normal mode only)."""
+
+    def __init__(self, param_ham, norb, shape, iflag_fock):
+        self.param_ham = param_ham
+        self.shape = tuple(shape)
+        self.nvol = int(np.prod(shape))
+        self.norb = norb
+        self.ns = 2
+        self.nd = 2 * norb
+        self.enable_spin_orbital = False
+        self.iflag_fock = iflag_fock
+        self.block_info = [list(range(self.nd))]
+        self.ham_trans = np.zeros((self.nvol, self.nd, self.nd), dtype=np.complex128)
+
+    def _make_ham_inter(self):
+        logger.debug(">>> _make_ham_inter")
+
+        nx,ny,nz = self.shape
+        nvol     = self.nvol
+        # In spin-orbital mode, interaction arrays use physical orbital count
+        norb     = self.norb_phys if self.enable_spin_orbital else self.norb
+        nd       = self.nd
+
+        #----------------
+        # interaction table
+        #----------------
+        self.inter_table = {}
+        self.spin_table = {}
+
+        #----------------
+        # Coulomb Intra and Coulomb Inter
+        #----------------
+        if 'Coulomb' in self.param_ham.keys():
+            # The aggregate 'Coulomb' input already provides both the intra and
+            # inter parts; combining it with explicit CoulombIntra/CoulombInter
+            # is ambiguous (the explicit terms would be silently dropped).
+            if ('CoulombIntra' in self.param_ham.keys()
+                    or 'CoulombInter' in self.param_ham.keys()):
+                logger.error(
+                    "Coulomb cannot be specified together with "
+                    "CoulombIntra or CoulombInter")
+                exit(1)
+
+            # assume zvo_ur.dat
+            # divide into r=0 (coulomb intra) and r!=0 (coulomb inter)
+            # via the decomposition shared with RPA/FLEX
+            coulomb_intra, coulomb_inter = wan90.split_coulomb(
+                self.param_ham["Coulomb"])
+
+            # coulomb intra: diagonal part of r=0 cell
+            uab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            # coulomb inter: off-diagonal part
+            vab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            for (irvec,orbvec), v in coulomb_intra.items():
+                uab_r[(*irvec,*orbvec)] += v
+            for (irvec,orbvec), v in coulomb_inter.items():
+                vab_r[(*irvec,*orbvec)] += v
+
+            # coulomb intra
+            # interaction coeffs
+            self.inter_table["CoulombIntra"] = uab_r # r=0 component
+            # spin combination
+            self.spin_table["CoulombIntra"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["CoulombIntra"][0,1,1,0] = 1
+            self.spin_table["CoulombIntra"][1,0,0,1] = 1
+
+            #XXX
+            # n_up n_up = n_up -> include in one-body term
+
+            # coulomb inter
+            # J~ab(r) = Jab(r) + Jba(-r)
+            vba = np.conjugate(
+                np.transpose(
+                    reverse_fft_axes(vab_r, (0, 1, 2)),
+                    (0,1,2,4,3)
+                )
+            )
+
+            # interaction coeffs
+            self.inter_table["CoulombInter"] = (vab_r + vba)/2
+            # spin combination
+            self.spin_table["CoulombInter"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["CoulombInter"][0,0,0,0] = 1
+            self.spin_table["CoulombInter"][1,1,1,1] = 1
+            self.spin_table["CoulombInter"][0,1,1,0] = 1
+            self.spin_table["CoulombInter"][1,0,0,1] = 1
+
+        else:
+            self.inter_table["CoulombIntra"] = None
+            self.inter_table["CoulombInter"] = None
+
+            # coulomb intra
+            if 'CoulombIntra' in self.param_ham.keys():
+                uab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+                # only r=0 and a=b component
+                for (irvec,orbvec), v in self.param_ham["CoulombIntra"].items():
+                    alpha, beta = orbvec
+                    if irvec == (0,0,0) and alpha == beta:
+                        uab_r[(*irvec, *orbvec)] += v
+
+                # interaction coeffs
+                self.inter_table["CoulombIntra"] = uab_r
+                # spin combination
+                self.spin_table["CoulombIntra"] = np.zeros((2,2,2,2), dtype=int)
+                self.spin_table["CoulombIntra"][0,1,1,0] = 1
+                self.spin_table["CoulombIntra"][1,0,0,1] = 1
+
+            if 'CoulombInter' in self.param_ham.keys():
+                vab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+                for (irvec,orbvec), v in self.param_ham["CoulombInter"].items():
+#                    if irvec != (0,0,0):
+                        vab_r[(*irvec, *orbvec)] += v
+
+                vba = np.conjugate(
+                    np.transpose(
+                        reverse_fft_axes(vab_r, (0, 1, 2)),
+                        (0,1,2,4,3)
+                    )
+                )
+
+                # interaction coeffs
+                self.inter_table["CoulombInter"] = (vab_r + vba)/2
+                # spin combination
+                self.spin_table["CoulombInter"] = np.zeros((2,2,2,2), dtype=int)
+                self.spin_table["CoulombInter"][0,0,0,0] = 1
+                self.spin_table["CoulombInter"][1,1,1,1] = 1
+                self.spin_table["CoulombInter"][0,1,1,0] = 1
+                self.spin_table["CoulombInter"][1,0,0,1] = 1
+
+        #----------------
+        # Hund
+        #----------------        
+        if 'Hund' in self.param_ham.keys():
+            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            for (irvec,orbvec), v in self.param_ham["Hund"].items():
+                jab_r[(*irvec, *orbvec)] += v
+
+            # J~ab(r) = Jab(r) + Jba(-r)
+            jba = np.conjugate(
+                np.transpose(
+                    reverse_fft_axes(jab_r, (0, 1, 2)),
+                    (0,1,2,4,3)
+                )
+            )
+
+            # interaction coeffs : -J^{Hund} by convention
+            self.inter_table["Hund"] = -(jab_r + jba)/2
+            # spin combination
+            self.spin_table["Hund"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["Hund"][0,0,0,0] = 1
+            self.spin_table["Hund"][1,1,1,1] = 1
+        else:
+            self.inter_table["Hund"] = None
+
+        #----------------
+        # Ising
+        #----------------
+        if 'Ising' in self.param_ham.keys():
+            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            for (irvec,orbvec), v in self.param_ham["Ising"].items():
+                jab_r[(*irvec, *orbvec)] += v
+
+            # J~ab(r) = Jab(r) + Jba(-r)
+            jba = np.conjugate(
+                np.transpose(
+                    reverse_fft_axes(jab_r, (0, 1, 2)),
+                    (0,1,2,4,3)
+                )
+            )
+
+            # interaction coeffs -- no 1/4: the documented Hamiltonian is
+            # J (n_up - n_down)(n_up - n_down), and the RPA/FLEX vertex
+            # content was adjudicated by exact diagonalization against
+            # exactly that operator (#106); the historical /4 read the
+            # file as J S^z S^z instead, so the same Ising file meant
+            # couplings differing by 4 between UHFk and RPA/FLEX
+            self.inter_table["Ising"] = (jab_r + jba)/2
+            # spin combination
+            self.spin_table["Ising"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["Ising"][0,0,0,0] = 1
+            self.spin_table["Ising"][1,1,1,1] = 1
+            self.spin_table["Ising"][0,1,1,0] = -1
+            self.spin_table["Ising"][1,0,0,1] = -1
+        else:
+            self.inter_table["Ising"] = None
+
+        #----------------
+        # PairLift
+        #----------------
+        if 'PairLift' in self.param_ham.keys():
+            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            for (irvec,orbvec), v in self.param_ham["PairLift"].items():
+                jab_r[(*irvec, *orbvec)] += v
+
+            # J~ab(r) = Jab(r) + Jba(-r)
+            jba = np.conjugate(
+                np.transpose(
+                    reverse_fft_axes(jab_r, (0, 1, 2)),
+                    (0,1,2,4,3)
+                )
+            )
+
+            # interaction coeffs
+            self.inter_table["PairLift"] = (jab_r + jba)/2
+            # spin combination
+            self.spin_table["PairLift"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["PairLift"][0,0,1,1] = 1
+            self.spin_table["PairLift"][1,1,0,0] = 1
+        else:
+            self.inter_table["PairLift"] = None
+
+        #----------------
+        # Exchange
+        #----------------
+        if 'Exchange' in self.param_ham.keys():
+            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            for (irvec,orbvec), v in self.param_ham["Exchange"].items():
+                jab_r[(*irvec, *orbvec)] += v
+
+            # J~ab(r) = Jab(r) + Jba(-r)
+            jba = np.conjugate(
+                np.transpose(
+                    reverse_fft_axes(jab_r, (0, 1, 2)),
+                    (0,1,2,4,3)
+                )
+            )
+
+            # interaction coeffs : -J^{Ex} by convention
+            self.inter_table["Exchange"] = -(jab_r + jba)/2
+            # spin combination
+            self.spin_table["Exchange"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["Exchange"][0,1,0,1] = 1
+            self.spin_table["Exchange"][1,0,1,0] = 1
+        else:
+            self.inter_table["Exchange"] = None
+
+        #----------------
+        # PairHop
+        #----------------
+        if 'PairHop' in self.param_ham.keys():
+            jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
+
+            for (irvec,orbvec), v in self.param_ham["PairHop"].items():
+                jab_r[(*irvec, *orbvec)] += v
+
+            # J~ab(r) = Jab(r) + Jba(-r)
+            jba = np.conjugate(
+                np.transpose(
+                    reverse_fft_axes(jab_r, (0, 1, 2)),
+                    (0,1,2,4,3)
+                )
+            )
+
+            # interaction coeffs
+            self.inter_table["PairHop"] = (jab_r + jba)/2
+            # spin combination
+            self.spin_table["PairHop"] = np.zeros((2,2,2,2), dtype=int)
+            self.spin_table["PairHop"][0,1,1,0] = 1
+            self.spin_table["PairHop"][1,0,0,1] = 1
+        else:
+            self.inter_table["PairHop"] = None
+
+    def _make_ham(self):
+        logger.debug(">>> _make_ham")
+
+        nx,ny,nz = self.shape
+        nvol     = self.nvol
+        nd       = self.nd
+        ns       = self.ns
+
+        # In spin-orbital mode, use virtual (ns=2, norb_phys) form for interactions
+        if self.enable_spin_orbital:
+            norb_inter = self.norb_phys
+            nd_virt = 2 * norb_inter
+            gab_r = self._so_to_virtual_green(self.Green)
+        else:
+            norb_inter = self.norb
+            nd_virt = nd
+            gab_r = self.Green
+
+        # green function G_{ab,st}(r) : gab_r(r,s,a,t,b)
+        # diagonal part G_{bb,st}(r=0) : gbb(s,t,b)
+        gbb = np.diagonal(gab_r, axis1=2, axis2=4)[0,:,:,:]
+
+        # hamiltonian H_{ab,st}(k) : ham(k,(s,a),(t,b))
+        ham = np.zeros((nvol,nd,nd), dtype=np.complex128)
+
+        # transfer term  T_{ab}(k) (note convention)
+        logger.debug("Transfer")
+        ham += self.ham_trans
+
+        # interaction term: Coulomb type
+        for type in ['CoulombIntra', 'CoulombInter', 'Hund', 'Ising', 'PairLift', 'Exchange']:
+            if self.inter_table[type] is not None:
+                logger.debug(type)
+
+                # coefficient of interaction term J_{ab}(r)
+                jab_r = self.inter_table[type].reshape(nvol,norb_inter,norb_inter)
+                # and its spin combination  Spin(s1,s2,s3,s4)
+                spin = self.spin_table[type]
+
+                # non-cross term
+                #   sum_r J_{ab}(r) G_{bb,uv}(0) Spin{s,u,v,t}
+                hh0 = np.einsum('uvb, suvt -> stb', gbb, spin)
+                hh1 = np.einsum('rab, stb -> rsta', jab_r, hh0)
+                hh2 = np.einsum('rsta, ab -> rsatb', hh1, np.eye(norb_inter, norb_inter))
+                hh3 = np.sum(hh2, axis=0)  # shape: (2, norb_inter, 2, norb_inter)
+
+                if self.enable_spin_orbital:
+                    hh3_nd = self._virtual_ham_to_so(
+                        np.broadcast_to(hh3.reshape(1, 2, norb_inter, 2, norb_inter),
+                                       (nvol, 2, norb_inter, 2, norb_inter)).copy()
+                    )
+                else:
+                    hh3_nd = np.broadcast_to(hh3.reshape(nd, nd), (nvol, nd, nd))
+
+                ham += hh3_nd
+
+                # cross term
+                #   - sum_r J_{ab}(r) G_{ba,uv}(r) Spin{s,u,t,v} e^{ikr}
+                if self.iflag_fock:
+                    hh4 = np.einsum('rab, rubva, sutv -> rsatb', jab_r, gab_r, spin, optimize=True)
+
+                    #   fourier transform: sum_r (*) e^{ikr}
+                    hh5 = np.fft.ifftn(hh4.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+
+                    if self.enable_spin_orbital:
+                        ham -= self._virtual_ham_to_so(
+                            hh5.reshape(nvol, 2, norb_inter, 2, norb_inter)
+                        )
+                    else:
+                        ham -= hh5.reshape(nvol, nd, nd)
+
+        # interaction term: PairHop type
+        for type in ['PairHop']:
+            if self.inter_table[type] is not None:
+                logger.debug(type)
+
+                # coefficient of interaction term J_{ab}(r)
+                jab_r = self.inter_table[type].reshape(nvol,norb_inter,norb_inter)
+                # and its spin combination  Spin(s1,s2,s3,s4)
+                spin = self.spin_table[type]
+
+                # non-cross and cross term
+                #   + sum_r J_{ab}(r) G_{ab,uv}(-r) Spin{s,u,v,t} e^{ikr}
+                #   - sum_r J_{ab}(r) G_{ab,uv}(-r) Spin{s,u,t,v} e^{ikr}
+
+                if self.iflag_fock:
+                    hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
+                    hh2 = np.einsum('rvbua, sutv -> rsbta', np.conjugate(gab_r), spin)
+                    hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, (hh1 - hh2))
+                    hh4 = np.fft.ifftn(hh3.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+                else:
+                    hh1 = np.einsum('rvbua, suvt -> rsbta', np.conjugate(gab_r), spin)
+                    hh3 = np.einsum('rab, rsbta -> rsatb', jab_r, hh1)
+                    hh4 = np.fft.ifftn(hh3.reshape(nx,ny,nz,nd_virt,nd_virt), axes=(0,1,2), norm='forward')
+
+                if self.enable_spin_orbital:
+                    ham += self._virtual_ham_to_so(
+                        hh4.reshape(nvol, 2, norb_inter, 2, norb_inter)
+                    )
+                else:
+                    ham += hh4.reshape(nvol, nd, nd)
+
+        # Enforce block structure: zero out cross-block entries
+        if len(self.block_info) > 1:
+            mask = np.zeros((nd, nd), dtype=bool)
+            for blk in self.block_info:
+                idx = np.array(blk)
+                ix = np.ix_(idx, idx)
+                mask[ix] = True
+            ham[:, ~mask] = 0.0
+
+        # store
+        self.ham = ham
+
+
+def _random_density(rng, nvol, norb, paramagnetic):
+    """Hermitian-closed real-space density rho[r, s, a, t, b] with
+    rho(r) = conj(rho(-r))^T on the (s,a),(t,b) axes."""
+    nd = 2 * norb
+    g = rng.normal(size=(nvol, nd, nd)) + 1j * rng.normal(size=(nvol, nd, nd))
+    if paramagnetic:
+        blk = g[:, :norb, :norb]
+        g = np.zeros_like(g)
+        g[:, :norb, :norb] = blk
+        g[:, norb:, norb:] = blk
+    return g.reshape(nvol, 2, norb, 2, norb)
+
+
+def _cases():
+    rng = np.random.default_rng(7)
+    shape = (2, 2, 1)
+    nvol = 4
+    one = {"CoulombIntra": {((0, 0, 0), (0, 0)): 2.0}}
+    kanamori = {
+        "CoulombIntra": {((0, 0, 0), (0, 0)): 2.0, ((0, 0, 0), (1, 1)): 1.5},
+        "CoulombInter": {((0, 0, 0), (0, 1)): 0.7, ((0, 0, 0), (1, 0)): 0.7},
+        "Hund": {((0, 0, 0), (0, 1)): 0.3, ((0, 0, 0), (1, 0)): 0.3},
+        "Exchange": {((0, 0, 0), (0, 1)): 0.3, ((0, 0, 0), (1, 0)): 0.3},
+        "PairHop": {((0, 0, 0), (0, 1)): 0.3, ((0, 0, 0), (1, 0)): 0.3},
+    }
+    offsite = {
+        "CoulombInter": {((1, 0, 0), (0, 1)): 0.4, ((-1, 0, 0), (1, 0)): 0.4,
+                         ((0, 1, 0), (0, 0)): 0.2, ((0, -1, 0), (0, 0)): 0.2},
+        "Hund": {((1, 0, 0), (0, 0)): 0.1, ((-1, 0, 0), (0, 0)): 0.1},
+        "Ising": {((1, 0, 0), (0, 1)): 0.15, ((-1, 0, 0), (1, 0)): 0.15},
+        "PairLift": {((1, 0, 0), (0, 1)): 0.05, ((-1, 0, 0), (1, 0)): 0.05},
+        "Exchange": {((0, 1, 0), (0, 1)): 0.12, ((0, -1, 0), (1, 0)): 0.12},
+        "PairHop": {((1, 0, 0), (0, 1)): 0.08, ((-1, 0, 0), (1, 0)): 0.08},
+    }
+    aggregate = {"Coulomb": {((0, 0, 0), (0, 0)): 2.0, ((1, 0, 0), (0, 1)): 0.3,
+                             ((-1, 0, 0), (1, 0)): 0.3}}
+    return [
+        (one, 1, shape, _random_density(rng, nvol, 1, True)),
+        (kanamori, 2, shape, _random_density(rng, nvol, 2, True)),
+        (offsite, 2, shape, _random_density(rng, nvol, 2, True)),
+        (offsite, 2, shape, _random_density(rng, nvol, 2, False)),
+        (aggregate, 2, shape, _random_density(rng, nvol, 2, True)),
+    ]
+
+
+class TestKernelBitIdentity(unittest.TestCase):
+
+    def test_tables_equal_legacy(self):
+        from hwave.solver import hartree_fock as hf
+        for param_ham, norb, shape, _ in _cases():
+            with self.subTest(types=sorted(param_ham)):
+                got = hf.build_interaction_tables(param_ham, norb, shape)
+                leg = _LegacyUHFk(param_ham, norb, shape, True)
+                leg._make_ham_inter()
+                self.assertEqual(set(got.inter_table), set(leg.inter_table))
+                for k in leg.inter_table:
+                    if leg.inter_table[k] is None:
+                        self.assertIsNone(got.inter_table[k], k)
+                        continue
+                    self.assertTrue(np.array_equal(leg.inter_table[k], got.inter_table[k]), k)
+                    self.assertTrue(np.array_equal(leg.spin_table[k], got.spin_table[k]), k)
+
+    def test_accumulate_equal_legacy_both_fock_settings(self):
+        from hwave.solver import hartree_fock as hf
+        rng = np.random.default_rng(3)
+        for param_ham, norb, shape, rho in _cases():
+            tabs = hf.build_interaction_tables(param_ham, norb, shape)
+            nvol = int(np.prod(shape))
+            nd = 2 * norb
+            ham0 = rng.normal(size=(nvol, nd, nd)) + 1j * rng.normal(size=(nvol, nd, nd))
+            for fock in (True, False):
+                with self.subTest(types=sorted(param_ham), fock=fock):
+                    leg = _LegacyUHFk(param_ham, norb, shape, fock)
+                    leg._make_ham_inter()
+                    leg.ham_trans = ham0.copy()
+                    leg.Green = rho
+                    leg._make_ham()
+                    out = ham0.copy()
+                    hf.accumulate_hf(out, rho, tabs.inter_table, tabs.spin_table, shape,
+                                     include_fock=fock)
+                    self.assertTrue(np.array_equal(out, leg.ham))
+
+    def test_discarded_report_in_fixed_type_order(self):
+        from hwave.solver import hartree_fock as hf
+        ph = {"CoulombIntra": {((1, 0, 0), (0, 0)): 1.0, ((0, 0, 0), (0, 1)): 0.5,
+                               ((0, 0, 0), (0, 0)): 2.0}}
+        tabs = hf.build_interaction_tables(ph, 2, (2, 2, 1))
+        self.assertEqual(tabs.discarded,
+                         (("CoulombIntra", (1, 0, 0), (0, 0), 1.0),
+                          ("CoulombIntra", (0, 0, 0), (0, 1), 0.5)))
+        self.assertEqual(tabs.inter_table["CoulombIntra"][0, 0, 0, 0, 0], 2.0)
+        self.assertEqual(hf.build_interaction_tables({}, 1, (2, 2, 1)).discarded, ())
+
+    def test_ambiguous_coulomb_is_a_valueerror(self):
+        from hwave.solver import hartree_fock as hf
+        with self.assertRaises(ValueError):
+            hf.build_interaction_tables({"Coulomb": {}, "CoulombIntra": {}}, 1, (2, 2, 1))
+
+    def test_helpers(self):
+        from hwave.solver import hartree_fock as hf
+        a = np.array([[[1.0, 2.0 + 1j], [2.0 - 1j, 3.0]]])
+        ok, err = hf.is_hermitian_batch(a)
+        self.assertTrue(ok); self.assertEqual(err, 0.0)
+        ok, err = hf.is_hermitian_batch(a + np.array([[[0, 1e-3], [0, 0]]]))
+        self.assertFalse(ok); self.assertGreater(err, 1e-4)
+        self.assertTrue(issubclass(hf.NonFiniteError, FloatingPointError))
+
+
+class TestUHFkSolverBitIdentity(unittest.TestCase):
+    """The production UHFk (normal mode) builds exactly the legacy
+    Hamiltonian on real fixtures, iteration by iteration."""
+
+    def _run(self, case, fock):
+        import os, tempfile, tomli
+        from hwave.qlmsio import read_input_k
+        from hwave.solver.uhfk import UHFk
+        cur = os.getcwd()
+        os.chdir(os.path.join("tests", "uhfk", case))
+        try:
+            with open("input.toml", "rb") as f:
+                params = tomli.load(f)
+            params["file"]["input"].pop("initial", None)
+            params["mode"]["param"]["flag_fock"] = fock
+            params["mode"]["param"]["IterationMax"] = 3
+            read_io = read_input_k.QLMSkInput(params["file"]["input"])
+            ham_info = read_io.get_param("ham")
+            green_info = read_io.get_param("green")
+            solver = UHFk(ham_info, params["log"], params["mode"])
+            seen = []
+            orig = solver._make_ham
+
+            def spy():
+                orig()
+                leg = _LegacyUHFk(solver.param_ham, solver.norb, solver.shape, solver.iflag_fock)
+                leg._make_ham_inter()
+                leg.ham_trans = solver.ham_trans
+                leg.Green = solver.Green
+                leg.block_info = solver.block_info
+                leg._make_ham()
+                seen.append(np.array_equal(solver.ham, leg.ham))
+            solver._make_ham = spy
+            with tempfile.TemporaryDirectory() as tmp:
+                solver.solve(green_info, tmp)
+            return seen
+        finally:
+            os.chdir(cur)
+
+    def test_every_fixture_every_iteration(self):
+        for case in ("CoulombIntra", "CoulombInter", "Ising", "Exchange", "PairHop", "PairLift", "2sz0"):
+            for fock in (True, False):
+                with self.subTest(case=case, fock=fock):
+                    seen = self._run(case, fock)
+                    self.assertTrue(seen and all(seen), (case, fock, seen))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hartree_fock_kernel.py
+++ b/tests/test_hartree_fock_kernel.py
@@ -159,7 +159,7 @@ class _LegacyUHFk:
 
         #----------------
         # Hund
-        #----------------        
+        #----------------
         if 'Hund' in self.param_ham.keys():
             jab_r = np.zeros((nx,ny,nz,norb,norb), dtype=np.complex128)
 

--- a/tests/test_rpa_longitudinal_bond_gate.py
+++ b/tests/test_rpa_longitudinal_bond_gate.py
@@ -107,7 +107,7 @@ class TestGateConfig(unittest.TestCase):
     def test_flex_rejects_only_a_true_key(self):
         with self.assertRaises(ValueError) as cm:
             _build({"longitudinal_bond_channels": True}, mode="FLEX")
-        self.assertIn("Phase B", str(cm.exception))
+        self.assertIn("flex_hartree_fock", str(cm.exception))   # Phase B: gate needs HF
         _build({"longitudinal_bond_channels": False}, mode="FLEX")
         with self.assertRaises(ValueError):
             _build({"longitudinal_bond_channels": "true"}, mode="FLEX")
@@ -126,7 +126,7 @@ class TestGateConfig(unittest.TestCase):
                 "calc_scheme": "general", "calc_type": "ring+ladder"}
         with self.assertRaises(ValueError) as cm:
             flex_mod.FLEX(r.get_param("ham"), {}, info)
-        self.assertIn("Phase A", str(cm.exception))
+        self.assertIn("flex_hartree_fock", str(cm.exception))
 
 
 _EQ2 = "tests/equivalence_input/orb2"

--- a/tests/test_sigma_split_cli.py
+++ b/tests/test_sigma_split_cli.py
@@ -1,0 +1,204 @@
+"""``hwave_sigma_split`` (spec 2026-09-06 section 2.3): argument coupling,
+the static.npz contract, --zero-static, the UHFk trans_mod recipe against
+the solver's own mean-field seed path, --uhfk-spin-major, overwrite
+refusal, marker admissibility and the output's validity as a Phase B seed."""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import hwave.qlmsio.read_input_k as read_input_k
+
+_IN2 = "tests/rpa/input_2orb"
+_INTER = {"CoulombInter": "onsite_inter.dat", "CoulombIntra": "coulombintra.dat"}
+_PAR = {"T": 2.0, "filling": 0.5, "CellShape": [4, 4, 1], "SubShape": [1, 1, 1], "Nmat": 8,
+        "IterationMax": 1, "Mix": 1.0, "EPS": 1}
+
+
+def _reader():
+    idict = {"path_to_input": _IN2, "Geometry": "geom.dat", "Transfer": "transfer.dat"}
+    idict.update(_INTER)
+    return read_input_k.QLMSkInput({"path_to_input": _IN2, "interaction": idict})
+
+
+def _flex(hf, extra=None):
+    import hwave.solver.flex as flex_mod
+    r = _reader()
+    par = dict(_PAR, flex_hartree_fock=hf)
+    par.update(extra or {})
+    info = {"mode": "FLEX", "param": par, "enable_spin_orbital": False, "calc_scheme": "general"}
+    return flex_mod.FLEX(r.get_param("ham"), {}, info), r
+
+
+class _Files:
+    """total.npz (legacy, unmarked), split.npz (a Phase B archive) and a UHFk
+    trans_mod.npz on the same lattice, written once per class."""
+
+    def __init__(self, d):
+        self.d = d
+        s, r = _flex(False)
+        gi = r.get_param("green")
+        s.solve(gi, d)
+        s.save_results({"path_to_output": d, "sigma": "total.npz"}, gi)
+        s2, r2 = _flex(True)
+        gi2 = r2.get_param("green")
+        s2.solve(gi2, d)
+        s2.save_results({"path_to_output": d, "sigma": "split.npz"}, gi2)
+        self.total = os.path.join(d, "total.npz")
+        self.split = os.path.join(d, "split.npz")
+        # UHFk mean field on the same input (paramagnetic, T = 2)
+        from hwave.solver.uhfk import UHFk
+        nvol, norb = s.lattice.nvol, s.norb
+        par = {"T": 2.0, "Ncond": int(round(0.5 * 2 * norb * nvol)), "2Sz": 0, "flag_fock": True,
+               "CellShape": [4, 4, 1], "SubShape": [1, 1, 1], "IterationMax": 200, "EPS": 8, "Mix": 0.5,
+               "RndSeed": 1}
+        u = UHFk(r.get_param("ham"), {"print_level": 1, "print_step": 1}, {"mode": "UHFk", "param": par})
+        u.solve(r.get_param("green"), d)
+        self.trans_mod = os.path.join(d, "trans_mod.npz")
+        u._save_trans_mod(self.trans_mod)
+        self.norb, self.nvol = norb, nvol
+
+
+def _run(argv):
+    from hwave.sigma_split import main
+    return main(argv)
+
+
+class TestSigmaSplitCLI(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.f = _Files(cls._tmp.name)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def _out(self, name):
+        return os.path.join(self.f.d, name)
+
+    def _is_valid_seed(self, path):
+        from hwave.solver.flex_hf import make_seed_envelope, validate_split_seed
+        data = np.load(path)
+        env = make_seed_envelope(data, path, data["sigma"], None)
+        self.assertEqual(env.marker, "split")
+        st, fl = validate_split_seed(env, data["sigma"].shape)
+        np.testing.assert_allclose(st + fl, data["sigma"], rtol=0, atol=1e-13)
+        return data
+
+    def test_argument_coupling(self):
+        f = self.f
+        for argv in ([f.total, self._out("a.npz")],
+                     [f.total, self._out("a.npz"), "--zero-static", "--static", f.split],
+                     [f.total, self._out("a.npz"), "--uhfk-trans-mod", f.trans_mod],
+                     [f.total, self._out("a.npz"), "--zero-static", "--bare-transfer", "x"],
+                     [f.total, self._out("a.npz"), "--zero-static", "--uhfk-spin-major"]):
+            with self.subTest(argv=argv):
+                self.assertEqual(_run(argv), 1)
+                self.assertFalse(os.path.exists(self._out("a.npz")))
+
+    def test_zero_static(self):
+        out = self._out("zero.npz")
+        self.assertEqual(_run([self.f.total, out, "--zero-static"]), 0)
+        data = self._is_valid_seed(out)
+        self.assertEqual(np.abs(data["sigma_static"]).max(), 0.0)
+        np.testing.assert_array_equal(data["sigma_fluct"], data["sigma"])
+        total = np.load(self.f.total)
+        for k in total.files:
+            self.assertIn(k, data.files)
+        self.assertNotIn("scf_converged", data.files)          # no synthesised provenance
+        # overwrite refused without --force
+        self.assertEqual(_run([self.f.total, out, "--zero-static"]), 1)
+        self.assertEqual(_run([self.f.total, out, "--zero-static", "--force"]), 0)
+        # the seed is accepted by a Phase B run
+        s, r = _flex(True)
+        gi = r.get_param("green")
+        gi.update(s.read_init({"path_to_input": self.f.d, "sigma_init": "zero.npz"}))
+        s.solve(gi, self.f.d)
+
+    def test_static_contract(self):
+        f = self.f
+        split = np.load(f.split)
+        # rank 5 (from a Phase B archive) and the sigma fallback, rank-4 promotion
+        st5 = os.path.join(f.d, "st5.npz"); st4 = os.path.join(f.d, "st4.npz"); fb = os.path.join(f.d, "fb.npz")
+        meta = {k: split[k] for k in ("cell_shape", "momentum_convention", "wavevector_unit", "wavevector_index")}
+        np.savez(st5, sigma_static=split["sigma_static"], **meta)
+        np.savez(st4, sigma_static=split["sigma_static"][:, 0], **meta)
+        np.savez(fb, sigma=split["sigma_static"], **meta)
+        for src in (st5, st4, fb):
+            out = self._out("from_static.npz")
+            self.assertEqual(_run([f.total, out, "--static", src, "--force"]), 0)
+            data = self._is_valid_seed(out)
+            np.testing.assert_array_equal(data["sigma_static"], split["sigma_static"])
+        # metadata mismatch / missing
+        bad = os.path.join(f.d, "bad.npz")
+        m2 = dict(meta); m2["cell_shape"] = np.array([2, 8, 1])
+        np.savez(bad, sigma_static=split["sigma_static"], **m2)
+        self.assertEqual(_run([f.total, self._out("bad_out.npz"), "--static", bad]), 1)
+        m3 = dict(meta); del m3["wavevector_index"]
+        np.savez(bad, sigma_static=split["sigma_static"], **m3)
+        self.assertEqual(_run([f.total, self._out("bad_out.npz"), "--static", bad]), 1)
+        # wrong shape
+        np.savez(bad, sigma_static=split["sigma_static"][:, :, :8], **meta)
+        self.assertEqual(_run([f.total, self._out("bad_out.npz"), "--static", bad]), 1)
+        # non-Hermitian
+        nh = np.array(split["sigma_static"]); nh[0, 0, :, 0, 1] += 0.1
+        np.savez(bad, sigma_static=nh, **meta)
+        self.assertEqual(_run([f.total, self._out("bad_out.npz"), "--static", bad]), 1)
+        self.assertFalse(os.path.exists(self._out("bad_out.npz")))
+
+    def test_spin_major_static(self):
+        f = self.f
+        split = np.load(f.split)
+        meta = {k: split[k] for k in ("cell_shape", "momentum_convention", "wavevector_unit", "wavevector_index")}
+        st = split["sigma_static"][0, 0]
+        sm = np.einsum('kab,st->ksatb', st, np.eye(2)).reshape(f.nvol, 2 * f.norb, 2 * f.norb)
+        path = os.path.join(f.d, "sm.npz")
+        np.savez(path, sigma_static=sm, **meta)
+        out = self._out("sm_out.npz")
+        self.assertEqual(_run([f.total, out, "--static", path, "--uhfk-spin-major"]), 0)
+        np.testing.assert_array_equal(np.load(out)["sigma_static"], split["sigma_static"])
+        self.assertEqual(_run([f.total, out, "--static", path, "--force"]), 1)     # rank/shape refused without the flag
+        sm[:, 0, f.norb] = 0.3                                                       # spin mixing
+        np.savez(path, sigma_static=sm, **meta)
+        self.assertEqual(_run([f.total, out, "--static", path, "--uhfk-spin-major", "--force"]), 1)
+
+    def test_uhfk_trans_mod_recipe_equals_the_solver_seed(self):
+        f = self.f
+        out = self._out("uhfk.npz")
+        self.assertEqual(_run([f.total, out, "--uhfk-trans-mod", f.trans_mod, "--bare-transfer",
+                               os.path.join(_IN2, "transfer.dat")]), 0)
+        data = self._is_valid_seed(out)
+        # the in-solver D7 path: trans_mod through read_init -> Delta H
+        s, r = _flex(True)
+        gi = r.get_param("green")
+        gi.update(s.read_init({"path_to_input": f.d, "trans_mod": "trans_mod.npz"}))
+        s._phase_b_reset(gi)
+        s._phase_b_preflight(gi)
+        static, fluct = s._phase_b_seed
+        np.testing.assert_allclose(data["sigma_static"], static, rtol=0, atol=1e-12)
+        self.assertGreater(np.abs(static).max(), 1e-3)
+        # the .npz form of the bare transfer
+        tr = np.load(f.trans_mod)
+        npz_transfer = os.path.join(f.d, "transfer.npz")
+        np.savez(npz_transfer, Transfer=np.asarray(s.ham_info.ham_trans_r).reshape(f.nvol, f.norb, f.norb))
+        out2 = self._out("uhfk2.npz")
+        self.assertEqual(_run([f.total, out2, "--uhfk-trans-mod", f.trans_mod, "--bare-transfer", npz_transfer]), 0)
+        np.testing.assert_allclose(np.load(out2)["sigma_static"], static, rtol=0, atol=1e-12)
+
+    def test_marker_admissibility(self):
+        f = self.f
+        self.assertEqual(_run([f.split, self._out("x.npz"), "--zero-static"]), 1)   # split input refused
+        total = np.load(f.total)
+        marked = os.path.join(f.d, "marked.npz")
+        np.savez(marked, sigma_convention=np.str_("total"), **{k: total[k] for k in total.files})
+        self.assertEqual(_run([marked, self._out("x.npz"), "--zero-static"]), 0)
+        np.savez(marked, sigma_convention=np.str_("weird"), **{k: total[k] for k in total.files})
+        self.assertEqual(_run([marked, self._out("y.npz"), "--zero-static"]), 1)
+        self.assertFalse(os.path.exists(self._out("y.npz")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sigma_split_cli.py
+++ b/tests/test_sigma_split_cli.py
@@ -200,5 +200,35 @@ class TestSigmaSplitCLI(unittest.TestCase):
         self.assertFalse(os.path.exists(self._out("y.npz")))
 
 
+class TestSigmaSplitRefusalsWriteNothing(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.f = _Files(cls._tmp.name)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def test_output_name_without_suffix(self):
+        out = os.path.join(self.f.d, "noext")
+        self.assertEqual(_run([self.f.total, out, "--zero-static"]), 0)
+        self.assertTrue(os.path.exists(out + ".npz"))
+        self.assertFalse(os.path.exists(out))
+        self.assertEqual(_run([self.f.total, out, "--zero-static"]), 1)          # overwrite refused
+        self.assertEqual(_run([self.f.total, out + ".npz", "--zero-static"]), 1)
+        self.assertEqual(_run([self.f.total, out, "--zero-static", "--force"]), 0)
+
+    def test_non_finite_total_writes_nothing(self):
+        total = np.load(self.f.total)
+        bad = os.path.join(self.f.d, "nan_total.npz")
+        sig = np.array(total["sigma"]); sig[0, 0, 0, 0, 0] = np.nan
+        np.savez(bad, **{k: (sig if k == "sigma" else total[k]) for k in total.files})
+        out = os.path.join(self.f.d, "nan_out.npz")
+        self.assertEqual(_run([bad, out, "--zero-static"]), 1)
+        self.assertFalse(os.path.exists(out))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Phase B of #181: the bond-resolved longitudinal channel of Phase A (#188) becomes self-consistent inside the FLEX loop, on top of a new self-consistent Hartree-Fock self-energy component.

- `flex_hartree_fock = true` (experimental, `calc_scheme = "general"`, spin-free, uniform grid, CPU): the FLEX self-energy is `Sigma = Sigma_HF[G] + Sigma_fluct[G]`, where `Sigma_HF` is the Hartree-Fock self-energy of every accepted interaction term (on-site and off-site), built by the kernel extracted from the UHFk solver (`hwave/solver/hartree_fock.py`, UHFk stays bit-identical) from the equal-time density of the dressed Green function. The theory is exact at first order in every coupling; a fluctuation-free run reproduces the paramagnetic UHFk fixed point. A user mean field (`trans_mod` / `green_init`) is the initial static self-energy, never folded into the band. Convergence needs three residuals (total self-energy, Green function, split components) below `EPS` for three consecutive iterations.
- `longitudinal_bond_channels = true` in FLEX mode (requires the above): the fluctuation self-energy is built on the bond-enlarged pair basis at every bosonic frequency (block store, batched dressing, effective interaction, bond-aware self-energy transport), with the Phase A prerequisites, a memory preflight over a named-buffer table (batch chosen to fit `longitudinal_bond_memory_cap_gb`), the static `longitudinal_bond_*` keys of the last map, the collapses as `chi0q`/`chiq_s`/`chiq_c`, a provenance block on every archive, an optional dynamic archive (`longitudinal_bond_output_full`) and output-path validation.
- `sigma.npz` gains the split schema (`sigma_convention = "split"`, `sigma_static`, `sigma_fluct`); only such archives seed a Hartree-Fock run. The new `hwave_sigma_split` converter produces them from legacy archives (`--zero-static`, `--static`, or a native UHFk `trans_mod` plus the bare transfer).
- With both keys off every FLEX/RPA/UHFk output and log is unchanged (verified byte for byte against `develop`).

## Physics findings recorded during the work

- The self-energy transport must put the bond form factor on the internal leg at both ends of the effective interaction, with the block `(alpha, beta)` paired to the bubble block `(beta, alpha)`; the originally planned mixed-leg assignment broke `Sigma(k, iw)^dagger = Sigma(k, -iw)` at the 1e-3 level and was caught by the density evaluator's symmetry check.
- The Takimoto-Hotta-Ueda form of the effective interaction is not second-order exact for an off-site interaction. The bond path now uses the ring series from third order on plus the exact second order (channel-0: the general path's subtraction restricted to the on-site vertices; mixed blocks: the exchange skeleton once; bond-bond blocks: none), pinned at 1e-8 by an independent real-space enumeration of the direct and exchange skeletons (gate G2). The existing general path keeps half of the direct `V^2` term and no `UV` cross term at second order; this is recorded in the test and left unchanged here.

## Verification

- Gates: G0-off (byte identity vs `develop`), G0 (declared-zero off-site equals standalone Hartree-Fock FLEX per iteration at 1e-12), G1 (transport vs a `(k, q, tau)` direct-sum oracle, 1e-10), G2 (second-order coefficients vs the hand-enumerated skeletons, 1e-8), G3 (first-map static slice vs the Phase A RPA gate, 1e-12), G4 (configuration, refusal precedence, seeds, outputs, reuse/failure atomicity), G5 (UHFk fixed point, 1e-8), the memory tracer invariant, an opt-in subprocess RSS check, and the Onari-type trend milestone (`lambda_t` rising with `V`, two-seed check, compact observables committed).
- `python3 -m unittest discover -s tests -p "test_*.py"` and `pytest tests` pass; documentation in English and Japanese builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRqmKRgf8s2yi9CUV5phcL
