### PR TITLE
UHFk: fix the off-site Fock double-counting energy

### DIFF
--- a/src/hwave/solver/uhfk.py
+++ b/src/hwave/solver/uhfk.py
@@ -2034,11 +2034,11 @@ class UHFk(solver_base):
 
                 if type == "PairHop":
                     if self.iflag_fock:
-                        w1 = np.einsum('stuv, rsavb, rtaub -> rab', spin, gab_r, gab_r, optimize=True)
-                        w2 = np.einsum('stuv, rsaub, rtavb -> rab', spin, gab_r, gab_r, optimize=True)
+                        w1 = np.einsum('stuv, rvbsa, rubta -> rab', spin, np.conjugate(gab_r), np.conjugate(gab_r), optimize=True)
+                        w2 = np.einsum('stuv, rubsa, rvbta -> rab', spin, np.conjugate(gab_r), np.conjugate(gab_r), optimize=True)
                         ee = np.einsum('rab, rab ->', jab_r, w1-w2)
                     else:
-                        w1 = np.einsum('stuv, rsavb, rtaub -> rab', spin, gab_r, gab_r, optimize=True)
+                        w1 = np.einsum('stuv, rvbsa, rubta -> rab', spin, np.conjugate(gab_r), np.conjugate(gab_r), optimize=True)
                         ee = np.einsum('rab, rab ->', jab_r, w1)
                     energy[type] = -ee/2.0*nvol
 
@@ -2046,7 +2046,7 @@ class UHFk(solver_base):
                     if self.iflag_fock:
                         w1 = np.einsum('stuv, vasa, ubtb -> ab', spin, gab_r[0], gab_r[0])
                         w1b = np.broadcast_to(w1, (nvol,norb_inter,norb_inter))
-                        w2 = np.einsum('stuv, rubsa, rvatb -> rab', spin, gab_r, gab_r, optimize=True)
+                        w2 = np.einsum('stuv, rubsa, rtbva -> rab', spin, np.conjugate(gab_r), gab_r, optimize=True)
                         ee = np.einsum('rab, rab->', jab_r, w1b-w2)
                     else:
                         w1 = np.einsum('stuv, vasa, ubtb -> ab', spin, gab_r[0], gab_r[0])

--- a/tests/test_uhfk_offsite_fock_energy.py
+++ b/tests/test_uhfk_offsite_fock_energy.py
@@ -1,0 +1,89 @@
+"""Double-counting energies must equal -Tr(H_int rho)/2.
+
+The unequal intra-cell/inter-cell hoppings make the two directed orbital
+coherences differ. The on-site Exchange case fixes the sign and total-cell
+normalization independently of the off-site regression.
+
+Before the fix, plain UHFk gave these (energy, -Tr(H_int rho)/2) values:
+Exchange off-site: (-0.000996118502, -0.540038047857), error +0.539041929355.
+Ising off-site:    (+0.000927187264, +0.154288384881), error -0.153361197617.
+PairHop off-site:  (-0.000001837374, -0.540038047857), error +0.540036210483
+                  with Fock either enabled or disabled.
+On-site Exchange and PairHop already agreed to within 1e-15.
+
+PairHop's Hamiltonian contracts conj(G[r,v,b,u,a]) with the expectation
+conj(G[r,t,b,s,a]). Relabeling its spin table gives the direct product
+conj(G[r,v,b,s,a])*conj(G[r,u,b,t,a]) and the cross product
+conj(G[r,u,b,s,a])*conj(G[r,v,b,t,a]). Both previously used the opposite
+bond. Spin-orbital conversion only permutes basis indices, so the same
+contractions apply; complex spin mixing exercises the cross product.
+"""
+import numpy as np
+import pytest
+
+from hwave.solver.uhfk import UHFk
+
+
+@pytest.mark.parametrize("spin_orbital", [False, True], ids=["plain", "spin-orbital"])
+@pytest.mark.parametrize("interaction, offset, fock", [
+    ("Exchange", 0, True), ("Exchange", 1, True), ("Ising", 1, True),
+    ("PairHop", 0, True), ("PairHop", 1, True), ("PairHop", 1, False),
+], ids=["onsite-exchange", "offsite-exchange", "offsite-ising", "onsite-pairhop",
+        "offsite-pairhop", "offsite-pairhop-no-fock"])
+def test_fock_double_counting_matches_mean_field(interaction, offset, fock, spin_orbital):
+    transfer = {
+        ((0, 0, 0), (0, 0)): -0.4,
+        ((0, 0, 0), (1, 1)): 0.6,
+        ((0, 0, 0), (0, 1)): -0.3,
+        ((0, 0, 0), (1, 0)): -0.3,
+        ((1, 0, 0), (0, 1)): -1.0,
+        ((-1, 0, 0), (1, 0)): -1.0,
+    }
+    norb = 2
+    if spin_orbital:
+        norb = 4
+        transfer = {
+            (r, (2*a+s, 2*b+s)): value
+            for (r, (a, b)), value in transfer.items() for s in range(2)
+        }
+        # Complex spin mixing also exercises PairHop's cross contraction.
+        transfer[((0, 0, 0), (0, 1))] = 0.12j
+        transfer[((0, 0, 0), (1, 0))] = -0.12j
+    ham = {
+        "Geometry": {"norb": norb, "rvec": np.eye(3),
+                     "center": np.zeros((norb, 3)), "degree": np.ones(norb)},
+        "Transfer": transfer,
+        interaction: {((offset, 0, 0), (0, 1)): 0.4,
+                      ((-offset, 0, 0), (1, 0)): 0.4},
+    }
+    params = {"CellShape": [4, 1, 1], "SubShape": [1, 1, 1],
+              "Ncond": 8, "2Sz": None, "IterationMax": 1000,
+              "eps": 1e-10, "Mix": 0.5, "RndSeed": 7, "T": 0.05}
+    solver = UHFk(ham, {"print_level": 0},
+                  {"mode": "UHFk", "enable_spin_orbital": spin_orbital,
+                   "flag_fock": fock}, params)
+    solver.solve({"initial_mode": "random"}, ".")
+    assert solver.physics["Rest"] < 1e-10
+
+    # Rebuild both quantities from the same final (mixed) Green function.
+    solver._make_ham()
+    solver._calc_energy()
+    green_k = np.fft.ifftn(
+        solver.Green.reshape(*solver.shape, solver.nd, solver.nd),
+        axes=(0, 1, 2), norm="forward",
+    ).reshape(solver.nvol, solver.nd, solver.nd)
+    # G_ij = <c_i^dag c_j>, whereas rho_ij = <c_j^dag c_i>.
+    rho_k = green_k.transpose(0, 2, 1)
+    h_int = solver.ham - solver.ham_trans
+    expectation = np.trace(h_int @ rho_k, axis1=1, axis2=2).sum()
+    assert abs(expectation.imag) < 1e-12
+    expected = -expectation.real / 2
+    actual = solver.physics["Ene"][interaction]
+    if offset:
+        green = (solver._so_to_virtual_green(solver.Green)
+                 if spin_orbital else solver.Green)
+        assert abs(green[1, 0, 0, 0, 1] - green[-1, 0, 0, 0, 1]) > 0.1
+    print(f"{interaction} offset={offset} SO={spin_orbital} Fock={fock}: "
+          f"energy={actual.real:.12f}, oracle={expected:.12f}, "
+          f"error={actual.real - expected:.12g}")
+    assert actual == pytest.approx(expected, rel=0, abs=1e-10)


### PR DESCRIPTION
## Summary

`UHFk._calc_energy` contracts the wrong Green-function partner in the Fock (exchange) part of the double-counting energy for interaction rows between different orbitals at a nonzero cell offset. The term

```python
w2 = np.einsum('stuv, rubsa, rvatb -> rab', spin, gab_r, gab_r, optimize=True)
```

pairs `G_ba(r)` with `G_ab(r)`, i.e. with the bond at the opposite offset `-r`, while the Fock contraction of `a^dag_s a_v b^dag_t b_u` on the bond `(a at 0, b at r)` needs `<a^dag_s(0) b_u(r)> <b^dag_t(r) a_v(0)>`. With UHFk's storage convention `G[r, s, alpha, t, beta] = <alpha^dag_s(R + r) beta_t(R)>` (the one used by the correct Fock term of `_make_ham_inter`) this is `conj(G[r, u, b, s, a]) * G[r, t, b, v, a]`, hence

```python
w2 = np.einsum('stuv, rubsa, rtbva -> rab', spin, np.conjugate(gab_r), gab_r, optimize=True)
```

The same index pattern appears in the PairHop energy contractions (Fock enabled and disabled) and is corrected the same way.

Only the reported energies are affected: the self-consistent solution (Green function, order parameters, bands, chemical potential) does not depend on `_calc_energy`. On-site rows (`r = 0`) are unaffected because the two products are complex conjugates of each other, and single-orbital rows with collinear states are unaffected because the two factors coincide. The error shows up for inter-orbital inter-cell Ising / Exchange / PairHop rows, e.g. nearest-neighbour exchange on any two-sublattice cell (honeycomb, checkerboard, Kondo-Heisenberg models), where it is of order `J x (bond amplitude)^2` per site.

## Evidence

- Regression test `tests/test_uhfk_offsite_fock_energy.py`: the double-counting energy of an interaction type must equal `-Tr(H_int rho) / 2` at a converged state. On-site Exchange / PairHop pass before and after; off-site Exchange, Ising and PairHop fail before the fix (0.54, 0.15 and 0.54 per cell on a two-orbital chain) and pass to 1e-10 after, with and without `enable_spin_orbital`.
- An independent full Hartree-Fock implementation of the two-sublattice Kondo-Heisenberg lattice (Isaev and Vekhter, arXiv:1210.0573) with a nearest-neighbour `J_H` between the local orbitals: the UHFk energy differed by 6.2e-3 (Kondo phase) and 4.8e-3 (coexistence phase) per site with all order parameters agreeing to 1e-8; after the fix the energies agree to 1.2e-7 and 4.4e-8.
- Cross-check against mVMC's `UHF` binary (ComplexUHF, mVMC 1.4.0) and H-wave's UHFr on a honeycomb itinerant model with nearest-neighbour Exchange, Hund and CoulombInter under PP / AP / PA / AA boundary conditions: the converged UHFk state was exported to `UHF` as its initial state and the energies of the same state compared. In the 12 converged cases the fixed UHFk energy agrees with mVMC and UHFr to 5e-11 per site; before the fix the differences were 0.016 to 0.31 per site.
- Full test suite on this branch: all tests pass except the pre-existing `sparse_ir`-dependent FLEX test.

## Notes

- One line in the main path plus the two PairHop lines; no behaviour change elsewhere.
- Found while benchmarking a local-spin extension of UHFk; this fix is independent of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and Codex